### PR TITLE
feat: support for authenticated media

### DIFF
--- a/lib/src/utils/uri_extension.dart
+++ b/lib/src/utils/uri_extension.dart
@@ -21,7 +21,79 @@ import 'dart:core';
 import 'package:matrix/src/client.dart';
 
 extension MxcUriExtension on Uri {
-  /// Returns a download Link to this content.
+  /// Transforms this `mxc://` Uri into a `http` resource, which can be used
+  /// to download the content.
+  ///
+  /// Throws an exception if the scheme is not `mxc` or the homeserver is not
+  /// set.
+  ///
+  /// Important! To use this link you have to set a http header like this:
+  /// `headers: {"authorization": "Bearer ${client.accessToken}"}`
+  Future<Uri> getDownloadUri(Client client) async {
+    String uriPath;
+
+    if (await client.authenticatedMediaSupported()) {
+      uriPath =
+          '_matrix/client/v1/media/download/$host${hasPort ? ':$port' : ''}$path';
+    } else {
+      uriPath =
+          '_matrix/media/v3/download/$host${hasPort ? ':$port' : ''}$path';
+    }
+
+    return isScheme('mxc')
+        ? client.homeserver != null
+            ? client.homeserver?.resolve(uriPath) ?? Uri()
+            : Uri()
+        : Uri();
+  }
+
+  /// Transforms this `mxc://` Uri into a `http` resource, which can be used
+  /// to download the content with the given `width` and
+  /// `height`. `method` can be `ThumbnailMethod.crop` or
+  /// `ThumbnailMethod.scale` and defaults to `ThumbnailMethod.scale`.
+  /// If `animated` (default false) is set to true, an animated thumbnail is requested
+  /// as per MSC2705. Thumbnails only animate if the media repository supports that.
+  ///
+  /// Throws an exception if the scheme is not `mxc` or the homeserver is not
+  /// set.
+  ///
+  /// Important! To use this link you have to set a http header like this:
+  /// `headers: {"authorization": "Bearer ${client.accessToken}"}`
+  Future<Uri> getThumbnailUri(Client client,
+      {num? width,
+      num? height,
+      ThumbnailMethod? method = ThumbnailMethod.crop,
+      bool? animated = false}) async {
+    if (!isScheme('mxc')) return Uri();
+    final homeserver = client.homeserver;
+    if (homeserver == null) {
+      return Uri();
+    }
+
+    String requestPath;
+    if (await client.authenticatedMediaSupported()) {
+      requestPath =
+          '/_matrix/client/v1/media/thumbnail/$host${hasPort ? ':$port' : ''}$path';
+    } else {
+      requestPath =
+          '/_matrix/media/v3/thumbnail/$host${hasPort ? ':$port' : ''}$path';
+    }
+
+    return Uri(
+      scheme: homeserver.scheme,
+      host: homeserver.host,
+      path: requestPath,
+      port: homeserver.port,
+      queryParameters: {
+        if (width != null) 'width': width.round().toString(),
+        if (height != null) 'height': height.round().toString(),
+        if (method != null) 'method': method.toString().split('.').last,
+        if (animated != null) 'animated': animated.toString(),
+      },
+    );
+  }
+
+  @Deprecated('Use `getDownloadUri()` instead')
   Uri getDownloadLink(Client matrix) => isScheme('mxc')
       ? matrix.homeserver != null
           ? matrix.homeserver?.resolve(
@@ -35,6 +107,7 @@ extension MxcUriExtension on Uri {
   /// `ThumbnailMethod.scale` and defaults to `ThumbnailMethod.scale`.
   /// If `animated` (default false) is set to true, an animated thumbnail is requested
   /// as per MSC2705. Thumbnails only animate if the media repository supports that.
+  @Deprecated('Use `getThumbnailUri()` instead')
   Uri getThumbnail(Client matrix,
       {num? width,
       num? height,

--- a/lib/src/utils/versions_comparator.dart
+++ b/lib/src/utils/versions_comparator.dart
@@ -1,0 +1,24 @@
+import 'package:matrix/matrix_api_lite/utils/logs.dart';
+
+bool isVersionGreaterThanOrEqualTo(String version, String target) {
+  try {
+    final versionParts =
+        version.substring(1).split('.').map(int.parse).toList();
+    final targetParts = target.substring(1).split('.').map(int.parse).toList();
+
+    for (int i = 0; i < versionParts.length; i++) {
+      if (i >= targetParts.length) return true; // reached the end, both equal
+      if (versionParts[i] > targetParts[i]) return true; // ver greater
+      if (versionParts[i] < targetParts[i]) return false; // tar greater
+    }
+
+    return true;
+  } catch (e, s) {
+    Logs().e(
+      '[_isVersionGreaterThanOrEqualTo] Failed to parse version $version',
+      e,
+      s,
+    );
+    return false;
+  }
+}

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -1310,8 +1310,8 @@ void main() {
       final THUMBNAIL_BUFF = Uint8List.fromList([2]);
       Future<Uint8List> downloadCallback(Uri uri) async {
         return {
-          '/_matrix/media/v3/download/example.org/file': FILE_BUFF,
-          '/_matrix/media/v3/download/example.org/thumb': THUMBNAIL_BUFF,
+          '/_matrix/client/v1/media/download/example.org/file': FILE_BUFF,
+          '/_matrix/client/v1/media/download/example.org/thumb': THUMBNAIL_BUFF,
         }[uri.path]!;
       }
 
@@ -1366,22 +1366,23 @@ void main() {
           'mxc://example.org/file');
       expect(event.attachmentOrThumbnailMxcUrl(getThumbnail: true).toString(),
           'mxc://example.org/thumb');
-      expect(event.getAttachmentUrl().toString(),
-          'https://fakeserver.notexisting/_matrix/media/v3/download/example.org/file');
-      expect(event.getAttachmentUrl(getThumbnail: true).toString(),
-          'https://fakeserver.notexisting/_matrix/media/v3/thumbnail/example.org/file?width=800&height=800&method=scale&animated=false');
-      expect(event.getAttachmentUrl(useThumbnailMxcUrl: true).toString(),
-          'https://fakeserver.notexisting/_matrix/media/v3/download/example.org/thumb');
+      expect((await event.getAttachmentUri()).toString(),
+          'https://fakeserver.notexisting/_matrix/client/v1/media/download/example.org/file');
+      expect((await event.getAttachmentUri(getThumbnail: true)).toString(),
+          'https://fakeserver.notexisting/_matrix/client/v1/media/thumbnail/example.org/file?width=800&height=800&method=scale&animated=false');
       expect(
-          event
-              .getAttachmentUrl(getThumbnail: true, useThumbnailMxcUrl: true)
-              .toString(),
-          'https://fakeserver.notexisting/_matrix/media/v3/thumbnail/example.org/thumb?width=800&height=800&method=scale&animated=false');
+          (await event.getAttachmentUri(useThumbnailMxcUrl: true)).toString(),
+          'https://fakeserver.notexisting/_matrix/client/v1/media/download/example.org/thumb');
       expect(
-          event
-              .getAttachmentUrl(getThumbnail: true, minNoThumbSize: 9000000)
+          (await event.getAttachmentUri(
+                  getThumbnail: true, useThumbnailMxcUrl: true))
               .toString(),
-          'https://fakeserver.notexisting/_matrix/media/v3/download/example.org/file');
+          'https://fakeserver.notexisting/_matrix/client/v1/media/thumbnail/example.org/thumb?width=800&height=800&method=scale&animated=false');
+      expect(
+          (await event.getAttachmentUri(
+                  getThumbnail: true, minNoThumbSize: 9000000))
+              .toString(),
+          'https://fakeserver.notexisting/_matrix/client/v1/media/download/example.org/file');
 
       buffer = await event.downloadAndDecryptAttachment(
           downloadCallback: downloadCallback);
@@ -1404,8 +1405,9 @@ void main() {
             Uint8List.fromList([0x74, 0x68, 0x75, 0x6D, 0x62, 0x0A]);
         Future<Uint8List> downloadCallback(Uri uri) async {
           return {
-            '/_matrix/media/v3/download/example.com/file': FILE_BUFF_ENC,
-            '/_matrix/media/v3/download/example.com/thumb': THUMB_BUFF_ENC,
+            '/_matrix/client/v1/media/download/example.com/file': FILE_BUFF_ENC,
+            '/_matrix/client/v1/media/download/example.com/thumb':
+                THUMB_BUFF_ENC,
           }[uri.path]!;
         }
 
@@ -1508,7 +1510,7 @@ void main() {
       Future<Uint8List> downloadCallback(Uri uri) async {
         serverHits++;
         return {
-          '/_matrix/media/v3/download/example.org/newfile': FILE_BUFF,
+          '/_matrix/client/v1/media/download/example.org/newfile': FILE_BUFF,
         }[uri.path]!;
       }
 
@@ -1550,7 +1552,7 @@ void main() {
       Future<Uint8List> downloadCallback(Uri uri) async {
         serverHits++;
         return {
-          '/_matrix/media/v3/download/example.org/newfile': FILE_BUFF,
+          '/_matrix/client/v1/media/download/example.org/newfile': FILE_BUFF,
         }[uri.path]!;
       }
 
@@ -1599,7 +1601,7 @@ void main() {
       Future<Uint8List> downloadCallback(Uri uri) async {
         serverHits++;
         return {
-          '/_matrix/media/v3/download/example.org/newfile': FILE_BUFF,
+          '/_matrix/client/v1/media/download/example.org/newfile': FILE_BUFF,
         }[uri.path]!;
       }
 

--- a/test/mxc_uri_extension_test.dart
+++ b/test/mxc_uri_extension_test.dart
@@ -32,19 +32,20 @@ void main() {
       final content = Uri.parse(mxc);
       expect(content.isScheme('mxc'), true);
 
-      expect(content.getDownloadLink(client).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/download/exampleserver.abc/abcdefghijklmn');
-      expect(content.getThumbnail(client, width: 50, height: 50).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
+      expect((await content.getDownloadUri(client)).toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/download/exampleserver.abc/abcdefghijklmn');
       expect(
-          content
-              .getThumbnail(client,
+          (await content.getThumbnailUri(client, width: 50, height: 50))
+              .toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
+      expect(
+          (await content.getThumbnailUri(client,
                   width: 50,
                   height: 50,
                   method: ThumbnailMethod.scale,
-                  animated: true)
+                  animated: true))
               .toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=scale&animated=true');
+          '${client.homeserver.toString()}/_matrix/client/v1/media/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=scale&animated=true');
     });
     test('other port', () async {
       final client = Client('testclient', httpClient: FakeMatrixApi());
@@ -55,19 +56,20 @@ void main() {
       final content = Uri.parse(mxc);
       expect(content.isScheme('mxc'), true);
 
-      expect(content.getDownloadLink(client).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/download/exampleserver.abc/abcdefghijklmn');
-      expect(content.getThumbnail(client, width: 50, height: 50).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
+      expect((await content.getDownloadUri(client)).toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/download/exampleserver.abc/abcdefghijklmn');
       expect(
-          content
-              .getThumbnail(client,
+          (await content.getThumbnailUri(client, width: 50, height: 50))
+              .toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
+      expect(
+          (await content.getThumbnailUri(client,
                   width: 50,
                   height: 50,
                   method: ThumbnailMethod.scale,
-                  animated: true)
+                  animated: true))
               .toString(),
-          'https://fakeserver.notexisting:1337/_matrix/media/v3/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=scale&animated=true');
+          'https://fakeserver.notexisting:1337/_matrix/client/v1/media/thumbnail/exampleserver.abc/abcdefghijklmn?width=50&height=50&method=scale&animated=true');
     });
     test('other remote port', () async {
       final client = Client('testclient', httpClient: FakeMatrixApi());
@@ -77,18 +79,39 @@ void main() {
       final content = Uri.parse(mxc);
       expect(content.isScheme('mxc'), true);
 
-      expect(content.getDownloadLink(client).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/download/exampleserver.abc:1234/abcdefghijklmn');
-      expect(content.getThumbnail(client, width: 50, height: 50).toString(),
-          '${client.homeserver.toString()}/_matrix/media/v3/thumbnail/exampleserver.abc:1234/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
+      expect((await content.getDownloadUri(client)).toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/download/exampleserver.abc:1234/abcdefghijklmn');
+      expect(
+          (await content.getThumbnailUri(client, width: 50, height: 50))
+              .toString(),
+          '${client.homeserver.toString()}/_matrix/client/v1/media/thumbnail/exampleserver.abc:1234/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
     });
-    test('Wrong scheme returns empty object', () async {
+    test('Wrong scheme throw exception', () async {
       final client = Client('testclient', httpClient: FakeMatrixApi());
       await client.checkHomeserver(Uri.parse('https://fakeserver.notexisting'),
           checkWellKnown: false);
       final mxc = Uri.parse('https://wrong-scheme.com');
-      expect(mxc.getDownloadLink(client).toString(), '');
-      expect(mxc.getThumbnail(client).toString(), '');
+      expect((await mxc.getDownloadUri(client)).toString(), '');
+      expect((await mxc.getThumbnailUri(client)).toString(), '');
+    });
+
+    test('auth media fallback', () async {
+      final client = Client('testclient', httpClient: FakeMatrixApi());
+      await client.checkHomeserver(
+          Uri.parse('https://fakeserverpriortoauthmedia.notexisting'),
+          checkWellKnown: false);
+
+      expect(await client.authenticatedMediaSupported(), false);
+      final mxc = 'mxc://exampleserver.abc:1234/abcdefghijklmn';
+      final content = Uri.parse(mxc);
+      expect(content.isScheme('mxc'), true);
+
+      expect((await content.getDownloadUri(client)).toString(),
+          '${client.homeserver.toString()}/_matrix/media/v3/download/exampleserver.abc:1234/abcdefghijklmn');
+      expect(
+          (await content.getThumbnailUri(client, width: 50, height: 50))
+              .toString(),
+          '${client.homeserver.toString()}/_matrix/media/v3/thumbnail/exampleserver.abc:1234/abcdefghijklmn?width=50&height=50&method=crop&animated=false');
     });
   });
 }


### PR DESCRIPTION
The ideal way to fix this would be autogen with the v1.11 spec. But because it changed from openapi v2 to v3 that looks like a bit more work than expected. Separating out auth media stuff from that because of urgency.

To test these changes please make sure your server properly registers the new media endpoints. Famedly servers do not atm because of worker misconfiguration. Tracking issue: https://github.com/famedly/infra-meta/issues/1688