### PR TITLE
fix: dart:io import in matrix_sdk_database

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -47,6 +47,11 @@ jobs:
           rm -r example
           ./scripts/prepare.sh
           ./scripts/test.sh
+      - name: Ensure SDK compiles on web
+        run: |
+          pushd web_test
+          dart pub get
+          dart run webdev build
 
   coverage_without_olm:
     runs-on: ubuntu-latest

--- a/lib/src/database/filesystem/fake_filesystem.dart
+++ b/lib/src/database/filesystem/fake_filesystem.dart
@@ -1,0 +1,37 @@
+// This is a stub implementation of all filesystem related calls done
+// by the matrix SDK database. This fake implementation ensures we can compile
+// using dart2js.
+
+import 'dart:typed_data';
+
+class File extends FileSystemEntry {
+  const File(super.path);
+
+  Future<Uint8List> readAsBytes() async => Uint8List(0);
+
+  Future<void> writeAsBytes(Uint8List data) async => Future.value();
+}
+
+class Directory extends FileSystemEntry {
+  const Directory(super.path);
+
+  Stream<FileSystemEntry> list() async* {
+    return;
+  }
+}
+
+abstract class FileSystemEntry {
+  final String path;
+
+  const FileSystemEntry(this.path);
+
+  Future<void> delete() => Future.value();
+
+  Future<FileStat> stat() async => FileStat();
+
+  Future<bool> exists() async => false;
+}
+
+class FileStat {
+  final modified = DateTime.fromMillisecondsSinceEpoch(0);
+}

--- a/lib/src/database/filesystem/io_filesystem.dart
+++ b/lib/src/database/filesystem/io_filesystem.dart
@@ -1,0 +1,1 @@
+export 'dart:io';

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -18,7 +18,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -35,6 +34,11 @@ import 'package:matrix/src/utils/run_benchmarked.dart';
 
 import 'package:matrix/src/database/indexeddb_box.dart'
     if (dart.library.io) 'package:matrix/src/database/sqflite_box.dart';
