### PR TITLE
postLoad before setting famedly calls

### DIFF
--- a/lib/src/voip/utils/famedly_call_extension.dart
+++ b/lib/src/voip/utils/famedly_call_extension.dart
@@ -120,6 +120,7 @@ extension FamedlyCallMemberEventsExtension on Room {
   }
 
   Future<void> setFamedlyCallMemberEvent(Map<String, List> newContent) async {
+    await postLoad();
     if (canJoinGroupCall) {
       await client.setRoomStateWithKey(
         id,
@@ -130,7 +131,7 @@ extension FamedlyCallMemberEventsExtension on Room {
     } else {
       throw MatrixSDKVoipException(
         '''
-        User ${client.userID}:${client.deviceID} is not allowed to join famedly calls in room $id, 
+        User ${client.userID}:${client.deviceID} is not allowed to send com.famedly.call.member events in room $id, 
         canJoinGroupCall: $canJoinGroupCall, 
         groupCallsEnabledForEveryone: $groupCallsEnabledForEveryone, 
         needed: ${powerForChangingStateEvent(EventTypes.GroupCallMember)}, 


### PR DESCRIPTION
Fixes: https://github.com/famedly/matrix-dart-sdk/issues/1830

Found a missing postLoad from a maybe code path, this does not fix the admin indicator missing bug, you probably want to set powerlevels as a required event for that