### PR TITLE
refactor: Improve getTimeline senders

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1499,9 +1499,10 @@ class Room {
 
     // Fetch all users from database we have got here.
     if (eventContextId == null) {
-      for (final event in events) {
-        if (getState(EventTypes.RoomMember, event.senderId) != null) continue;
-        final dbUser = await client.database?.getUser(event.senderId, this);
+      final userIds = events.map((event) => event.senderId).toSet();
+      for (final userId in userIds) {
+        if (getState(EventTypes.RoomMember, userId) != null) continue;
+        final dbUser = await client.database?.getUser(userId, this);
         if (dbUser != null) setState(dbUser);
       }
     }


### PR DESCRIPTION
This creates a set before
requesting users from the
database. This prevents
doing the same check for
the same user multiple
times and also prevents
concurrent modifications
of the event list.

Fixes https://github.com/krille-chan/fluffychat/issues/810