### PR TITLE
fix: make sure room is postLoaded before starting calls

### DIFF
--- a/lib/src/voip/utils/famedly_call_extension.dart
+++ b/lib/src/voip/utils/famedly_call_extension.dart
@@ -129,7 +129,14 @@ extension FamedlyCallMemberEventsExtension on Room {
       );
     } else {
       throw MatrixSDKVoipException(
-        'User ${client.userID}:${client.deviceID} is not allowed to send famedly call member events in room $id, canJoinGroupCall: $canJoinGroupCall, room.canJoinGroupCall: $groupCallsEnabledForEveryone',
+        '''
+        User ${client.userID}:${client.deviceID} is not allowed to join famedly calls in room $id, 
+        canJoinGroupCall: $canJoinGroupCall, 
+        groupCallsEnabledForEveryone: $groupCallsEnabledForEveryone, 
+        needed: ${powerForChangingStateEvent(EventTypes.GroupCallMember)}, 
+        own: $ownPowerLevel}
+        plMap: ${getState(EventTypes.RoomPowerLevels)?.content}
+        ''',
       );
     }
   }


### PR DESCRIPTION
Fixes:


![image](https://github.com/famedly/matrix-dart-sdk/assets/152161658/3f28c405-b8c4-423f-8da0-ce80c4deae93)
