### PR TITLE
Upgrade markdown to 7.1.1

### DIFF
--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -32,12 +32,12 @@ class LinebreakSyntax extends InlineSyntax {
   }
 }
 
-class SpoilerSyntax extends TagSyntax {
+class SpoilerSyntax extends DelimiterSyntax {
   SpoilerSyntax() : super(r'\|\|', requiresDelimiterRun: true);
 
   @override
-  Node close(InlineParser parser, Delimiter opener, Delimiter closer,
-      {required List<Node> Function() getChildren}) {
+  Iterable<Node>? close(InlineParser parser, Delimiter opener, Delimiter closer,
+      {required String tag, required List<Node> Function() getChildren}) {
     final children = getChildren();
     final newChildren = <Node>[];
     var searchingForReason = true;
@@ -67,7 +67,7 @@ class SpoilerSyntax extends TagSyntax {
         Element('span', searchingForReason ? children : newChildren);
     element.attributes['data-mx-spoiler'] =
         searchingForReason ? '' : htmlAttrEscape.convert(reason);
-    return element;
+    return <Node>[element];
   }
 }
 
@@ -110,7 +110,7 @@ class EmoteSyntax extends InlineSyntax {
   }
 }
 
-class InlineLatexSyntax extends TagSyntax {
+class InlineLatexSyntax extends DelimiterSyntax {
   InlineLatexSyntax() : super(r'\$([^\s$]([^\$]*[^\s$])?)\$');
 
   @override
@@ -131,16 +131,16 @@ class BlockLatexSyntax extends BlockSyntax {
   final endPattern = RegExp(r'^(.*)\$\$\s*$');
 
   @override
-  List<String> parseChildLines(BlockParser parser) {
-    final childLines = <String>[];
+  List<Line?> parseChildLines(BlockParser parser) {
+    final childLines = <Line>[];
     var first = true;
     while (!parser.isDone) {
-      final match = endPattern.firstMatch(parser.current);
+      final match = endPattern.firstMatch(parser.current.content);
       if (match == null || (first && match[1]!.trim().isEmpty)) {
         childLines.add(parser.current);
         parser.advance();
       } else {
-        childLines.add(match[1]!);
+        childLines.add(Line(match[1]!));
         parser.advance();
         break;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: ^0.13.0
   image: ^4.0.15
   js: ^0.6.3
-  markdown: ^4.0.0
+  markdown: ^7.1.1
   matrix_api_lite: ^1.7.0
   mime: ^1.0.0
   olm: ^2.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,28 +8,28 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  async: ^2.8.0
+  async: ^2.11.0
   base58check: ^2.0.0
-  blurhash_dart: ^1.1.0
-  canonical_json: ^1.1.0
-  collection: ^1.15.0
-  crypto: ^3.0.0
-  ffi: ^2.0.0
+  blurhash_dart: ^1.2.1
+  canonical_json: ^1.1.2
+  collection: ^1.18.0
+  crypto: ^3.0.3
+  ffi: ^2.1.0
   hive: ^2.2.3
-  html: ^0.15.0
+  html: ^0.15.4
   html_unescape: ^2.0.0
   http: ^0.13.0
-  image: ^4.0.15
-  js: ^0.6.3
-  markdown: ^7.1.1
-  matrix_api_lite: ^1.7.0
-  mime: ^1.0.0
-  olm: ^2.0.2
+  image: ^4.0.17
+  js: ^0.6.7
+  markdown: ^4.0.0
+  matrix_api_lite: ^1.7.1
+  mime: ^1.0.4
+  olm: ^2.0.3
   random_string: ^2.3.1
   sdp_transform: ^0.3.2
   slugify: ^2.0.0
   typed_data: ^1.3.2
-  webrtc_interface: ^1.0.13
+  webrtc_interface: ^1.1.2
 
 dev_dependencies:
   coverage: ">=0.15.0 <2.0.0"


### PR DESCRIPTION
Addressing dependency issues when using matrix SDK.  Updated from 4.0.0 to 7.1.1.  Required code changes in markdown.dart.