### PR TITLE
feat: support for JWT authentication

### DIFF
--- a/lib/matrix_api_lite/generated/model.dart
+++ b/lib/matrix_api_lite/generated/model.dart
@@ -1398,7 +1398,9 @@ enum LoginType {
   @EnhancedEnumValue(name: 'm.login.password')
   mLoginPassword,
   @EnhancedEnumValue(name: 'm.login.token')
-  mLoginToken
+  mLoginToken,
+  @EnhancedEnumValue(name: 'org.matrix.login.jwt')
+  mLoginJWT
 }
 
 ///

--- a/lib/matrix_api_lite/generated/model.g.dart
+++ b/lib/matrix_api_lite/generated/model.g.dart
@@ -308,6 +308,7 @@ extension LoginTypeFromStringExtension on Iterable<LoginType> {
     final override = {
       'm.login.password': LoginType.mLoginPassword,
       'm.login.token': LoginType.mLoginToken,
+      'org.matrix.login.jwt': LoginType.mLoginJWT,
     }[val];
 // ignore: unnecessary_this
     return this.contains(override) ? override : null;
@@ -320,25 +321,31 @@ extension LoginTypeEnhancedEnum on LoginType {
   String get name => {
         LoginType.mLoginPassword: 'm.login.password',
         LoginType.mLoginToken: 'm.login.token',
+        LoginType.mLoginJWT: 'org.matrix.login.jwt',
       }[this]!;
   bool get isMLoginPassword => this == LoginType.mLoginPassword;
   bool get isMLoginToken => this == LoginType.mLoginToken;
+  bool get isMLoginJWT => this == LoginType.mLoginJWT;
   T when<T>({
     required T Function() mLoginPassword,
     required T Function() mLoginToken,
+    required T Function() mLoginJWT,
   }) =>
       {
         LoginType.mLoginPassword: mLoginPassword,
         LoginType.mLoginToken: mLoginToken,
+        LoginType.mLoginJWT: mLoginJWT,
       }[this]!();
   T maybeWhen<T>({
     T? Function()? mLoginPassword,
     T? Function()? mLoginToken,
+    T? Function()? mLoginJWT,
     required T Function() orElse,
   }) =>
       {
         LoginType.mLoginPassword: mLoginPassword,
         LoginType.mLoginToken: mLoginToken,
+        LoginType.mLoginJWT: mLoginJWT,
       }[this]
           ?.call() ??
       orElse();


### PR DESCRIPTION
This adds the support for JWT authentication. It's now as easy as using the following code.

```dart
LoginResponse result = await _client.login(LoginType.mLoginJWT, token: accessToken);
```

In Synpase config file, add the following to allow JWT auth:

```yaml
jwt_config:
  enabled: true
  secret: "YOUR_SECRET"
  algorithm: "HS256"
```

For more details, please refer to [JWT Login Type](https://matrix-org.github.io/synapse/latest/jwt.html#jwt-login-type)