### PR TITLE
refactor: Connect timeline to event updates earlier

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1488,6 +1488,15 @@ class Room {
       }
     }
 
+    final timeline = Timeline(
+        room: this,
+        chunk: chunk,
+        onChange: onChange,
+        onRemove: onRemove,
+        onInsert: onInsert,
+        onNewEvent: onNewEvent,
+        onUpdate: onUpdate);
+
     // Fetch all users from database we have got here.
     if (eventContextId == null) {
       for (final event in events) {
@@ -1528,14 +1537,6 @@ class Room {
       }
     }
 
-    final timeline = Timeline(
-        room: this,
-        chunk: chunk,
-        onChange: onChange,
-        onRemove: onRemove,
-        onInsert: onInsert,
-        onNewEvent: onNewEvent,
-        onUpdate: onUpdate);
     return timeline;
   }
 


### PR DESCRIPTION
This creates the timeline object
earlier in the Room.getTimeline() method.
This results to that the
Timeline object already starts
to listen on the event stream
while the getTimeline() method
requests users from the database
and tries to decrypt room
events. I assume that this
causes the problem that
on timeline creation new
events get lost because they
come in, while getTimeline() is
not yet completed but the
onEvent stream is not yet
connected at the same time.