### PR TITLE
fix: Do not use invitor avatar_url for room

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -288,8 +288,9 @@ class Room {
 
   /// The avatar of the room if set by a participant.
   Uri? get avatar {
-    final avatarUrl = getState(EventTypes.RoomAvatar)?.content['url'];
-    if (avatarUrl is String) {
+    final avatarUrl =
+        getState(EventTypes.RoomAvatar)?.content.tryGet<String>('url');
+    if (avatarUrl != null) {
       return Uri.tryParse(avatarUrl);
     }
 
@@ -305,13 +306,6 @@ class Room {
       if (user != null) {
         return unsafeGetUserFromMemoryOrFallback(user).avatarUrl;
       }
-    }
-    if (membership == Membership.invite) {
-      final userID = client.userID;
-      if (userID == null) return null;
-      return getState(EventTypes.RoomMember, userID)
-          ?.senderFromMemoryOrFallback
-          .avatarUrl;
     }
     return null;
   }


### PR DESCRIPTION
When user A invites user B to
a group chat, the avatar getter
should not return the
avatar of the inviting user A.
This is not intuitive. A client might
decide to do so but IMO it makes
no sense to do this by default.
If the
room is a DM invite, user A's
avatar is already used in the
code block before.