### PR TITLE
fix: leave->invite in the same sync would hide the invite

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -49,7 +49,6 @@ jobs:
           path: coverage_dir/
           retention-days: 1
 
-
   coverage:
     runs-on: arm-ubuntu-latest-16core
     steps:
@@ -61,6 +60,10 @@ jobs:
           architecture: "arm64"
       - name: Run tests
         run: |
+          # Prevent restarting the github actions service on package upgrades
+          # See https://discourse.ubuntu.com/t/needrestart-changes-in-ubuntu-24-04-service-restarts/44671
+          echo '$nrconf{override_rc}{qr(^actions.runner.*.service$)} = 0;' | sudo tee /etc/needrestart/conf.d/githubactions.conf
+
           sudo apt-get update && sudo apt-get install --no-install-recommends --no-install-suggests -y lcov libsqlite3-0 libsqlite3-dev libolm3 libssl3
           ./scripts/test.sh
       - uses: actions/upload-artifact@v4
@@ -69,7 +72,6 @@ jobs:
           name: coverage
           path: coverage_dir/
           retention-days: 1
-
 
   merge_converage:
     if: ${{ !cancelled() }}

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2037,13 +2037,17 @@ class Client extends MatrixApi {
       if (join != null) {
         await _handleRooms(join, direction: direction);
       }
-      final invite = sync.rooms?.invite;
-      if (invite != null) {
-        await _handleRooms(invite, direction: direction);
-      }
+      // We need to handle leave before invite. If you decline an invite and
+      // then get another invite to the same room, Synapse will include the
+      // room both in invite and leave. If you get an invite and then leave, it
+      // will only be included in leave.
       final leave = sync.rooms?.leave;
       if (leave != null) {
         await _handleRooms(leave, direction: direction);
+      }
+      final invite = sync.rooms?.invite;
+      if (invite != null) {
+        await _handleRooms(invite, direction: direction);
       }
     }
     for (final newPresence in sync.presence ?? <Presence>[]) {


### PR DESCRIPTION
Synapse includes the room in both sections if you have both an invite->leave and a leave->invite transition in one sync response. Transitions in the other order are only included once (in the leave section) it seems, so this should work correctly in all cases.

Fixes https://github.com/famedly/product-management/issues/2283