### PR TITLE
fix: Transactions on web by doing them in the same way as on io

### DIFF
--- a/lib/src/database/indexeddb_box.dart
+++ b/lib/src/database/indexeddb_box.dart
@@ -2,9 +2,11 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:indexed_db';
 
+import 'package:matrix/src/database/zone_transaction_mixin.dart';
+
 /// Key-Value store abstraction over IndexedDB so that the sdk database can use
 /// a single interface for all platforms. API is inspired by Hive.
-class BoxCollection {
+class BoxCollection with ZoneTransactionMixin {
   final Database _db;
   final Set<String> boxNames;
   final String _name;
@@ -43,25 +45,28 @@ class BoxCollection {
     Future<void> Function() action, {
     List<String>? boxNames,
     bool readOnly = false,
-  }) async {
-    boxNames ??= _db.objectStoreNames!.toList();
-    _txnCache = [];
-    await action();
-    final cache = List<Future<void> Function(Transaction txn)>.from(_txnCache!);
-    _txnCache = null;
-    if (cache.isEmpty) return;
-    final txn = _db.transaction(boxNames, readOnly ? 'readonly' : 'readwrite');
-    for (final fun in cache) {
-      // The IDB methods return a Future in Dart but must not be awaited in
-      // order to have an actual transaction. They must only be performed and
-      // then the transaction object must call `txn.completed;` which then
-      // returns the actual future.
-      // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction
-      unawaited(fun(txn));
-    }
-    await txn.completed;
-    return;
-  }
+  }) =>
+      zoneTransaction(() async {
+        boxNames ??= _db.objectStoreNames!.toList();
+        final txnCache = _txnCache = [];
+        await action();
+        final cache =
+            List<Future<void> Function(Transaction txn)>.from(txnCache);
+        _txnCache = null;
+        if (cache.isEmpty) return;
+        final txn =
+            _db.transaction(boxNames, readOnly ? 'readonly' : 'readwrite');
+        for (final fun in cache) {
+          // The IDB methods return a Future in Dart but must not be awaited in
+          // order to have an actual transaction. They must only be performed and
+          // then the transaction object must call `txn.completed;` which then
+          // returns the actual future.
+          // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction
+          unawaited(fun(txn));
+        }
+        await txn.completed;
+        return;
+      });
 
   Future<void> clear() async {
     final txn = _db.transaction(boxNames, 'readwrite');

--- a/lib/src/database/sqflite_box.dart
+++ b/lib/src/database/sqflite_box.dart
@@ -3,9 +3,11 @@ import 'dart:convert';
 
 import 'package:sqflite_common/sqflite.dart';
 
+import 'package:matrix/src/database/zone_transaction_mixin.dart';
+
 /// Key-Value store abstraction over Sqflite so that the sdk database can use
 /// a single interface for all platforms. API is inspired by Hive.
-class BoxCollection {
+class BoxCollection with ZoneTransactionMixin {
   final Database _db;
   final Set<String> boxNames;
   final DatabaseFactory? _factory;
@@ -42,66 +44,18 @@ class BoxCollection {
 
   Batch? _activeBatch;
 
-  Completer<void>? _transactionLock;
-  final _transactionZones = <Zone>{};
-
   Future<void> transaction(
     Future<void> Function() action, {
     List<String>? boxNames,
     bool readOnly = false,
-  }) async {
-    // we want transactions to lock, however NOT if transactoins are run inside of each other.
-    // to be able to do this, we use dart zones (https://dart.dev/articles/archive/zones).
-    // _transactionZones holds a set of all zones which are currently running a transaction.
-    // _transactionLock holds the lock.
-
-    // first we try to determine if we are inside of a transaction currently
-    var isInTransaction = false;
-    Zone? zone = Zone.current;
-    // for that we keep on iterating to the parent zone until there is either no zone anymore
-    // or we have found a zone inside of _transactionZones.
-    while (zone != null) {
-      if (_transactionZones.contains(zone)) {
-        isInTransaction = true;
-        break;
-      }
-      zone = zone.parent;
-    }
-    // if we are inside a transaction....just run the action
-    if (isInTransaction) {
-      return await action();
-    }
-    // if we are *not* in a transaction, time to wait for the lock!
-    while (_transactionLock != null) {
-      await _transactionLock!.future;
-    }
-    // claim the lock
-    final lock = Completer<void>();
-    _transactionLock = lock;
-    try {
-      // run the action inside of a new zone
-      return await runZoned(() async {
-        try {
-          // don't forget to add the new zone to _transactionZones!
-          _transactionZones.add(Zone.current);
-
-          final batch = _db.batch();
-          _activeBatch = batch;
-          await action();
-          _activeBatch = null;
-          await batch.commit(noResult: true);
-          return;
-        } finally {
-          // aaaand remove the zone from _transactionZones again
-          _transactionZones.remove(Zone.current);
-        }
+  }) =>
+      zoneTransaction(() async {
+        final batch = _db.batch();
+        _activeBatch = batch;
+        await action();
+        _activeBatch = null;
+        await batch.commit(noResult: true);
       });
-    } finally {
-      // aaaand finally release the lock
-      _transactionLock = null;
-      lock.complete();
-    }
-  }
 
   Future<void> clear() => transaction(
         () async {

--- a/lib/src/database/zone_transaction_mixin.dart
+++ b/lib/src/database/zone_transaction_mixin.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+// we want transactions to lock, however NOT if transactoins are run inside of each other.
+// to be able to do this, we use dart zones (https://dart.dev/articles/archive/zones).
+// _transactionZones holds a set of all zones which are currently running a transaction.
+// _transactionLock holds the lock.
+mixin ZoneTransactionMixin {
+  Completer<void>? _transactionLock;
+  final _transactionZones = <Zone>{};
+
+  Future<void> zoneTransaction(Future<void> Function() action) async {
+    // first we try to determine if we are inside of a transaction currently
+    var isInTransaction = false;
+    Zone? zone = Zone.current;
+    // for that we keep on iterating to the parent zone until there is either no zone anymore
+    // or we have found a zone inside of _transactionZones.
+    while (zone != null) {
+      if (_transactionZones.contains(zone)) {
+        isInTransaction = true;
+        break;
+      }
+      zone = zone.parent;
+    }
+    // if we are inside a transaction....just run the action
+    if (isInTransaction) {
+      return await action();
+    }
+    // if we are *not* in a transaction, time to wait for the lock!
+    while (_transactionLock != null) {
+      await _transactionLock!.future;
+    }
+    // claim the lock
+    final lock = Completer<void>();
+    _transactionLock = lock;
+    try {
+      // run the action inside of a new zone
+      return await runZoned(() async {
+        try {
+          // don't forget to add the new zone to _transactionZones!
+          _transactionZones.add(Zone.current);
+
+          await action();
+          return;
+        } finally {
+          // aaaand remove the zone from _transactionZones again
+          _transactionZones.remove(Zone.current);
+        }
+      });
+    } finally {
+      // aaaand finally release the lock
+      _transactionLock = null;
+      lock.complete();
+    }
+  }
+}


### PR DESCRIPTION
This refactors the transaction
workaround with
"zone transactions" and
abstracts them in a mixin. Then
it just uses this mixin in the
HiveDatabase and the
sqflite_box and also applies
them on indexedDB to
fix transactions on web.