### PR TITLE
fix: do not fire missedCall on answeredElseWhere

### DIFF
--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -983,7 +983,9 @@ class CallSession {
       onCallHangupNotifierForGroupCalls.add(this);
       await voip.delegate.handleCallEnded(this);
       fireCallEvent(CallStateChange.kHangup);
-      if ((party == CallParty.kRemote && _missedCall)) {
+      if ((party == CallParty.kRemote &&
+          _missedCall &&
+          reason != CallErrorCode.answeredElsewhere)) {
         await voip.delegate.handleMissedCall(this);
       }
     }


### PR DESCRIPTION
Related: https://github.com/famedly/product-management/issues/2070