### PR TITLE
refactor: Make getDisplayname and calcAvatar of room async

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -223,6 +223,29 @@ class Room {
     return pinned is Iterable ? pinned.map((e) => e.toString()).toList() : [];
   }
 
+  /// Returns the heroes as `User` objects.
+  /// This is very useful if you want to make sure that all users are loaded
+  /// from the database, that you need to correctly calculate the displayname
+  /// and the avatar of the room.
+  Future<List<User>> loadHeroUsers() async {
+    var heroes = summary.mHeroes;
+    if (heroes == null) {
+      final directChatMatrixID = this.directChatMatrixID;
+      if (directChatMatrixID != null) {
+        heroes = [directChatMatrixID];
+      }
+    }
+
+    if (heroes == null) return [];
+
+    return await Future.wait(heroes.map((hero) async =>
+        (await requestUser(
+          hero,
+          ignoreErrors: true,
+        )) ??
+        User(hero, room: this)));
+  }
+
   /// Returns a localized displayname for this server. If the room is a groupchat
   /// without a name, then it will return the localized version of 'Group with Alice' instead
   /// of just 'Alice' to make it different to a direct chat.

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -81,6 +81,9 @@ void main() {
         stateKey: '',
       ));
 
+      final heroUsers = await room.loadHeroUsers();
+      expect(heroUsers.length, 3);
+
       expect(room.id, id);
       expect(room.membership, membership);
       expect(room.notificationCount, notificationCount);


### PR DESCRIPTION
This makes it possible to
load users lazy
for rooms to calculate the
name and the avatar. The
changes explain the new
behavior in detail in the
dart docs. The old
avatar getter now only
returns the avatar from the
room state m.room.avatar.