### PR TITLE
refactor: Do not trigger event updates on room ephemerals

### DIFF
--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -155,8 +155,7 @@ class Encryption {
   }
 
   Future<void> handleEventUpdate(EventUpdate update) async {
-    if (update.type == EventUpdateType.ephemeral ||
-        update.type == EventUpdateType.history) {
+    if (update.type == EventUpdateType.history) {
       return;
     }
     if (update.content['type'].startsWith('m.key.verification.') ||

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2704,7 +2704,7 @@ class Client extends MatrixApi {
     final List<ReceiptEventContent> receipts = [];
 
     for (final event in events) {
-      await _handleRoomEvents(room, [event], EventUpdateType.ephemeral);
+      room.ephemerals[event.type] = event;
 
       // Receipt events are deltas between two states. We will create a
       // fake room account data event for this and store the difference
@@ -2804,7 +2804,7 @@ class Client extends MatrixApi {
         }
       }
       _updateRoomsByEventUpdate(room, update);
-      if (type != EventUpdateType.ephemeral && store) {
+      if (store) {
         await database?.storeEventUpdate(update, this);
       }
       if (encryptionEnabled) {
@@ -2977,9 +2977,6 @@ class Client extends MatrixApi {
       case EventUpdateType.accountData:
         room.roomAccountData[eventUpdate.content['type']] =
             BasicRoomEvent.fromJson(eventUpdate.content);
-        break;
-      case EventUpdateType.ephemeral:
-        room.setEphemeral(BasicRoomEvent.fromJson(eventUpdate.content));
         break;
       case EventUpdateType.history:
       case EventUpdateType.decryptedTimelineQueue:

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -82,6 +82,8 @@ abstract class DatabaseApi {
   /// [transaction].
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client);
 
+  Future<void> storeRoomAccountData(BasicRoomEvent event);
+
   Future<Event?> getEventById(String eventId, Room room);
 
   Future<void> forgetRoom(String roomId);

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1080,9 +1080,6 @@ class HiveCollectionsDatabase extends DatabaseApi {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
-
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
 

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1227,18 +1227,17 @@ class HiveCollectionsDatabase extends DatabaseApi {
         await _roomStateBox.put(key, stateMap);
       }
     }
-
-    // Store a room account data event
-    if (eventUpdate.type == EventUpdateType.accountData) {
-      await _roomAccountDataBox.put(
-        TupleKey(
-          eventUpdate.roomID,
-          eventUpdate.content['type'],
-        ).toString(),
-        eventUpdate.content,
-      );
-    }
   }
+
+  @override
+  Future<void> storeRoomAccountData(BasicRoomEvent event) =>
+      _roomAccountDataBox.put(
+        TupleKey(
+          event.roomId.toString(),
+          event.type,
+        ).toString(),
+        event.content,
+      );
 
   @override
   Future<void> storeFile(Uri mxcUri, Uint8List bytes, int time) async {

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1042,9 +1042,6 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
-
     // In case of this is a redaction event
     if (eventUpdate.content['type'] == EventTypes.Redaction) {
       final tmpRoom = client.getRoomById(eventUpdate.roomID) ??

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1187,18 +1187,17 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
         await _roomStateBox.put(key, stateMap);
       }
     }
-
-    // Store a room account data event
-    if (eventUpdate.type == EventUpdateType.accountData) {
-      await _roomAccountDataBox.put(
-        MultiKey(
-          eventUpdate.roomID,
-          eventUpdate.content['type'],
-        ).toString(),
-        eventUpdate.content,
-      );
-    }
   }
+
+  @override
+  Future<void> storeRoomAccountData(BasicRoomEvent event) =>
+      _roomAccountDataBox.put(
+        TupleKey(
+          event.roomId.toString(),
+          event.type,
+        ).toString(),
+        event.content,
+      );
 
   @override
   Future<void> storeFile(Uri mxcUri, Uint8List bytes, int time) async {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1043,8 +1043,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
 

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1197,18 +1197,17 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         await roomStateBox.put(key, eventUpdate.content);
       }
     }
-
-    // Store a room account data event
-    if (eventUpdate.type == EventUpdateType.accountData) {
-      await _roomAccountDataBox.put(
-        TupleKey(
-          eventUpdate.roomID,
-          eventUpdate.content['type'],
-        ).toString(),
-        eventUpdate.content,
-      );
-    }
   }
+
+  @override
+  Future<void> storeRoomAccountData(BasicRoomEvent event) =>
+      _roomAccountDataBox.put(
+        TupleKey(
+          event.roomId.toString(),
+          event.type,
+        ).toString(),
+        event.content,
+      );
 
   @override
   Future<void> storeInboundGroupSession(

--- a/lib/src/utils/event_update.dart
+++ b/lib/src/utils/event_update.dart
@@ -31,9 +31,6 @@ enum EventUpdateType {
   /// Updates to account data
   accountData,
 
-  /// Ephemeral events like receipts
-  ephemeral,
-
   /// The state of an invite
   inviteState,
 

--- a/lib/src/utils/event_update.dart
+++ b/lib/src/utils/event_update.dart
@@ -28,9 +28,6 @@ enum EventUpdateType {
   /// Messages that have been fetched when requesting past history
   history,
 
-  /// Updates to account data
-  accountData,
-
   /// The state of an invite
   inviteState,
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -308,21 +308,22 @@ void main() {
       expect(eventUpdateList[5].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[5].type, EventUpdateType.timeline);
 
-      expect(eventUpdateList[6].content['type'], 'm.typing');
+      expect(eventUpdateList[6].content['type'], LatestReceiptState.eventType);
       expect(eventUpdateList[6].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[6].type, EventUpdateType.ephemeral);
+      expect(eventUpdateList[6].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[7].content['type'], 'm.receipt');
+      expect(eventUpdateList[7].content['type'], 'm.tag');
       expect(eventUpdateList[7].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[7].type, EventUpdateType.ephemeral);
+      expect(eventUpdateList[7].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[8].content['type'], LatestReceiptState.eventType);
+      expect(
+          eventUpdateList[8].content['type'], 'org.example.custom.room.config');
       expect(eventUpdateList[8].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[8].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[9].content['type'], 'm.tag');
-      expect(eventUpdateList[9].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[9].type, EventUpdateType.accountData);
+      expect(eventUpdateList[9].content['type'], 'm.room.member');
+      expect(eventUpdateList[9].roomID, '!calls:example.com');
+      expect(eventUpdateList[9].type, EventUpdateType.state);
 
       expect(
         eventUpdateList[10].content['type'],

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -308,9 +308,9 @@ void main() {
       expect(eventUpdateList[5].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[5].type, EventUpdateType.timeline);
 
-      expect(eventUpdateList[6].content['type'], LatestReceiptState.eventType);
-      expect(eventUpdateList[6].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[6].type, EventUpdateType.accountData);
+      expect(eventUpdateList[6].content['type'], 'm.room.member');
+      expect(eventUpdateList[6].roomID, '!calls:example.com');
+      expect(eventUpdateList[6].type, EventUpdateType.state);
 
       expect(eventUpdateList[7].content['type'], 'm.tag');
       expect(eventUpdateList[7].roomID, '!726s6s6q:example.com');


### PR DESCRIPTION
This is the first step to
finally refactor the EventUpdate
class. This will remove the
ephemerals from being
handled by the EventUpdate.
In the next step, I would do
the same with account data
and THEN we are able to
define InviteState as a base
class for the EventUpdate content
instead of JSON