### PR TITLE
refactor: Store fetched presence in db and deprecate own cache

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -304,6 +304,7 @@ class Client extends MatrixApi {
   }
 
   /// Presences of users by a given matrix ID
+  @Deprecated('Use `fetchCurrentPresence(userId)` instead.')
   Map<String, CachedPresence> presences = {};
 
   int _transactionCounter = 0;
@@ -1570,6 +1571,7 @@ class Client extends MatrixApi {
           _accountData = data;
           _updatePushrules();
         });
+        // ignore: deprecated_member_use_from_same_package
         presences.clear();
         if (waitUntilLoadCompletedLoaded) {
           await userDeviceKeysLoading;
@@ -1794,6 +1796,7 @@ class Client extends MatrixApi {
     }
     for (final newPresence in sync.presence ?? <Presence>[]) {
       final cachedPresence = CachedPresence.fromMatrixEvent(newPresence);
+      // ignore: deprecated_member_use_from_same_package
       presences[newPresence.senderId] = cachedPresence;
       // ignore: deprecated_member_use_from_same_package
       onPresence.add(newPresence);
@@ -2929,17 +2932,22 @@ class Client extends MatrixApi {
   /// The newest presence of this user if there is any. Fetches it from the
   /// database first and then from the server if necessary or returns offline.
   Future<CachedPresence> fetchCurrentPresence(String userId) async {
+    // ignore: deprecated_member_use_from_same_package
     final cachedPresence = presences[userId];
     if (cachedPresence != null) {
       return cachedPresence;
     }
 
     final dbPresence = await database?.getPresence(userId);
+    // ignore: deprecated_member_use_from_same_package
     if (dbPresence != null) return presences[userId] = dbPresence;
 
     try {
-      final newPresence = await getPresence(userId);
-      return CachedPresence.fromPresenceResponse(newPresence, userId);
+      final result = await getPresence(userId);
+      final presence = CachedPresence.fromPresenceResponse(result, userId);
+      await database?.storePresence(userId, presence);
+      // ignore: deprecated_member_use_from_same_package
+      return presences[userId] = presence;
     } catch (e) {
       return CachedPresence.neverSeen(userId);
     }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -123,6 +123,7 @@ void main() {
           '!726s6s6q:example.com');
       expect(matrix.rooms[1].directChatMatrixID, '@bob:example.com');
       expect(matrix.directChats, matrix.accountData['m.direct']?.content);
+      // ignore: deprecated_member_use_from_same_package
       expect(matrix.presences.length, 1);
       expect(matrix.rooms[1].ephemerals.length, 2);
       expect(matrix.rooms[1].typingUsers.length, 1);
@@ -147,6 +148,7 @@ void main() {
       expect(matrix.rooms.length, 2);
       expect(matrix.rooms[1].canonicalAlias,
           "#famedlyContactDiscovery:${matrix.userID!.split(":")[1]}");
+      // ignore: deprecated_member_use_from_same_package
       expect(matrix.presences['@alice:example.com']?.presence,
           PresenceType.online);
       expect(presenceCounter, 1);


### PR DESCRIPTION
For the initiative to make the SDK more database centric.