### PR TITLE
Pass string to login method instead of LoginType for OIDC adaptation

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -497,7 +497,7 @@ class Client extends MatrixApi {
   /// older server versions.
   @override
   Future<LoginResponse> login(
-    LoginType type, {
+    String type, {
     AuthenticationIdentifier? identifier,
     String? password,
     String? token,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,10 @@ dependencies:
   image: ^4.0.15
   js: ^0.6.3
   markdown: ^7.1.1
-  matrix_api_lite: ^1.7.0
+  matrix_api_lite:
+    git: # Will be replace with the new api lite version after it merged
+      url: git@github.com:famedly/dart_matrix_api_lite.git
+      ref: reza/oidc-login-flow
   mime: ^1.0.0
   olm: ^2.0.2
   random_string: ^2.3.1
@@ -41,6 +44,6 @@ dev_dependencies:
   sqflite_common_ffi: ^2.2.5
   test: ^1.15.7
   #flutter_test: {sdk: flutter}
-#dependency_overrides:
-#  matrix_api_lite:
-#    path: ../matrix_api_lite
+# dependency_overrides: # easy uncomment for dev purposes
+#   matrix_api_lite:
+#     path: ../dart_matrix_api_lite

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -435,7 +435,7 @@ void main() {
       await matrix.checkHomeserver(Uri.parse('https://fakeserver.notexisting'),
           checkWellKnown: false);
 
-      final loginResp = await matrix.login(LoginType.mLoginPassword,
+      final loginResp = await matrix.login(LoginType.mLoginPassword.name,
           identifier: AuthenticationUserIdentifier(user: 'test'),
           password: '1234');
 

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -268,7 +268,7 @@ void main() {
       final matrix = Client('testclient', httpClient: FakeMatrixApi());
       await matrix.checkHomeserver(Uri.parse('https://fakeserver.notexisting'),
           checkWellKnown: false);
-      await matrix.login(LoginType.mLoginPassword,
+      await matrix.login(LoginType.mLoginPassword.name,
           identifier: AuthenticationUserIdentifier(user: 'test'),
           password: '1234');
 
@@ -287,7 +287,7 @@ void main() {
       final matrix = Client('testclient', httpClient: FakeMatrixApi());
       await matrix.checkHomeserver(Uri.parse('https://fakeserver.notexisting'),
           checkWellKnown: false);
-      await matrix.login(LoginType.mLoginPassword,
+      await matrix.login(LoginType.mLoginPassword.name,
           identifier: AuthenticationUserIdentifier(user: 'test'),
           password: '1234');
 

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -46,7 +46,7 @@ void main() {
     setUp(() async {
       await client.checkHomeserver(Uri.parse('https://fakeserver.notexisting'),
           checkWellKnown: false);
-      await client.login(LoginType.mLoginPassword,
+      await client.login(LoginType.mLoginPassword.name,
           identifier: AuthenticationUserIdentifier(user: 'test'),
           password: '1234');
     });

--- a/test_driver/matrixsdk_test.dart
+++ b/test_driver/matrixsdk_test.dart
@@ -51,7 +51,7 @@ void main() => group('Integration tests', () {
           testClientA = Client('TestClientA', databaseBuilder: getDatabase);
           await testClientA.checkHomeserver(homeserverUri);
           await testClientA.login(
-            LoginType.mLoginPassword,
+            LoginType.mLoginPassword.name,
             identifier: AuthenticationUserIdentifier(user: Users.user1.name),
             password: Users.user1.password,
           );
@@ -61,7 +61,7 @@ void main() => group('Integration tests', () {
           testClientB = Client('TestClientB', databaseBuilder: getDatabase);
           await testClientB.checkHomeserver(homeserverUri);
           await testClientB.login(
-            LoginType.mLoginPassword,
+            LoginType.mLoginPassword.name,
             identifier: AuthenticationUserIdentifier(user: Users.user2.name),
             password: Users.user2.password,
           );
@@ -302,7 +302,7 @@ void main() => group('Integration tests', () {
           await testClientC.checkHomeserver(homeserverUri);
           // We can't sign in using the displayname, since that breaks e2ee on dendrite: https://github.com/matrix-org/dendrite/issues/2914
           await testClientC.login(
-            LoginType.mLoginPassword,
+            LoginType.mLoginPassword.name,
             identifier: AuthenticationUserIdentifier(user: Users.user2.name),
             password: Users.user2.password,
           );
@@ -438,7 +438,7 @@ void main() => group('Integration tests', () {
           testClientA = Client('TestClientA', databaseBuilder: getDatabase);
           await testClientA.checkHomeserver(homeserverUri);
           await testClientA.login(
-            LoginType.mLoginPassword,
+            LoginType.mLoginPassword.name,
             identifier: AuthenticationUserIdentifier(user: Users.user1.name),
             password: Users.user1.password,
           );
@@ -448,7 +448,7 @@ void main() => group('Integration tests', () {
           testClientB = Client('TestClientB', databaseBuilder: getDatabase);
           await testClientB.checkHomeserver(homeserverUri);
           await testClientB.login(
-            LoginType.mLoginPassword,
+            LoginType.mLoginPassword.name,
             identifier: AuthenticationUserIdentifier(user: Users.user2.name),
             password: Users.user2.password,
           );


### PR DESCRIPTION
Breaking change: In order to call the login method users need to pass ```LoginType.loginType.name``` instead of ```LoginType.loginType```.
In order to adapt with OIDC login-flow we need to pass the string as type now since the OIDC login flow type is not a matrix type. Will be part of the work for https://github.com/famedly/product-management/issues/1563