### PR TITLE
refactor: delete not sent events without eventupdate stream workaround

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1312,6 +1312,9 @@ class Client extends MatrixApi {
 
   final CachedStreamController<Event> onGroupMember = CachedStreamController();
 
+  final CachedStreamController<String> onCancelSendEvent =
+      CachedStreamController();
+
   /// When a state in a room has been updated this will return the room ID
   /// and the state event.
   final CachedStreamController<({String roomId, StrippedStateEvent state})>

--- a/lib/src/event_status.dart
+++ b/lib/src/event_status.dart
@@ -6,7 +6,6 @@
 /// - synced: (event came from sync loop)
 /// - roomState
 enum EventStatus {
-  removed,
   error,
   sending,
   sent,
@@ -33,16 +32,12 @@ EventStatus latestEventStatus(EventStatus status1, EventStatus status2) =>
 extension EventStatusExtension on EventStatus {
   /// Returns int value of the event status.
   ///
-  /// - -2 == removed;
   /// - -1 == error;
   /// -  0 == sending;
   /// -  1 == sent;
   /// -  2 == synced;
   /// -  3 == roomState;
   int get intValue => (index - 2);
-
-  /// Return `true` if the `EventStatus` equals `removed`.
-  bool get isRemoved => this == EventStatus.removed;
 
   /// Return `true` if the `EventStatus` equals `error`.
   bool get isError => this == EventStatus.error;

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -242,12 +242,12 @@ void main() {
 
     test('remove', () async {
       final event = Event.fromJson(
-          jsonObj, Room(id: '1234', client: Client('testclient')));
-      final removed1 = await event.remove();
+        jsonObj,
+        Room(id: '1234', client: Client('testclient')),
+      );
+      expect(() async => await event.cancelSend(), throwsException);
       event.status = EventStatus.sending;
-      final removed2 = await event.remove();
-      expect(removed1, false);
-      expect(removed2, true);
+      await event.cancelSend();
     });
 
     test('sendAgain', () async {

--- a/test/timeline_context_test.dart
+++ b/test/timeline_context_test.dart
@@ -270,7 +270,7 @@ void main() {
       ));
       await waitForCount(7);
 
-      await timeline.events[0].remove();
+      await timeline.events[0].cancelSend();
 
       await waitForCount(8);
       expect(updateCount, 8);

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -507,7 +507,7 @@ void main() {
       ));
       await waitForCount(1);
 
-      await timeline.events[0].remove();
+      await timeline.events[0].cancelSend();
 
       await waitForCount(2);
 


### PR DESCRIPTION
Fixes https://github.com/famedly/product-management/issues/1984

This fixes several problems. First
sending a fake event through the
onEventUpdate stream was not a
good design and lead to problems
if you expect a timeline event but
then are unable to build the
event from json. This now uses
a new stream in the Client which
is listened to in the timeline to
delete an event which should be
much more reliable.
It also now throws an exception
if deleting the event fails
instead of returning true or false.
A deprecation note is added.
It also removes the behavior of
silently delete a file event where
the file is not stored. This is
confusing for the user and the
event should stay in the timeline
until the user activly decides to
try to send it again or delete the
message.