### PR TITLE
Don't fail sync if a presence event contains an empty presence field

### DIFF
--- a/lib/matrix_api_lite/model/presence_content.dart
+++ b/lib/matrix_api_lite/model/presence_content.dart
@@ -31,7 +31,8 @@ class PresenceContent {
 
   PresenceContent.fromJson(Map<String, Object?> json)
       : presence = PresenceType.values.firstWhere(
-            (p) => p.toString().split('.').last == json['presence']),
+            (p) => p.toString().split('.').last == json['presence'],
+            orElse: () => PresenceType.offline),
         lastActiveAgo = json.tryGet<int>('last_active_ago'),
         statusMsg = json.tryGet<String>('status_msg'),
         currentlyActive = json.tryGet<bool>('currently_active');


### PR DESCRIPTION
Observed by using FluffyChat and conduit/conduwuit as the server

Example:
```
@nomad:daedric.net: {type: m.presence, content: {currently_active: false, last_active_ago: 1712913753736, presence: , status_msg...}
```