### PR TITLE
fix: Make database deleteable without the need to init the boxcollection

### DIFF
--- a/lib/src/database/indexeddb_box.dart
+++ b/lib/src/database/indexeddb_box.dart
@@ -9,10 +9,9 @@ import 'package:matrix/src/database/zone_transaction_mixin.dart';
 class BoxCollection with ZoneTransactionMixin {
   final Database _db;
   final Set<String> boxNames;
-  final String _name;
-  final IdbFactory _idbFactory;
+  final String name;
 
-  BoxCollection(this._db, this.boxNames, this._name, this._idbFactory);
+  BoxCollection(this._db, this.boxNames, this.name);
 
   static Future<BoxCollection> open(
     String name,
@@ -29,7 +28,7 @@ class BoxCollection with ZoneTransactionMixin {
         db.createObjectStore(name, autoIncrement: true);
       }
     });
-    return BoxCollection(db, boxNames, name, idbFactory);
+    return BoxCollection(db, boxNames, name);
   }
 
   Box<V> openBox<V>(String name) {
@@ -81,7 +80,8 @@ class BoxCollection with ZoneTransactionMixin {
     return _db.close();
   }
 
-  Future<void> delete() => _idbFactory.deleteDatabase(_name);
+  static Future<void> delete(String path, [IdbFactory? factory]) =>
+      (factory ?? window.indexedDB!).deleteDatabase(path);
 }
 
 class Box<V> {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1594,5 +1594,8 @@ class MatrixSdkDatabase extends DatabaseApi {
   }
 
   @override
-  Future<void> delete() => _collection.delete();
+  Future<void> delete() => BoxCollection.delete(
+        name,
+        sqfliteFactory ?? idbFactory,
+      );
 }

--- a/lib/src/database/sqflite_box.dart
+++ b/lib/src/database/sqflite_box.dart
@@ -10,9 +10,9 @@ import 'package:matrix/src/database/zone_transaction_mixin.dart';
 class BoxCollection with ZoneTransactionMixin {
   final Database _db;
   final Set<String> boxNames;
-  final DatabaseFactory? _factory;
+  final String name;
 
-  BoxCollection(this._db, this.boxNames, this._factory);
+  BoxCollection(this._db, this.boxNames, this.name);
 
   static Future<BoxCollection> open(
     String name,
@@ -32,7 +32,7 @@ class BoxCollection with ZoneTransactionMixin {
       batch.execute('CREATE INDEX IF NOT EXISTS k_index ON $name (k)');
     }
     await batch.commit(noResult: true);
-    return BoxCollection(sqfliteDatabase, boxNames, sqfliteFactory);
+    return BoxCollection(sqfliteDatabase, boxNames, name);
   }
 
   Box<V> openBox<V>(String name) {
@@ -67,8 +67,8 @@ class BoxCollection with ZoneTransactionMixin {
 
   Future<void> close() => _db.close();
 
-  Future<void> delete() =>
-      (_factory ?? databaseFactory).deleteDatabase(_db.path);
+  static Future<void> delete(String path, [DatabaseFactory? factory]) =>
+      (factory ?? databaseFactory).deleteDatabase(path);
 }
 
 class Box<V> {

--- a/test/box_test.dart
+++ b/test/box_test.dart
@@ -9,8 +9,9 @@ void main() {
     const Set<String> boxNames = {'cats', 'dogs'};
     const data = {'name': 'Fluffy', 'age': 2};
     const data2 = {'name': 'Loki', 'age': 4};
+    late Database db;
     setUp(() async {
-      final db = await databaseFactoryFfi.openDatabase(':memory:');
+      db = await databaseFactoryFfi.openDatabase(':memory:');
       collection = await BoxCollection.open(
         'testbox',
         boxNames,
@@ -91,7 +92,7 @@ void main() {
     });
 
     test('Box.delete', () async {
-      await collection.delete();
+      await BoxCollection.delete(db.path, databaseFactoryFfi);
     });
   });
 }


### PR DESCRIPTION
Usually we want to delete a corrupted database. To do this
we need to init the BoxCollection first
which is not possible with a
corrupted database.

To fix this, this PR makes the
delete method a static function so that we can delete a
database at any time. This
makes it no longer necessary
to store the database factory
in the boxcollection so I
have removed it.