### PR TITLE
fix: add missing upload for inbound group sessions on dehydrated devices

### DIFF
--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -169,6 +169,7 @@ extension DehydratedDeviceHandler on Client {
         userDeviceKeys[userID]!.deviceKeys[device]!,
       ];
       await this.encryption?.crossSigning.sign(keysToSign);
+      encryption.keyManager.startAutoUploadKeys();
     } finally {
       await encryption.dispose();
     }


### PR DESCRIPTION
In case the auto upload is already running, execute it once.

Fixes: #1624