### PR TITLE
perf: check event size in bytes without encoding twice

### DIFF
--- a/lib/matrix_api_lite/generated/api.dart
+++ b/lib/matrix_api_lite/generated/api.dart
@@ -22,6 +22,10 @@ class Api {
     throw Exception('http error response');
   }
 
+  Never bodySizeExceeded(int expected, int actual) {
+    throw Exception('body size $actual exceeded $expected');
+  }
+
   /// Gets discovery information about the domain. The file may include
   /// additional keys, which MUST follow the Java package naming convention,
   /// e.g. `com.example.myapp.property`. This ensures property names are
@@ -3798,6 +3802,10 @@ class Api {
     request.headers['authorization'] = 'Bearer ${bearerToken!}';
     request.headers['content-type'] = 'application/json';
     request.bodyBytes = utf8.encode(jsonEncode(body));
+    const maxBodySize = 60000;
+    if (request.bodyBytes.length > maxBodySize) {
+      bodySizeExceeded(maxBodySize, request.bodyBytes.length);
+    }
     final response = await httpClient.send(request);
     final responseBody = await response.stream.toBytes();
     if (response.statusCode != 200) unexpectedResponse(response, responseBody);

--- a/lib/matrix_api_lite/matrix_api.dart
+++ b/lib/matrix_api_lite/matrix_api.dart
@@ -56,6 +56,11 @@ class MatrixApi extends Api {
     super.unexpectedResponse(response, body);
   }
 
+  @override
+  Never bodySizeExceeded(int expected, int actual) {
+    throw EventTooLarge(expected, actual);
+  }
+
   MatrixApi({
     Uri? homeserver,
     String? accessToken,
@@ -235,4 +240,9 @@ class MatrixApi extends Api {
       String roomId, String sessionId, String version) async {
     return getRoomKeyBySessionId(roomId, sessionId, version);
   }
+}
+
+class EventTooLarge implements Exception {
+  int maxSize, actualSize;
+  EventTooLarge(this.maxSize, this.actualSize);
 }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -966,12 +966,6 @@ class Room {
             .encryptGroupMessagePayload(id, content, type: type)
         : content;
 
-    final utf8EncodedJsonLength =
-        utf8.encode(jsonEncode(sendMessageContent)).length;
-
-    if (utf8EncodedJsonLength > maxPDUSize) {
-      throw EventTooLarge(utf8EncodedJsonLength);
-    }
     return await client.sendMessage(
       id,
       sendMessageContent.containsKey('ciphertext')
@@ -2379,9 +2373,4 @@ class Room {
 enum EncryptionHealthState {
   allVerified,
   unverifiedDevices,
-}
-
-class EventTooLarge implements Exception {
-  int length;
-  EventTooLarge(this.length);
 }


### PR DESCRIPTION
Needed for https://github.com/famedly/product-management/issues/2019

Also refer https://github.com/famedly/dart_openapi_codegen/pull/47 which has the actual change for code generation.