### PR TITLE
refactor: Simplify room sorting logic to make invite sorting more obv…

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2245,12 +2245,21 @@ class Client extends MatrixApi {
   /// The compare function how the rooms should be sorted internally. By default
   /// rooms are sorted by timestamp of the last m.room.message event or the last
   /// event if there is no known message.
-  RoomSorter get sortRoomsBy => (a, b) => (a.isFavourite != b.isFavourite)
-      ? (a.isFavourite ? -1 : 1)
-      : (pinUnreadRooms && a.notificationCount != b.notificationCount)
-          ? b.notificationCount.compareTo(a.notificationCount)
-          : b.timeCreated.millisecondsSinceEpoch
+  RoomSorter get sortRoomsBy => (a, b) {
+        if (pinInvitedRooms &&
+            a.membership != b.membership &&
+            [a.membership, b.membership].any((m) => m == Membership.invite)) {
+          return a.membership == Membership.invite ? -1 : 1;
+        } else if (a.isFavourite != b.isFavourite) {
+          return a.isFavourite ? -1 : 1;
+        } else if (pinUnreadRooms &&
+            a.notificationCount != b.notificationCount) {
+          return b.notificationCount.compareTo(a.notificationCount);
+        } else {
+          return b.timeCreated.millisecondsSinceEpoch
               .compareTo(a.timeCreated.millisecondsSinceEpoch);
+        }
+      };
 
   void _sortRooms() {
     if (_sortLock || rooms.length < 2) return;

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -599,9 +599,7 @@ class Room {
   }
 
   /// Returns true if this room has a m.favourite tag.
-  bool get isFavourite =>
-      tags[TagType.favourite] != null ||
-      (client.pinInvitedRooms && membership == Membership.invite);
+  bool get isFavourite => tags[TagType.favourite] != null;
 
   /// Sets the m.favourite tag for this room.
   Future<void> setFavourite(bool favourite) =>


### PR DESCRIPTION
…ious

It wasn't quite obvious that invites were always sorted at the top, if you just looked at the sort function. This makes it more explicit and also makes invites always sort before favourited rooms.