### PR TITLE
feat: Store sending attachment in temporary file storage

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -378,6 +378,14 @@ class Event extends MatrixEvent {
 
     await room.client.database?.removeEvent(eventId, room.id);
 
+    // Delete possible send file requests:
+    await room.client.database?.deleteFile(
+      Uri.parse('com.famedly.sendingAttachment://file/$eventId'),
+    );
+    await room.client.database?.deleteFile(
+      Uri.parse('com.famedly.sendingAttachment://thumbnail/$eventId'),
+    );
+
     if (room.lastEvent != null && room.lastEvent!.eventId == eventId) {
       final redactedBecause = Event.fromMatrixEvent(
         MatrixEvent(
@@ -420,12 +428,29 @@ class Event extends MatrixEvent {
       MessageTypes.Audio,
       MessageTypes.File,
     }.contains(messageType)) {
-      final file = room.sendingFilePlaceholders[eventId];
+      final bytes = await room.client.database?.getFile(
+        Uri.parse('com.famedly.sendingAttachment://file/$eventId'),
+      );
+      final file = bytes == null
+          ? null
+          : MatrixFile(
+              bytes: bytes,
+              name: content.tryGet<String>('filename') ?? 'image',
+            );
       if (file == null) {
         await cancelSend();
         throw Exception('Can not try to send again. File is no longer cached.');
       }
-      final thumbnail = room.sendingFileThumbnails[eventId];
+      final thumbnailBytes = await room.client.database?.getFile(
+        Uri.parse('com.famedly.sendingAttachment://thumbnail/$txid'),
+      );
+      final thumbnail = thumbnailBytes == null
+          ? null
+          : MatrixImageFile(
+              bytes: thumbnailBytes,
+              name:
+                  'thumbnail_${content.tryGet<String>('filename') ?? 'image'}',
+            );
       final credentials = FileSendRequestCredentials.fromJson(unsigned ?? {});
       final inReplyTo = credentials.inReplyTo == null
           ? null
@@ -708,7 +733,15 @@ class Event extends MatrixEvent {
       throw ("This event has the type '$type' and so it can't contain an attachment.");
     }
     if (status.isSending) {
-      final localFile = room.sendingFilePlaceholders[eventId];
+      final bytes = await room.client.database?.getFile(
+        Uri.parse('com.famedly.sendingAttachment://file/$eventId'),
+      );
+      final localFile = bytes == null
+          ? null
+          : MatrixImageFile(
+              bytes: bytes,
+              name: content.tryGet<String>('filename') ?? 'image',
+            );
       if (localFile != null) return localFile;
     }
     final database = room.client.database;

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -689,9 +689,6 @@ class Room {
     return sendEvent(event, txid: txid);
   }
 
-  final Map<String, MatrixFile> sendingFilePlaceholders = {};
-  final Map<String, MatrixImageFile> sendingFileThumbnails = {};
-
   /// Sends a [file] to this room after uploading it. Returns the mxc uri of
   /// the uploaded file. If [waitUntilSent] is true, the future will wait until
   /// the message event has received the server. Otherwise the future will only
@@ -715,10 +712,6 @@ class Room {
     String? threadLastEventId,
   }) async {
     txid ??= client.generateUniqueTransactionId();
-    sendingFilePlaceholders[txid] = file;
-    if (thumbnail != null) {
-      sendingFileThumbnails[txid] = thumbnail;
-    }
 
     // Create a fake Event object as a placeholder for the uploading file:
     final syncUpdate = SyncUpdate(
@@ -755,6 +748,22 @@ class Room {
         },
       ),
     );
+    await _handleFakeSync(syncUpdate);
+
+    if (client.database?.supportsFileStoring == true) {
+      await client.database?.storeFile(
+        Uri.parse('com.famedly.sendingAttachment://file/$txid'),
+        file.bytes,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+      if (thumbnail != null) {
+        await client.database?.storeFile(
+          Uri.parse('com.famedly.sendingAttachment://thumbnail/$txid'),
+          file.bytes,
+          DateTime.now().millisecondsSinceEpoch,
+        );
+      }
+    }
 
     MatrixFile uploadFile = file; // ignore: omit_local_variable_types
     // computing the thumbnail in case we can
@@ -840,12 +849,22 @@ class Room {
         syncUpdate.rooms!.join!.values.first.timeline!.events!.first
             .unsigned![messageSendingStatusKey] = EventStatus.error.intValue;
         await _handleFakeSync(syncUpdate);
+
+        if (client.database?.supportsFileStoring != true) {
+          final sendEvent = await getEventById(txid);
+          await sendEvent?.cancelSend();
+        }
         rethrow;
       } catch (_) {
         if (DateTime.now().isAfter(timeoutDate)) {
           syncUpdate.rooms!.join!.values.first.timeline!.events!.first
               .unsigned![messageSendingStatusKey] = EventStatus.error.intValue;
           await _handleFakeSync(syncUpdate);
+
+          if (client.database?.supportsFileStoring != true) {
+            final sendEvent = await getEventById(txid);
+            await sendEvent?.cancelSend();
+          }
           rethrow;
         }
         Logs().v('Send File into room failed. Try again...');
@@ -909,8 +928,13 @@ class Room {
       threadRootEventId: threadRootEventId,
       threadLastEventId: threadLastEventId,
     );
-    sendingFilePlaceholders.remove(txid);
-    sendingFileThumbnails.remove(txid);
+    await client.database?.deleteFile(
+      Uri.parse('com.famedly.sendingAttachment://file/$txid'),
+    );
+    await client.database?.deleteFile(
+      Uri.parse('com.famedly.sendingAttachment://thumbnail/$txid'),
+    );
+
     return eventId;
   }
 


### PR DESCRIPTION
This could make retrying to send
files more easy as the file is
stored in the file storage.