### PR TITLE
preShareKey improvements

### DIFF
--- a/lib/src/voip/backend/call_backend_model.dart
+++ b/lib/src/voip/backend/call_backend_model.dart
@@ -73,6 +73,8 @@ abstract class CallBackend {
     List<CallParticipant> anyLeft,
   );
 
+  Future<void> preShareKey(GroupCallSession groupCall);
+
   Future<void> requestEncrytionKey(
     GroupCallSession groupCall,
     List<CallParticipant> remoteParticipants,

--- a/lib/src/voip/backend/mesh_backend.dart
+++ b/lib/src/voip/backend/mesh_backend.dart
@@ -877,4 +877,9 @@ class MeshBackend extends CallBackend {
       List<CallParticipant> remoteParticipants) async {
     return;
   }
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    return;
+  }
 }


### PR DESCRIPTION
fix: only fire backend.onNewParticipant and backend.onLeftParticipant when it is not the local participant, this fixes the issue where onNewParticipant would get triggered when it detects a new call even though you were not in the call, as of now there is no code in those functions which needs to be triggered before you have joined the call so this should be fine

chore: also improve participants join leave tracking logic