### PR TITLE
fix: Delayed encrypted event in timeline not added to aggregated events

### DIFF
--- a/lib/src/timeline.dart
+++ b/lib/src/timeline.dart
@@ -325,6 +325,7 @@ class Timeline {
             store: true,
             updateType: EventUpdateType.history,
           );
+          addAggregatedEvent(events[i]);
           onChange?.call(i);
           if (events[i].type != EventTypes.Encrypted) {
             decryptAtLeastOneEvent = true;


### PR DESCRIPTION
https://github.com/famedly/matrix-dart-sdk/issues/255