### PR TITLE
fix: bump database version to v9

### DIFF
--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -52,7 +52,7 @@ import 'package:matrix/src/database/database_file_storage_stub.dart'
 /// Learn more at:
 /// https://github.com/famedly/matrix-dart-sdk/issues/1642#issuecomment-1865827227
 class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
-  static const int version = 8;
+  static const int version = 9;
   final String name;
   late BoxCollection _collection;
   late Box<String> _clientBox;


### PR DESCRIPTION
clears database to handle any old state seen in history getting applied bug bc336709af6e0a0a7ec132db991a9418c0f0b149