### PR TITLE
refactor: Better avatar and names for invites

### DIFF
--- a/lib/src/utils/matrix_default_localizations.dart
+++ b/lib/src/utils/matrix_default_localizations.dart
@@ -249,6 +249,9 @@ class MatrixDefaultLocalizations extends MatrixLocalizations {
       'You have been invited by $senderName';
 
   @override
+  String invitedBy(String senderName) => 'Invited by $senderName';
+
+  @override
   String youInvitedUser(String targetName) => 'You invited $targetName';
 
   @override

--- a/lib/src/utils/matrix_localizations.dart
+++ b/lib/src/utils/matrix_localizations.dart
@@ -62,6 +62,8 @@ abstract class MatrixLocalizations {
 
   String youInvitedBy(String senderName);
 
+  String invitedBy(String senderName);
+
   String youInvitedUser(String targetName);
 
   String youUnbannedUser(String targetName);


### PR DESCRIPTION
Group chats with no user
avatar should return null for
the room.avatar getter and not
a random hero avatar. This could
otherwise lead to confusion as
it looks like this is a DM which
is not the case.

For the name we should also
not just display the name of
the invitor like in a DM even for
group chats, but some more
additional information. I found
a String for
invites quite useful here as
this would name rooms without
a m.room.name like this:
"Invited by $senderName"
which should be short enough.
The alternative
"You have been invited by $senderName" could be too
long IMO.