### PR TITLE
fix: Type error when combining dynamic lists

### DIFF
--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1585,7 +1585,12 @@ class MatrixSdkDatabase extends DatabaseApi {
         }
 
         // Combine those two lists while respecting the start and limit parameters.
-        final eventIds = sendingEventIds + timelineEventIds;
+        // Create a new list object instead of concatonating list to prevent
+        // random type errors.
+        final eventIds = [
+          ...sendingEventIds,
+          ...timelineEventIds,
+        ];
         if (limit != null && eventIds.length > limit) {
           eventIds.removeRange(limit, eventIds.length);
         }


### PR DESCRIPTION
I don't know why but using concatonating produces type errors in one of 1000 times because one of these lists becomes a List<dynamic> while this should actually not be possible after casting them. Maybe that's a bug in Dart itself? However I have verified in dartpad that  it works this way.