### PR TITLE
fix: canRequestHistory doesn't reflect reality follow-up

### DIFF
--- a/lib/src/timeline.dart
+++ b/lib/src/timeline.dart
@@ -80,8 +80,8 @@ class Timeline {
 
   bool get canRequestHistory {
     if (events.isEmpty) return true;
-    return !_fetchedAllDatabaseEvents ||
-        (room.prev_batch != null && events.last.type != EventTypes.RoomCreate);
+    return (!_fetchedAllDatabaseEvents || room.prev_batch != null) &&
+        events.last.type != EventTypes.RoomCreate;
   }
 
   Future<void> requestHistory(


### PR DESCRIPTION
Fixes room name changing back to old one in 'Archive group' test.