+
+import 'package:matrix/src/database/filesystem/fake_filesystem.dart'
+    if (dart.library.io) 'package:matrix/src/database/filesystem/fake_filesystem.dart';
+
+const _kIsWeb = bool.fromEnvironment('dart.library.js_util');
 
 class MatrixSdkDatabase extends DatabaseApi {
   static const int version = 7;
@@ -86,11 +90,28 @@ class MatrixSdkDatabase extends DatabaseApi {
   late Box<String> _seenDeviceIdsBox;
 
   late Box<String> _seenDeviceKeysBox;
+
   @override
-  bool get supportsFileStoring => fileStoragePath != null;
+  bool get supportsFileStoring => fileStorageLocation != null;
   @override
   final int maxFileSize;
-  final Directory? fileStoragePath;
+
+  // there was a field of type `dart:io:Directory` here. This one broke the
+  // dart js standalone compiler. Migration via URI as file system identifier.
+  @Deprecated(
+      'Breaks support for web standalone. Use [fileStorageLocation] instead.')
+  Object? get fileStoragePath => fileStorageLocation?.toFilePath();
+
+  /// A [Uri] defining the file storage location.
+  ///
+  /// Unless you support custom Uri schemes, this should usually be a
+  /// [Uri.directory] identifier.
+  ///
+  /// Using a [Uri] as type here enables users to technically extend the API to
+  /// support file storage on non-io platforms as well - or to use non-File
+  /// based storage mechanisms on io.
+  final Uri? fileStorageLocation;
+
   final Duration? deleteFilesAfterDuration;
 
   static const String _clientBoxName = 'box_client';
@@ -154,9 +175,11 @@ class MatrixSdkDatabase extends DatabaseApi {
     this.idbFactory,
     this.sqfliteFactory,
     this.maxFileSize = 0,
-    this.fileStoragePath,
+    // TODO : remove deprecated member migration on next major release
+    dynamic fileStoragePath,
+    Uri? fileStorageLocation,
     this.deleteFilesAfterDuration,
-  });
+  }) : fileStorageLocation = fileStorageLocation ?? fileStoragePath?.path;
 
   Future<void> open() async {
     _collection = await BoxCollection.open(
@@ -297,13 +320,15 @@ class MatrixSdkDatabase extends DatabaseApi {
 
   @override
   Future<void> deleteOldFiles(int savedAt) async {
-    final dir = fileStoragePath;
+    if (_kIsWeb) return;
+    final path = fileStorageLocation?.toFilePath();
     final deleteFilesAfterDuration = this.deleteFilesAfterDuration;
     if (!supportsFileStoring ||
-        dir == null ||
+        path == null ||
         deleteFilesAfterDuration == null) {
       return;
     }
+    final dir = Directory(path);
     final entities = await dir.list().toList();
     for (final file in entities) {
       if (file is! File) continue;
@@ -439,11 +464,11 @@ class MatrixSdkDatabase extends DatabaseApi {
 
   @override
   Future<Uint8List?> getFile(Uri mxcUri) async {
-    final fileStoragePath = this.fileStoragePath;
-    if (!supportsFileStoring || fileStoragePath == null) return null;
+    if (_kIsWeb) return null;
+    final path = fileStorageLocation?.toFilePath();
+    if (!supportsFileStoring || path == null) return null;
 
-    final file =
-        File('${fileStoragePath.path}/${mxcUri.toString().split('/').last}');
+    final file = File('$path/${mxcUri.toString().split('/').last}');
 
     if (await file.exists()) return await file.readAsBytes();
     return null;
@@ -1124,11 +1149,11 @@ class MatrixSdkDatabase extends DatabaseApi {
 
   @override
   Future<void> storeFile(Uri mxcUri, Uint8List bytes, int time) async {
-    final fileStoragePath = this.fileStoragePath;
-    if (!supportsFileStoring || fileStoragePath == null) return;
+    if (_kIsWeb) return;
+    final path = fileStorageLocation?.toFilePath();
+    if (!supportsFileStoring || path == null) return;
 
-    final file =
-        File('${fileStoragePath.path}/${mxcUri.toString().split('/').last}');
+    final file = File('$path/${mxcUri.toString().split('/').last}');
 
     if (await file.exists()) return;
     await file.writeAsBytes(bytes);

--- a/web_test/.gitignore
+++ b/web_test/.gitignore
@@ -1,0 +1,3 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/

--- a/web_test/README.md
+++ b/web_test/README.md
@@ -1,0 +1,1 @@
+This is a bare-bone sample project in order to ensure webdev can compile the SDK.

--- a/web_test/pubspec.yaml
+++ b/web_test/pubspec.yaml
@@ -1,0 +1,17 @@
+name: web_test
+description: A test project for the webdev compiler.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.2.0
+
+# Add regular dependencies here.
+dependencies:
+  matrix:
+    path: ..
+
+dev_dependencies:
+  build_runner: ^2.4.9
+  build_web_compilers: ^4.0.10
+  webdev: ^3.4.0

--- a/web_test/web/main.dart
+++ b/web_test/web/main.dart
@@ -1,0 +1,6 @@
+import 'package:matrix/matrix.dart';
+
+Future<void> main() async {
+  final client = Client('web_test');
+  await client.init();
+}


### PR DESCRIPTION
- removes `Directory` field in high-level `MatrixSdkDatabase`
- migrates `Directory fileStoragePath` to `Uri fileStorageLocation`
- makes file operations in `MatrixSdkDatabase` conditional on `dart.libraries.js_util`
- implements a tiny stub of the file operations used in `MatrixSdkDatabase`

It seems like the Flutter tool can compile despite these imports. Sadly the Dart standalone dart2js compiler doesn't reach there. While refactorying the code, I decided it's likely cleaner to have a `Uri` as storage location provider than using some fake directory or String as relacement.

The advantage of a `Uri` at this place is the explicit `Uri.directory` constructor available to ensure type and encoding safe directory locations supporting both Windows and *nix.

Additionally, admitted, that's an edge-case, one could even easily extend the use of a `Uri` based descriptor to support future storage location accesses (e.g. IPFS or custom schemes for e.g. local web browser based file system APIs). Using a `Uri`, one would only need to override the three methods making use of the `fileStorageLocation` property to handle different Uri schemes too.