### PR TITLE
fix: Wait for secrets come down sync

### DIFF
--- a/lib/encryption/utils/bootstrap.dart
+++ b/lib/encryption/utils/bootstrap.dart
@@ -584,10 +584,9 @@ class Bootstrap {
       Logs().v('Wait for secret to come down sync');
 
       if (!await encryption.keyManager.isCached()) {
-        await client.onSync.stream.firstWhere((syncUpdate) =>
-            syncUpdate.accountData != null &&
-            syncUpdate.accountData!
-                .any((accountData) => accountData.type == megolmKey));
+        await for (final _ in client.onSync.stream) {
+          if (await encryption.keyManager.isCached()) break;
+        }
       }
 
       Logs().v(


### PR DESCRIPTION
Somehow on some servers
we wait forever for the keys
while they are not detected
in the sync. I think this has
something to do with how
different server handle uri
encoding. However, this should
make it more stable.

Other things I tried: Put the key we are waiting for in Uri.encodeComponent() or wait on both encoded and not encoded. Found no better solution to this :-(