### PR TITLE
fix: Change power level without changing memory

### DIFF
--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -787,6 +787,20 @@ void main() {
       await room.invite('Testname');
     });
 
+    test('setPower', () async {
+      final powerLevelMap =
+          room.getState(EventTypes.RoomPowerLevels, '')!.content.copy();
+
+      // Request to fake api does not update anything:
+      await room.setPower('@bob:fakeServer.notExisting', 100);
+
+      // Original power level map has not changed:
+      expect(
+        powerLevelMap,
+        room.getState(EventTypes.RoomPowerLevels, '')!.content.copy(),
+      );
+    });
+
     test('getParticipants', () async {
       var userList = room.getParticipants();
       expect(userList.length, 4);


### PR DESCRIPTION
The problem here is that we
have not created a deep copy
of the power level map. By using .copy() we create a
deep copy now.

Closes https://github.com/famedly/product-management/issues/2412