### PR TITLE
fix: race condition between getState and requestUser updates

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1694,10 +1694,9 @@ class Room {
     required bool requestProfile,
   }) async {
     // Is user already in cache?
-    final userFromState = getState(EventTypes.RoomMember, mxID)?.asUser(this);
 
     // If not in cache, try the database
-    var foundUser = userFromState;
+    User? foundUser = getState(EventTypes.RoomMember, mxID)?.asUser(this);
 
     // If the room is not postloaded, check the database
     if (partial && foundUser == null) {
@@ -1706,8 +1705,10 @@ class Room {
 
     // If not in the database, try fetching the member from the server
     if (requestState && foundUser == null) {
-      foundUser = await _requestSingleParticipantViaState(mxID,
-          ignoreErrors: ignoreErrors);
+      foundUser = await _requestSingleParticipantViaState(
+        mxID,
+        ignoreErrors: ignoreErrors,
+      );
     }
 
     // If the user isn't found or they have left and no displayname set anymore, request their profile from the server
@@ -1739,11 +1740,14 @@ class Room {
     }
 
     if (foundUser == null) return null;
+    // make sure we didn't actually store anything by the time we did those requests
+    final userFromCurrentState =
+        getState(EventTypes.RoomMember, mxID)?.asUser(this);
 
     // Set user in the local state if the state changed.
     // If we set the state unconditionally, we might end up with a client calling this over and over thinking the user changed.
-    if (userFromState == null ||
-        userFromState.displayName != foundUser.displayName) {
+    if (userFromCurrentState == null ||
+        userFromCurrentState.displayName != foundUser.displayName) {
       setState(foundUser);
       // ignore: deprecated_member_use_from_same_package
       onUpdate.add(id);


### PR DESCRIPTION
Fixes: https://github.com/famedly/product-management/issues/2319
 
tldr  notification > requestUser > requestState fails  > requestProfile > updates RoomMember stateKey with bad data (data with no longer is_direct or the membership)