### PR TITLE
refactor: Throw client init exception on client init fail

### DIFF
--- a/lib/src/utils/client_init_exception.dart
+++ b/lib/src/utils/client_init_exception.dart
@@ -1,0 +1,34 @@
+/// Exception thrown on Client initialization. This object might contain
+/// enough information to restore the session or to decide if you need to
+/// logout the session or clear the database.
+class ClientInitException implements Exception {
+  final Object originalException;
+  final Uri? homeserver;
+  final String? accessToken;
+  final String? userId;
+  final String? deviceId;
+  final String? deviceName;
+  final String? olmAccount;
+
+  ClientInitException(
+    this.originalException, {
+    this.homeserver,
+    this.accessToken,
+    this.userId,
+    this.deviceId,
+    this.deviceName,
+    this.olmAccount,
+  });
+
+  @override
+  String toString() => originalException.toString();
+}
+
+class ClientInitPreconditionError implements Exception {
+  final String cause;
+
+  ClientInitPreconditionError(this.cause);
+
+  @override
+  String toString() => 'Client Init Precondition Error: $cause';
+}


### PR DESCRIPTION
This changes the behavior
when client init fails. It
no longer calls logout and does
only clear local data while
returning all available
information in a new
exception type so that the
SDK consumer can decide
to logout or try again to init
with these information. This
should make it much more rare
that users loose their sessions.