### PR TITLE
fix: SQLCipher dylib location on macOS builds

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -60,10 +60,6 @@ jobs:
           architecture: "arm64"
       - name: Run tests
         run: |
-          # Prevent restarting the github actions service on package upgrades
-          # See https://discourse.ubuntu.com/t/needrestart-changes-in-ubuntu-24-04-service-restarts/44671
-          echo '$nrconf{override_rc}{qr(^actions.runner.*.service$)} = 0;' | sudo tee /etc/needrestart/conf.d/githubactions.conf
-
           sudo apt-get update && sudo apt-get install --no-install-recommends --no-install-suggests -y lcov libsqlite3-0 libsqlite3-dev libolm3 libssl3
           ./scripts/test.sh
       - uses: actions/upload-artifact@v4

--- a/lib/src/database/sqflite_encryption_helper/io.dart
+++ b/lib/src/database/sqflite_encryption_helper/io.dart
@@ -81,7 +81,9 @@ class SQfLiteEncryptionHelper {
     }
     if (Platform.isMacOS) {
       return DynamicLibrary.open(
-          '/usr/lib/libsqlcipher_flutter_libs_plugin.dylib');
+        'sqlcipher_flutter_libs.framework/Versions/Current/'
+        'sqlcipher_flutter_libs',
+      );
     }
     if (Platform.isWindows) {
       return DynamicLibrary.open('libsqlcipher.dll');


### PR DESCRIPTION
I guess no one ever noticed, but obviously the path of the SQLCipher build on macOS is relative to the build app on macOS. I double checked in both release and debug mode, this is the correct path for the SQLCipher dylib on macOS. The `Current` in the path defines it automatically chooses the matching one whether on aarch64 or amd64.