### PR TITLE
perf: use decodeNamedImage instead of decodeImage

### DIFF
--- a/lib/src/utils/native_implementations.dart
+++ b/lib/src/utils/native_implementations.dart
@@ -46,7 +46,7 @@ abstract class NativeImplementations {
   });
 
   FutureOr<MatrixImageFileResizedResponse?> calcImageMetadata(
-    Uint8List bytes, {
+    MatrixImageFileCalcMetadataArguments args, {
     bool retryInDummy = false,
   });
 
@@ -119,10 +119,10 @@ class NativeImplementationsDummy extends NativeImplementations {
 
   @override
   MatrixImageFileResizedResponse? calcImageMetadata(
-    Uint8List bytes, {
+    MatrixImageFileCalcMetadataArguments args, {
     bool retryInDummy = false,
   }) {
-    return MatrixImageFile.calcMetadataImplementation(bytes);
+    return MatrixImageFile.calcMetadataImplementation(args);
   }
 }
 
@@ -199,12 +199,13 @@ class NativeImplementationsIsolate extends NativeImplementations {
 
   @override
   FutureOr<MatrixImageFileResizedResponse?> calcImageMetadata(
-    Uint8List bytes, {
+    MatrixImageFileCalcMetadataArguments args, {
     bool retryInDummy = false,
   }) {
-    return runInBackground<MatrixImageFileResizedResponse?, Uint8List>(
+    return runInBackground<MatrixImageFileResizedResponse?,
+        MatrixImageFileCalcMetadataArguments>(
       NativeImplementations.dummy.calcImageMetadata,
-      bytes,
+      args,
     );
   }
 }

--- a/lib/src/utils/web_worker/native_implementations_web_worker.dart
+++ b/lib/src/utils/web_worker/native_implementations_web_worker.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:matrix/matrix.dart';
 
@@ -59,13 +58,14 @@ class NativeImplementationsWebWorker extends NativeImplementations {
 
   @override
   Future<MatrixImageFileResizedResponse?> calcImageMetadata(
-    Uint8List bytes, {
+    MatrixImageFileCalcMetadataArguments args, {
     bool retryInDummy = false,
   }) async {
     try {
-      final result = await operation<Map<dynamic, dynamic>, Uint8List>(
+      final result =
+          await operation<Map<dynamic, dynamic>, Map<String, dynamic>>(
         WebWorkerOperations.calcImageMetadata,
-        bytes,
+        args.toJson(),
       );
       return MatrixImageFileResizedResponse.fromJson(Map.from(result));
     } catch (e, s) {
@@ -75,7 +75,7 @@ class NativeImplementationsWebWorker extends NativeImplementations {
         return null;
       }
       Logs().e('Web worker computation error. Fallback to main thread', e, s);
-      return NativeImplementations.dummy.calcImageMetadata(bytes);
+      return NativeImplementations.dummy.calcImageMetadata(args);
     }
   }
 

--- a/lib/src/utils/web_worker/web_worker.dart
+++ b/lib/src/utils/web_worker/web_worker.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:indexed_db';
 import 'dart:js';
-import 'dart:typed_data';
 
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
@@ -52,8 +51,8 @@ Future<void> startWebWorker() async {
               break;
             case WebWorkerOperations.calcImageMetadata:
               final result = MatrixImageFile.calcMetadataImplementation(
-                  Uint8List.fromList(
-                      (operation.data as JsArray).whereType<int>().toList()));
+                  MatrixImageFileCalcMetadataArguments.fromJson(
+                      Map.from(operation.data as Map)));
               sendResponse(operation.label as double, result?.toJson());
               break;
             default:


### PR DESCRIPTION
Might improve image compression performance because `decodeImage` documentation reads "...**WARNING** Since this will check the image data against all known decoders, it is much slower than using an explicit decoder."