### PR TITLE
feat: make voip key generator public

### DIFF
--- a/lib/src/voip/backend/livekit_backend.dart
+++ b/lib/src/voip/backend/livekit_backend.dart
@@ -56,7 +56,7 @@ class LiveKitBackend extends CallBackend {
   /// used on first join and when someone leaves
   ///
   /// also does the sending for you
-  Future<void> _makeNewSenderKey(
+  Future<void> makeNewSenderKey(
       GroupCallSession groupCall, bool delayBeforeUsingKeyOurself) async {
     final key = secureRandomBytes(32);
     final keyIndex = _getNewEncryptionKeyIndex();
@@ -87,7 +87,7 @@ class LiveKitBackend extends CallBackend {
     final myKeys = _encryptionKeysMap[groupCall.localParticipant];
 
     if (myKeys == null || myKeys.isEmpty) {
-      await _makeNewSenderKey(groupCall, false);
+      await makeNewSenderKey(groupCall, false);
       return;
     }
 
@@ -186,7 +186,7 @@ class LiveKitBackend extends CallBackend {
     if (myKeys == null || myLatestKey == null) {
       Logs().w(
           '[VOIP E2EE] _sendEncryptionKeysEvent Tried to send encryption keys event but no keys found!');
-      await _makeNewSenderKey(groupCall, false);
+      await makeNewSenderKey(groupCall, false);
       await _sendEncryptionKeysEvent(
         groupCall,
         keyIndex,
@@ -392,7 +392,7 @@ class LiveKitBackend extends CallBackend {
     if (groupCall.voip.enableSFUE2EEKeyRatcheting) {
       await _ratchetLocalParticipantKey(groupCall, anyJoined);
     } else {
-      await _makeNewSenderKey(groupCall, true);
+      await makeNewSenderKey(groupCall, true);
     }
   }
 
@@ -409,7 +409,7 @@ class LiveKitBackend extends CallBackend {
     }
     _memberLeaveEncKeyRotateDebounceTimer =
         Timer(CallTimeouts.makeKeyDelay, () async {
-      await _makeNewSenderKey(groupCall, true);
+      await makeNewSenderKey(groupCall, true);
     });
   }
 

--- a/lib/src/voip/group_call_session.dart
+++ b/lib/src/voip/group_call_session.dart
@@ -199,12 +199,6 @@ class GroupCallSession {
 
   /// compltetely rebuilds the local _participants list
   Future<void> onMemberStateChanged() async {
-    if (state != GroupCallState.entered) {
-      Logs().d(
-          '[VOIP] early return onMemberStateChanged, group call state is not Entered. Actual state: ${state.toString()} ');
-      return;
-    }
-
     // The member events may be received for another room, which we will ignore.
     final mems =
         room.getCallMembershipsFromRoom().values.expand((element) => element);


### PR DESCRIPTION
For: https://github.com/famedly/product-management/issues/2051
Relevant app PR: https://github.com/famedly/app/pull/5879

with this you can now send the key before joining the call to the participants, make sure to call onMemberStateChanged first to ensure groupCall.participants is populated