### PR TITLE
fix: always return a copy from room.getState

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -135,8 +135,18 @@ class Room {
   /// ```dart
   /// if (state is Event) { /*...*/ }
   /// ```
-  StrippedStateEvent? getState(String typeKey, [String stateKey = '']) =>
-      states[typeKey]?[stateKey];
+  StrippedStateEvent? getState(String typeKey, [String stateKey = '']) {
+    final ev = states[typeKey]?[stateKey];
+    if (ev != null) {
+      return StrippedStateEvent(
+        type: ev.type,
+        content: ev.content.copy(),
+        senderId: ev.senderId,
+        stateKey: ev.stateKey,
+      );
+    }
+    return null;
+  }
 
   /// Adds the [state] to this room and overwrites a state with the same
   /// typeKey/stateKey key pair if there is one.


### PR DESCRIPTION
avoid https://github.com/famedly/matrix-dart-sdk/pull/1929 in the future

could break stuff, needs more testing

I would like to have a cleaner unmodifiable map way but this was easier