### PR TITLE
fix: Make room.setPower more type safe and avoid change powerlevel in RAM before sending request to server

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1201,11 +1201,15 @@ class Room {
   /// Returns the event ID of the new state event. If there is no known
   /// power level event, there might something broken and this returns null.
   Future<String> setPower(String userID, int power) async {
-    var powerMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (powerMap is! Map<String, dynamic>) {
-      powerMap = <String, dynamic>{};
-    }
-    (powerMap['users'] ??= {})[userID] = power;
+    final powerMap = Map<String, Object?>.from(
+      getState(EventTypes.RoomPowerLevels)?.content ?? {},
+    );
+
+    final usersPowerMap = powerMap['users'] is Map<String, Object?>
+        ? powerMap['users'] as Map<String, Object?>
+        : (powerMap['users'] = <String, Object?>{});
+
+    usersPowerMap[userID] = power;
 
     return await client.setRoomStateWithKey(
       id,


### PR DESCRIPTION
This fixes the bug that the
actual dart Map in the state
has been manipulated because
we have not worked with a
copy of the map. Also this
crashes if the powerlevelmap
would had a wrong type in
users.