### PR TITLE
fix: state updates being also applied when fetching history

### DIFF
--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1134,7 +1134,11 @@ class HiveCollectionsDatabase extends DatabaseApi {
 
     final stateKey = eventUpdate.content['state_key'];
     // Store a common state event
-    if (stateKey != null) {
+    if (stateKey != null &&
+        // Don't store events as state updates when paginating backwards.
+        (eventUpdate.type == EventUpdateType.timeline ||
+            eventUpdate.type == EventUpdateType.state ||
+            eventUpdate.type == EventUpdateType.inviteState)) {
       if (eventUpdate.content['type'] == EventTypes.RoomMember) {
         await _roomMembersBox.put(
             TupleKey(

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1063,7 +1063,11 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
 
     final stateKey = eventUpdate.content['state_key'];
     // Store a common state event
-    if (stateKey != null) {
+    if (stateKey != null &&
+        // Don't store events as state updates when paginating backwards.
+        (eventUpdate.type == EventUpdateType.timeline ||
+            eventUpdate.type == EventUpdateType.state ||
+            eventUpdate.type == EventUpdateType.inviteState)) {
       if (eventUpdate.content['type'] == EventTypes.RoomMember) {
         await _roomMembersBox.put(
             MultiKey(

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1105,7 +1105,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
     final stateKey = eventUpdate.content['state_key'];
     // Store a common state event
-    if (stateKey != null) {
+    if (stateKey != null &&
+        // Don't store events as state updates when paginating backwards.
+        (eventUpdate.type == EventUpdateType.timeline ||
+            eventUpdate.type == EventUpdateType.state ||
+            eventUpdate.type == EventUpdateType.inviteState)) {
       if (eventUpdate.content['type'] == EventTypes.RoomMember) {
         await _roomMembersBox.put(
             TupleKey(

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -231,6 +231,124 @@ void main() {
             ),
             Client('testclient'));
       });
+      test('storeEventUpdate (state)', () async {
+        final roomid = '!testrooma:example.com';
+        final client = Client('testclient');
+
+        await database.storeRoomUpdate(
+          roomid,
+          JoinedRoomUpdate(),
+          null,
+          client,
+        );
+
+        await database.storeEventUpdate(
+          EventUpdate(
+            roomID: roomid,
+            type: EventUpdateType.timeline,
+            content: {
+              'type': EventTypes.RoomName,
+              'content': {
+                'name': 'start',
+              },
+              'event_id': '\$eventstart:example.com',
+              'sender': '@bob:example.org',
+              'state_key': '',
+            },
+          ),
+          client,
+        );
+
+        var room = await database.getSingleRoom(client, roomid);
+
+        expect(room, isNotNull);
+
+        expect(room?.name, 'start');
+
+        await database.storeEventUpdate(
+          EventUpdate(
+            roomID: roomid,
+            type: EventUpdateType.timeline,
+            content: {
+              'type': EventTypes.RoomName,
+              'content': {
+                'name': 'update',
+              },
+              'event_id': '\$eventupdate:example.com',
+              'sender': '@bob:example.org',
+              'state_key': '',
+            },
+          ),
+          client,
+        );
+
+        room = await database.getSingleRoom(client, roomid);
+
+        expect(room?.name, 'update');
+
+        await database.storeEventUpdate(
+          EventUpdate(
+            roomID: roomid,
+            type: EventUpdateType.state,
+            content: {
+              'type': EventTypes.RoomName,
+              'content': {
+                'name': 'update2',
+              },
+              'event_id': '\$eventupdate2:example.com',
+              'sender': '@bob:example.org',
+              'state_key': '',
+            },
+          ),
+          client,
+        );
+
+        room = await database.getSingleRoom(client, roomid);
+
+        expect(room?.name, 'update2');
+
+        await database.storeEventUpdate(
+          EventUpdate(
+            roomID: roomid,
+            type: EventUpdateType.inviteState,
+            content: {
+              'type': EventTypes.RoomName,
+              'content': {
+                'name': 'update3',
+              },
+              'event_id': '\$eventupdate3:example.com',
+              'sender': '@bob:example.org',
+              'state_key': '',
+            },
+          ),
+          client,
+        );
+
+        room = await database.getSingleRoom(client, roomid);
+
+        expect(room?.name, 'update3');
+
+        await database.storeEventUpdate(
+          EventUpdate(
+            roomID: roomid,
+            type: EventUpdateType.history,
+            content: {
+              'type': EventTypes.RoomName,
+              'content': {
+                'name': 'notupdate',
+              },
+              'event_id': '\$eventnotupdate:example.com',
+              'sender': '@bob:example.org',
+              'state_key': '',
+            },
+          ),
+          client,
+        );
+
+        room = await database.getSingleRoom(client, roomid);
+
+        expect(room?.name, 'update3');
+      });
       test('getEventById', () async {
         final event = await database.getEventById('\$event:example.com',
             Room(id: '!testroom:example.com', client: Client('testclient')));


### PR DESCRIPTION
This could sometimes lead to the room name or the names of members in the room being incorrect.