### PR TITLE
fix: App freezes because of recursive loop with getLocalizedDisplayname() call

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1641,9 +1641,7 @@ class Room {
     required bool ignoreErrors,
   }) async {
     try {
-      Logs().v(
-        'Request missing user $mxID in room ${getLocalizedDisplayname()} from the server...',
-      );
+      Logs().v('Request missing user $mxID in room $id from the server...');
       final resp = await client.getRoomStateWithKey(
         id,
         EventTypes.RoomMember,


### PR DESCRIPTION
closes https://github.com/famedly/product-management/issues/2137

Got confirmation from @phillshort that this fixes the bug!