### PR TITLE
refactor: Removes the behavior of deleting an event if the file is no longer cached

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -145,19 +145,6 @@ class Event extends MatrixEvent {
         );
       }
     }
-
-    // If this is failed to send and the file is no longer cached, it should be removed!
-    if (!status.isSent &&
-        {
-          MessageTypes.Image,
-          MessageTypes.Video,
-          MessageTypes.Audio,
-          MessageTypes.File,
-        }.contains(messageType) &&
-        !room.sendingFilePlaceholders.containsKey(eventId)) {
-      // ignore: discarded_futures
-      remove();
-    }
   }
 
   static Map<String, dynamic> getMapFromPayload(Object? payload) {


### PR DESCRIPTION
This brings more problems than it
helps. It leads to bugs like flickering
of sending images and also
confuses the user. This should
either be handled by the app
or the user.

Closes https://github.com/famedly/product-management/issues/1977