### PR TITLE
refactor: Add delete database method

### DIFF
--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -316,4 +316,8 @@ abstract class DatabaseApi {
   Future<void> storePresence(String userId, CachedPresence presence);
 
   Future<CachedPresence?> getPresence(String userId);
+
+  /// Deletes the whole database. The database needs to be created again after
+  /// this. Used for migration only.
+  Future<void> delete();
 }

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1594,6 +1594,9 @@ class HiveCollectionsDatabase extends DatabaseApi {
       return false;
     }
   }
+
+  @override
+  Future<void> delete() => _collection.deleteFromDisk();
 }
 
 class TupleKey {

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1474,6 +1474,9 @@ class FamedlySdkHiveDatabase extends DatabaseApi {
     // see no need to implement this in a deprecated part
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> delete() => Hive.deleteFromDisk();
 }
 
 dynamic _castValue(dynamic value) {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -144,10 +144,15 @@ class MatrixSdkDatabase extends DatabaseApi {
   /// typed.
   final dynamic idbFactory;
 
+  /// Custom SQFlite Database Factory used for high level operations on IO
+  /// like delete. Set it if you want to use sqlite FFI.
+  final DatabaseFactory? sqfliteFactory;
+
   MatrixSdkDatabase(
     this.name, {
     this.database,
     this.idbFactory,
+    this.sqfliteFactory,
     this.maxFileSize = 0,
     this.fileStoragePath,
     this.deleteFilesAfterDuration,
@@ -179,6 +184,7 @@ class MatrixSdkDatabase extends DatabaseApi {
         _seenDeviceKeysBoxName,
       },
       sqfliteDatabase: database,
+      sqfliteFactory: sqfliteFactory,
       idbFactory: idbFactory,
     );
     _clientBox = _collection.openBox<String>(
@@ -1596,4 +1602,7 @@ class MatrixSdkDatabase extends DatabaseApi {
 
     return CachedPresence.fromJson(copyMap(rawPresence));
   }
+
+  @override
+  Future<void> delete() => _collection.delete();
 }

--- a/test/box_test.dart
+++ b/test/box_test.dart
@@ -15,6 +15,7 @@ void main() {
         'testbox',
         boxNames,
         sqfliteDatabase: db,
+        sqfliteFactory: databaseFactoryFfi,
       );
     });
 
@@ -75,6 +76,10 @@ void main() {
       await box.clear();
       expect(await box.get('fluffy'), null);
       expect(await box.get('loki'), null);
+    });
+
+    test('Box.delete', () async {
+      await collection.delete();
     });
   });
 }

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -472,6 +472,19 @@ void main() {
     test('Close', () async {
       await database.close();
     });
+    test('Delete', () async {
+      final database = await getMatrixSdkDatabase(null);
+      await database.storeAccountData(
+        'm.test.data',
+        jsonEncode({'foo': 'bar'}),
+      );
+      await database.delete();
+
+      // Check if previously stored data is gone:
+      final reopenedDatabase = await getMatrixSdkDatabase(null);
+      final dump = await reopenedDatabase.getAccountData();
+      expect(dump.isEmpty, true);
+    });
   });
 }
 

--- a/test/fake_database.dart
+++ b/test/fake_database.dart
@@ -44,7 +44,11 @@ Future<HiveCollectionsDatabase> getHiveCollectionsDatabase(Client? c) async {
 // ignore: deprecated_member_use_from_same_package
 Future<MatrixSdkDatabase> getMatrixSdkDatabase(Client? c) async {
   final database = await databaseFactoryFfi.openDatabase(':memory:');
-  final db = MatrixSdkDatabase('unit_test.${c?.hashCode}', database: database);
+  final db = MatrixSdkDatabase(
+    'unit_test.${c?.hashCode}',
+    database: database,
+    sqfliteFactory: databaseFactoryFfi,
+  );
   await db.open();
   return db;
 }


### PR DESCRIPTION
This adds a delete database
method used for migration to
correctly delete the whole
legacy database instead just
empty it.