### PR TITLE
stale call checker leak

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -90,9 +90,6 @@ class Room {
   /// Key-Value store for private account data only visible for this user.
   Map<String, BasicRoomEvent> roomAccountData = {};
 
-  /// stores stale group call checking timers for rooms.
-  Map<String, Timer> staleGroupCallsTimer = {};
-
   final _sendingQueue = <Completer>[];
 
   Map<String, dynamic> toJson() => {
@@ -136,9 +133,6 @@ class Room {
       for (final state in allStates) {
         setState(state);
       }
-    }
-    if (!isArchived) {
-      startStaleCallsChecker(id);
     }
     partial = false;
   }


### PR DESCRIPTION
We were accumulating stale call checkers with every room. Also when we removed a room, the stale call checker kept running in some instances. We can just run the checker after the sync without a timer though, which means we don't need to clean up the timers in the end and we don't need to call sync in every call checker.