### PR TITLE
fix: convert boxNames to List in clear function when creating transaction

### DIFF
--- a/lib/src/database/indexeddb_box.dart
+++ b/lib/src/database/indexeddb_box.dart
@@ -69,7 +69,7 @@ class BoxCollection with ZoneTransactionMixin {
       });
 
   Future<void> clear() async {
-    final txn = _db.transaction(boxNames, 'readwrite');
+    final txn = _db.transaction(boxNames.toList(), 'readwrite');
     for (final name in boxNames) {
       unawaited(txn.objectStore(name).clear());
     }


### PR DESCRIPTION
Currently, the boxNames object is a Set, which causes this error when calling it: "Unable to clear database - NotFoundError: Failed to execute 'transaction' on 'IDBDatabase': One of the specified object stores was not found."