### PR TITLE
update read receipts from mainThreadupdate read receipts from mainThread

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -329,6 +329,19 @@ class Event extends MatrixEvent {
             room.unsafeGetUserFromMemoryOrFallback(entry.key),
             entry.value.timestamp))
         .toList();
+    if (receipts.mainThread?.otherUsers.entries != null) {
+      receipts.mainThread!.otherUsers.entries
+          .where((entry) => entry.value.eventId == eventId)
+          .forEach((entry) {
+        if (receiptsList
+                .indexWhere((element) => element.user.stateKey == entry.key) ==
+            -1) {
+          receiptsList.add(Receipt(
+              room.unsafeGetUserFromMemoryOrFallback(entry.key),
+              entry.value.timestamp));
+        }
+      });
+    }
 
     final own = receipts.global.latestOwnReceipt;
     if (own != null && own.eventId == eventId) {


### PR DESCRIPTION
Fixes: https://github.com/famedly/product-management/issues/1020

Update other users read receipts from both global and mainThread.

This is primarily intended to fix read receipts not always updating in FluffyChat (relates to https://github.com/krille-chan/fluffychat/issues/549). I do this by not only checking for read receipts in global but also mainThread as some clients only seem to update mainThread and not global.

This is my first pull request and I am not experienced with dart so hopefully any issues with this PR are fixable :)