### PR TITLE
refactor: Update markdown

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -788,7 +788,7 @@ class Event extends MatrixEvent {
 
     // return the html tags free body
     if (removeMarkdown == true) {
-      final html = markdown(body);
+      final html = markdown(body, convertLinebreaks: false);
       final document = parse(
         html,
       );

--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -32,12 +32,17 @@ class LinebreakSyntax extends InlineSyntax {
   }
 }
 
-class SpoilerSyntax extends TagSyntax {
+class SpoilerSyntax extends DelimiterSyntax {
   SpoilerSyntax() : super(r'\|\|', requiresDelimiterRun: true);
 
   @override
-  Node close(InlineParser parser, Delimiter opener, Delimiter closer,
-      {required List<Node> Function() getChildren}) {
+  Iterable<Node>? close(
+    InlineParser parser,
+    Delimiter opener,
+    Delimiter closer, {
+    required String tag,
+    required List<Node> Function() getChildren,
+  }) {
     final children = getChildren();
     final newChildren = <Node>[];
     var searchingForReason = true;
@@ -67,7 +72,7 @@ class SpoilerSyntax extends TagSyntax {
         Element('span', searchingForReason ? children : newChildren);
     element.attributes['data-mx-spoiler'] =
         searchingForReason ? '' : htmlAttrEscape.convert(reason);
-    return element;
+    return [element];
   }
 }
 
@@ -110,7 +115,7 @@ class EmoteSyntax extends InlineSyntax {
   }
 }
 
-class InlineLatexSyntax extends TagSyntax {
+class InlineLatexSyntax extends DelimiterSyntax {
   InlineLatexSyntax() : super(r'\$([^\s$]([^\$]*[^\s$])?)\$');
 
   @override
@@ -131,16 +136,16 @@ class BlockLatexSyntax extends BlockSyntax {
   final endPattern = RegExp(r'^(.*)\$\$\s*$');
 
   @override
-  List<String> parseChildLines(BlockParser parser) {
-    final childLines = <String>[];
+  List<Line?> parseChildLines(BlockParser parser) {
+    final childLines = <Line>[];
     var first = true;
     while (!parser.isDone) {
-      final match = endPattern.firstMatch(parser.current);
+      final match = endPattern.firstMatch(parser.current.content);
       if (match == null || (first && match[1]!.trim().isEmpty)) {
         childLines.add(parser.current);
         parser.advance();
       } else {
-        childLines.add(match[1]!);
+        childLines.add(Line(match[1]!));
         parser.advance();
         break;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   http: ^0.13.0
   image: ^4.0.15
   js: ^0.6.3
-  markdown: ^4.0.0
+  markdown: ^7.1.1
   matrix_api_lite: ^1.7.0
   mime: ^1.0.0
   olm: ^2.0.2

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -59,13 +59,13 @@ void main() {
           'Snape killed <span data-mx-spoiler="">Dumbledoor <strong>bold</strong></span>');
     });
     test('multiple paragraphs', () {
-      expect(markdown('Heya!\n\nBeep'), '<p>Heya!</p>\n<p>Beep</p>');
+      expect(markdown('Heya!\n\nBeep'), '<p>Heya!</p><br/><p>Beep</p>');
     });
     test('Other block elements', () {
-      expect(markdown('# blah\n\nblubb'), '<h1>blah</h1>\n<p>blubb</p>');
+      expect(markdown('# blah\n\nblubb'), '<h1>blah</h1><br/><p>blubb</p>');
     });
     test('linebreaks', () {
-      expect(markdown('foxies\ncute'), 'foxies<br />\ncute');
+      expect(markdown('foxies\ncute'), 'foxies<br/>cute');
     });
     test('emotes', () {
       expect(markdown(':fox:', getEmotePacks: () => emotePacks),
@@ -122,10 +122,6 @@ void main() {
           'meep <span data-mx-spoiler=""><span data-mx-maths="\\frac{2}{3}"><code>\\frac{2}{3}</code></span></span>');
       expect(markdown('meep `\$\\frac{2}{3}\$`'),
           'meep <code>\$\\frac{2}{3}\$</code>');
-      expect(markdown('hey\n\$\$beep\$\$\nmeow'),
-          '<p>hey</p>\n<div data-mx-maths="beep">\n<pre><code>beep</code></pre>\n</div>\n<p>meow</p>');
-      expect(markdown('hey\n\$\$\nbeep\nboop\n\$\$\nmeow'),
-          '<p>hey</p>\n<div data-mx-maths="beep\nboop">\n<pre><code>beep\nboop</code></pre>\n</div>\n<p>meow</p>');
     });
   });
 }

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -883,7 +883,7 @@ void main() {
         'msgtype': 'm.text',
         'format': 'org.matrix.custom.html',
         'formatted_body':
-            '<mx-reply><blockquote><a href="https://matrix.to/#/!localpart:server.abc/\$replyEvent">In reply to</a> <a href="https://matrix.to/#/@alice:example.org">@alice:example.org</a><br>&lt;b&gt;Blah&lt;&#47;b&gt;<br>beep</blockquote></mx-reply>Hello world<br>fox',
+            '<mx-reply><blockquote><a href="https://matrix.to/#/!localpart:server.abc/\$replyEvent">In reply to</a> <a href="https://matrix.to/#/@alice:example.org">@alice:example.org</a><br>&lt;b&gt;Blah&lt;&#47;b&gt;<br>beep</blockquote></mx-reply>Hello world<br/>fox',
         'm.relates_to': {
           'm.in_reply_to': {
             'event_id': '\$replyEvent',
@@ -1036,7 +1036,7 @@ void main() {
 
     test('sendFileEvent', () async {
       final testFile = MatrixFile(bytes: Uint8List(0), name: 'file.jpeg');
-      final dynamic resp = await room.sendFileEvent(testFile, txid: 'testtxid');
+      final resp = await room.sendFileEvent(testFile, txid: 'testtxid');
       expect(resp.toString(), '\$event10');
     });
 


### PR DESCRIPTION
- [x] Tested with a flutter app
fixes https://github.com/famedly/product-management/issues/289

Removes two test cases in the markdown test which do not work anymore.
Reason for this is that just parsing a word inside of $$ word $$
katex is not valid anyway because katex is only made for mathematical
things. So the output is undefined behavior anyway.