### PR TITLE
refactor: Deprecate Streams in favor of client.onSync

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1310,6 +1310,7 @@ class Client extends MatrixApi {
       CachedStreamController();
 
   /// Callback will be called on account data updates.
+  @Deprecated('Use `client.onSync` instead')
   final CachedStreamController<BasicEvent> onAccountData =
       CachedStreamController();
 
@@ -1326,6 +1327,7 @@ class Client extends MatrixApi {
   final CachedStreamController<UiaRequest> onUiaRequest =
       CachedStreamController();
 
+  @Deprecated('This is not in use anywhere anymore')
   final CachedStreamController<Event> onGroupMember = CachedStreamController();
 
   final CachedStreamController<String> onCancelSendEvent =
@@ -2024,6 +2026,7 @@ class Client extends MatrixApi {
         jsonEncode(newAccountData.content),
       );
       accountData[newAccountData.type] = newAccountData;
+      // ignore: deprecated_member_use_from_same_package
       onAccountData.add(newAccountData);
 
       if (newAccountData.type == EventTypes.PushRules) {
@@ -2398,6 +2401,7 @@ class Client extends MatrixApi {
           ..addAll(summary.toJson());
         rooms[roomIndex].summary = RoomSummary.fromJson(roomSummaryJson);
       }
+      // ignore: deprecated_member_use_from_same_package
       rooms[roomIndex].onUpdate.add(rooms[roomIndex].id);
       if ((chatUpdate.timeline?.limited ?? false) &&
           requestHistoryOnLimitedTimeline) {
@@ -2473,6 +2477,7 @@ class Client extends MatrixApi {
       case EventUpdateType.decryptedTimelineQueue:
         break;
     }
+    // ignore: deprecated_member_use_from_same_package
     room.onUpdate.add(room.id);
   }
 

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -202,6 +202,7 @@ class Room {
 
   /// If something changes, this callback will be triggered. Will return the
   /// room id.
+  @Deprecated('Use `client.onSync` instead and filter for this room ID')
   final CachedStreamController<String> onUpdate = CachedStreamController();
 
   /// If there is a new session key received, this will be triggered with
@@ -1702,6 +1703,7 @@ class Room {
     final dbuser = await client.database?.getUser(mxID, this);
     if (dbuser != null) {
       setState(dbuser);
+      // ignore: deprecated_member_use_from_same_package
       onUpdate.add(id);
       return dbuser;
     }
@@ -1777,6 +1779,7 @@ class Room {
         client,
       );
     });
+    // ignore: deprecated_member_use_from_same_package
     onUpdate.add(id);
     _requestingMatrixIds.remove(mxID);
     return user;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -62,6 +62,7 @@ void main() {
       matrix.onPresenceChanged.stream.listen((CachedPresence data) {
         presenceCounter++;
       });
+      // ignore: deprecated_member_use_from_same_package
       matrix.onAccountData.stream.listen((BasicEvent data) {
         accountDataCounter++;
       });


### PR DESCRIPTION
This deprecates all streams which can
be created by using client.onSync
anyway for a more predictable state
handling in consuming apps.