### PR TITLE
feat: Reset unread count directly on set read marker

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1356,8 +1356,28 @@ class Room {
   /// read receipt's location.
   /// If you set `public` to false, only a private receipt will be sent. A private receipt is always sent if `mRead` is set. If no value is provided, the default from the `client` is used.
   /// You can leave out the `eventId`, which will not update the read marker but just send receipts, but there are few cases where that makes sense.
-  Future<void> setReadMarker(String? eventId,
-      {String? mRead, bool? public}) async {
+  Future<void> setReadMarker(
+    String? eventId, {
+    String? mRead,
+    bool? public,
+    bool resetUnreadCountLocally = false,
+  }) async {
+    if (resetUnreadCountLocally) {
+      await _handleFakeSync(
+        SyncUpdate(
+          nextBatch: '',
+          rooms: RoomsUpdate(
+            join: {
+              id: JoinedRoomUpdate(
+                  unreadNotifications: UnreadNotificationCounts(
+                notificationCount: 0,
+                highlightCount: 0,
+              ))
+            },
+          ),
+        ),
+      );
+    }
     await client.setReadMarker(
       id,
       mFullyRead: eventId,

--- a/lib/src/timeline.dart
+++ b/lib/src/timeline.dart
@@ -366,12 +366,27 @@ class Timeline {
     }
   }
 
-  /// Set the read marker to the last synced event in this timeline.
-  Future<void> setReadMarker({String? eventId, bool? public}) async {
-    eventId ??=
+  /// Set the read marker to the last synced event in this timeline. By
+  /// default this resets the unread count locally when the read marker is set
+  /// on the last event in this timeline.
+  Future<void> setReadMarker({
+    String? eventId,
+    bool? public,
+    bool? resetUnreadCountLocally,
+  }) async {
+    final lastEventId =
         events.firstWhereOrNull((event) => event.status.isSynced)?.eventId;
+    eventId ??= lastEventId;
+
+    resetUnreadCountLocally ??= eventId == lastEventId;
+
     if (eventId == null) return;
-    return room.setReadMarker(eventId, mRead: eventId, public: public);
+    return room.setReadMarker(
+      eventId,
+      mRead: eventId,
+      public: public,
+      resetUnreadCountLocally: resetUnreadCountLocally,
+    );
   }
 
   int _findEvent({String? event_id, String? unsigned_txid}) {


### PR DESCRIPTION
Like in other apps this resets
the unread count when
using setReadMarker without
waiting for the server to
responde. Should lead to
a much better UX when
dealing with a slow connection
to the server but is configurable
by the sdk consumer.