### PR TITLE
fix: maintain event relation data on redact

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -251,6 +251,8 @@ class Event extends MatrixEvent {
     _originalSource = null;
     final contentKeyWhiteList = <String>[];
     switch (type) {
+      case EventTypes.Message:
+        contentKeyWhiteList.add('m.relates_to');
       case EventTypes.RoomMember:
         contentKeyWhiteList.add('membership');
         break;


### PR DESCRIPTION
alternative fix where we just ignore empty content unredacted messages https://github.com/famedly/app/pull/6100

proper solution would be saving the lastEvents with a different id (or atleast a different cache key so that they don't pollute the timeline events, this will need more investigation)


ideally only the original event should be redacted when we call setRedact, but incase an edited event is the lastEvent, setRedact is also called on the edited version of the message, this causes the db memory cache to have a wrong version of the message for the timeline, theis then causes the m.room.message as we have no content, another solution would be to just ignore empty content bodies