### PR TITLE
fix: Use name of other participant on archived rooms

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -290,6 +290,19 @@ class Room {
           .calcDisplayname(i18n: i18n);
       if (sender != null) return sender;
     }
+    if (isArchived) {
+      // In case of a direct chat, we need to get the room-members via the RoomMember event-type
+      // then we have to make sure to get the other room-member that is not us, to add them to the display name.
+      final roomMemberEvents = states.entries
+          .firstWhereOrNull((element) => element.key == EventTypes.RoomMember);
+      final otherRoomMember = roomMemberEvents?.value.entries
+          .firstWhereOrNull((entry) => entry.value.senderId != client.userID);
+
+      if (otherRoomMember?.value.prevContent?.tryGet('displayname') != null) {
+        return i18n.wasDirectChatDisplayName(
+            otherRoomMember!.value.prevContent!.tryGet('displayname')!);
+      }
+    }
     if (membership == Membership.leave) {
       final invitation = getState(EventTypes.RoomMember, client.userID!);
       if (invitation != null &&

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -290,20 +290,12 @@ class Room {
           .calcDisplayname(i18n: i18n);
       if (sender != null) return sender;
     }
-    if (isArchived) {
-      // In case of a direct chat, we need to get the room-members via the RoomMember event-type
-      // then we have to make sure to get the other room-member that is not us, to add them to the display name.
-      final roomMemberEvents = states.entries
-          .firstWhereOrNull((element) => element.key == EventTypes.RoomMember);
-      final otherRoomMember = roomMemberEvents?.value.entries
-          .firstWhereOrNull((entry) => entry.value.senderId != client.userID);
-
-      if (otherRoomMember?.value.prevContent?.tryGet('displayname') != null) {
-        return i18n.wasDirectChatDisplayName(
-            otherRoomMember!.value.prevContent!.tryGet('displayname')!);
-      }
-    }
     if (membership == Membership.leave) {
+      if (directChatMatrixID != null) {
+        return i18n.wasDirectChatDisplayName(
+            unsafeGetUserFromMemoryOrFallback(directChatMatrixID)
+                .calcDisplayname(i18n: i18n));
+      }
       final invitation = getState(EventTypes.RoomMember, client.userID!);
       if (invitation != null &&
           invitation.unsigned?.tryGet<String>('prev_sender') != null) {

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -296,14 +296,6 @@ class Room {
             unsafeGetUserFromMemoryOrFallback(directChatMatrixID)
                 .calcDisplayname(i18n: i18n));
       }
-      final invitation = getState(EventTypes.RoomMember, client.userID!);
-      if (invitation != null &&
-          invitation.unsigned?.tryGet<String>('prev_sender') != null) {
-        final name = unsafeGetUserFromMemoryOrFallback(
-                invitation.unsigned!.tryGet<String>('prev_sender')!)
-            .calcDisplayname(i18n: i18n);
-        return i18n.wasDirectChatDisplayName(name);
-      }
     }
     return i18n.emptyChat;
   }


### PR DESCRIPTION
Previously archived rooms where called Empty chat (was <Your own username>).
Now the other username is selected in case of direct chats that are archived, via the room-member-states and client-userID