### PR TITLE
feat: cache .well-known data

### DIFF
--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -27,7 +27,9 @@ import 'package:matrix/src/utils/queued_to_device_event.dart';
 
 abstract class DatabaseApi {
   int get maxFileSize => 1 * 1024 * 1024;
+
   bool get supportsFileStoring => false;
+
   Future<Map<String, dynamic>?> getClient(String name);
 
   Future updateClient(
@@ -333,6 +335,10 @@ abstract class DatabaseApi {
   Future<void> storePresence(String userId, CachedPresence presence);
 
   Future<CachedPresence?> getPresence(String userId);
+
+  Future<void> storeWellKnown(DiscoveryInformation? discoveryInformation);
+
+  Future<DiscoveryInformation?> getWellKnown();
 
   /// Deletes the whole database. The database needs to be created again after
   /// this.

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1596,6 +1596,25 @@ class HiveCollectionsDatabase extends DatabaseApi {
   }
 
   @override
+  Future<void> storeWellKnown(DiscoveryInformation? discoveryInformation) {
+    if (discoveryInformation == null) {
+      return _clientBox.delete('discovery_information');
+    }
+    return _clientBox.put(
+      'discovery_information',
+      jsonEncode(discoveryInformation.toJson()),
+    );
+  }
+
+  @override
+  Future<DiscoveryInformation?> getWellKnown() async {
+    final rawDiscoveryInformation =
+        await _clientBox.get('discovery_information');
+    if (rawDiscoveryInformation == null) return null;
+    return DiscoveryInformation.fromJson(jsonDecode(rawDiscoveryInformation));
+  }
+
+  @override
   Future<void> delete() => _collection.deleteFromDisk();
 
   @override

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1402,6 +1402,25 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
   }
 
   @override
+  Future<void> storeWellKnown(DiscoveryInformation? discoveryInformation) {
+    if (discoveryInformation == null) {
+      return _clientBox.delete('discovery_information');
+    }
+    return _clientBox.put(
+      'discovery_information',
+      jsonEncode(discoveryInformation.toJson()),
+    );
+  }
+
+  @override
+  Future<DiscoveryInformation?> getWellKnown() async {
+    final rawDiscoveryInformation =
+        await _clientBox.get('discovery_information');
+    if (rawDiscoveryInformation == null) return null;
+    return DiscoveryInformation.fromJson(jsonDecode(rawDiscoveryInformation));
+  }
+
+  @override
   Future<void> delete() => Hive.deleteFromDisk();
 
   @override

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1624,6 +1624,25 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
+  Future<void> storeWellKnown(DiscoveryInformation? discoveryInformation) {
+    if (discoveryInformation == null) {
+      return _clientBox.delete('discovery_information');
+    }
+    return _clientBox.put(
+      'discovery_information',
+      jsonEncode(discoveryInformation.toJson()),
+    );
+  }
+
+  @override
+  Future<DiscoveryInformation?> getWellKnown() async {
+    final rawDiscoveryInformation =
+        await _clientBox.get('discovery_information');
+    if (rawDiscoveryInformation == null) return null;
+    return DiscoveryInformation.fromJson(jsonDecode(rawDiscoveryInformation));
+  }
+
+  @override
   Future<void> delete() async {
     // database?.path is null on web
     await _collection.deleteDatabase(

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -175,6 +175,7 @@ void main() {
           matrix.userDeviceKeys['@alice:example.com']?.deviceKeys['JLAFKJWSCS']
               ?.verified,
           false);
+      expect(matrix.wellKnown, isNull);
 
       await matrix.handleSync(SyncUpdate.fromJson({
         'next_batch': 'fakesync',
@@ -1166,6 +1167,13 @@ void main() {
       expect(await client.database?.getFile(response) != null,
           client.database?.supportsFileStoring);
       await client.dispose(closeDatabase: true);
+    });
+
+    test('wellKnown cache', () async {
+      final client = await getClient();
+      expect(client.wellKnown, null);
+      await client.getWellknown();
+      expect(client.wellKnown?.mHomeserver.baseUrl.host, 'matrix.example.com');
     });
 
     test('refreshAccessToken', () async {


### PR DESCRIPTION
- BREAKING: remove `DiscoveryInformation` from the `checkHomeserver` response tuple
- BREAKING: create `DatabaseApi.storeWellKnown` method
- BREAKING: create `DatabaseApi.getWellKnown` method
- add new getter `Client.wellKnown` containing cached `DiscoveryInformation`
- override `Client.homeserver` to invalidate `Client.wellKnown` in case the domain changed
- override `Client.getWellknown` to cache the resolved `DiscoveryInformation`
- add tests for well-known cache

Fixes: https://github.com/famedly/matrix-dart-sdk/issues/1865