### PR TITLE
fix: fixed hardcoded historyCount

### DIFF
--- a/lib/src/timeline.dart
+++ b/lib/src/timeline.dart
@@ -116,7 +116,7 @@ class Timeline {
           : await room.client.database?.getEventList(
               room,
               start: events.length,
-              limit: Room.defaultHistoryCount,
+              limit: historyCount,
             );
 
       if (eventsFromStore != null && eventsFromStore.isNotEmpty) {


### PR DESCRIPTION
Hi there
Found a bug in _requestEvents. `historyCount` is supposed to be applied to `limit`, however it is using Room.DefaultHistoryCount.

Also, is it possible to filter event types? Otherwise, when retrieving historical chat, there might be events not supposed to be shown.
