### PR TITLE
chore: allow clients to set their own voip key delays

### DIFF
--- a/lib/src/voip/utils/voip_constants.dart
+++ b/lib/src/voip/utils/voip_constants.dart
@@ -35,7 +35,7 @@ class CallTimeouts {
   /// a chance to receive the new key to minimise the chance they don't get media they can't decrypt.
   /// The total time between a member leaving and the call switching to new keys is therefore
   /// makeKeyDelay + useKeyDelay
-  static const useKeyDelay = Duration(seconds: 6);
+  static const useKeyDelay = Duration(seconds: 4);
 }
 
 class CallConstants {


### PR DESCRIPTION
well that wasn't really helpful because you could not end up in a state where you have to wait for an additional 6 seconds before the key you got was just used.
we always send the latest key (to avoid breaking secrecy) but 6 seconds might have been too long for UX
also now exposes those timeouts