### PR TITLE
Speedup tests

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -50,14 +50,15 @@ jobs:
           retention-days: 1
 
   coverage:
-    runs-on: arm-ubuntu-latest-16core
+    #runs-on: arm-ubuntu-latest-16core
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: cat .github/workflows/versions.env >> $GITHUB_ENV
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
         with:
           sdk: ${{ env.dart_version }}
-          architecture: "arm64"
+          #architecture: "arm64"
       - name: Run tests
         run: |
           sudo apt-get update && sudo apt-get install --no-install-recommends --no-install-suggests -y lcov libsqlite3-0 libsqlite3-dev libolm3 libssl3

--- a/.github/workflows/versions.env
+++ b/.github/workflows/versions.env
@@ -1,2 +1,2 @@
 flutter_version=3.22.2
-dart_version=3.4.3
+dart_version=3.5.3

--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -204,7 +204,13 @@ class FakeMatrixApi extends BaseClient {
           await Future.delayed(Duration(milliseconds: 50));
         }
         res = {
-          'next_batch': DateTime.now().millisecondsSinceEpoch.toString(),
+          // So that it is clear which sync we are processing prefix it with 'empty_'
+          'next_batch': 'empty_${DateTime.now().millisecondsSinceEpoch}',
+          // ensure we don't generate new keys for no reason
+          'device_one_time_keys_count': {
+            'curve25519': 10,
+            'signed_curve25519': 100
+          },
         };
       } else if (method == 'PUT' &&
           _client != null &&
@@ -1038,7 +1044,7 @@ class FakeMatrixApi extends BaseClient {
         '@bob:example.com',
       ],
     },
-    'device_one_time_keys_count': {'curve25519': 10, 'signed_curve25519': 20},
+    'device_one_time_keys_count': {'curve25519': 10, 'signed_curve25519': 100},
   };
 
   static Map<String, dynamic> archiveSyncResponse = {

--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -127,10 +127,6 @@ class FakeMatrixApi extends BaseClient {
 
     //print('\$method request to $action with Data: $data');
 
-    // Sync requests with timeout
-    if (data is Map<String, dynamic> && data['timeout'] is String) {
-      await Future.delayed(Duration(seconds: 5));
-    }
     if (!servers.contains(request.url.origin)) {
       return Response(
           '<html><head></head><body>Not found ${request.url.origin}...</body></html>',
@@ -202,6 +198,11 @@ class FakeMatrixApi extends BaseClient {
               '/client/v3/rooms/!1234%3AfakeServer.notExisting/state/')) {
         res = {'event_id': '\$event${_eventCounter++}'};
       } else if (action.contains('/client/v3/sync')) {
+        // Sync requests with timeout
+        final timeout = request.url.queryParameters['timeout'];
+        if (timeout != null && timeout != '0') {
+          await Future.delayed(Duration(milliseconds: 50));
+        }
         res = {
           'next_batch': DateTime.now().millisecondsSinceEpoch.toString(),
         };

--- a/test/calls_test.dart
+++ b/test/calls_test.dart
@@ -16,6 +16,7 @@ void main() {
     Logs().level = Level.info;
     setUp(() async {
       matrix = await getClient();
+      await matrix.abortSync();
 
       voip = VoIP(matrix, MockWebRTCDelegate());
       VoIP.customTxid = '1234';

--- a/test/device_keys_list_test.dart
+++ b/test/device_keys_list_test.dart
@@ -32,6 +32,7 @@ void main() {
 
     test('setupClient', () async {
       client = await getClient();
+      await client.abortSync();
     });
 
     test('fromJson', () async {

--- a/test/encryption/cross_signing_test.dart
+++ b/test/encryption/cross_signing_test.dart
@@ -34,6 +34,7 @@ void main() {
       await olm.init();
       olm.get_library_version();
       client = await getClient();
+      await client.abortSync();
     });
 
     test('basic things', () async {

--- a/test/encryption/key_request_test.dart
+++ b/test/encryption/key_request_test.dart
@@ -76,6 +76,8 @@ void main() {
     });
     test('Reply To Request', () async {
       final matrix = await getClient();
+      await matrix.abortSync();
+
       matrix.setUserId('@alice:example.com'); // we need to pretend to be alice
       FakeMatrixApi.calledEndpoints.clear();
       await matrix

--- a/test/encryption/key_verification_test.dart
+++ b/test/encryption/key_verification_test.dart
@@ -95,8 +95,13 @@ void main() async {
         KeyVerificationMethod.reciprocate
       };
 
+      // cancel sync to reduce background load and prevent sync overwriting which keys are tracked.
+      await client1.abortSync();
+      await client2.abortSync();
+
       // get client2 device keys to start verification
       await client1.updateUserDeviceKeys(additionalUsers: {client2.userID!});
+      await client2.updateUserDeviceKeys(additionalUsers: {client1.userID!});
     });
 
     tearDown(() async {

--- a/test/fake_client.dart
+++ b/test/fake_client.dart
@@ -53,6 +53,7 @@ Future<Client> getClient({
     newOlmAccount: pickledOlmAccount,
   );
   await Future.delayed(Duration(milliseconds: 10));
+  await client.abortSync();
   return client;
 }
 

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -55,6 +55,7 @@ void main() {
     Logs().level = Level.error;
     test('Login', () async {
       matrix = await getClient();
+      await matrix.abortSync();
     });
 
     test('Create from json', () async {

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -67,6 +67,7 @@ void main() {
       client = await getClient(
         sendTimelineEventTimeout: const Duration(seconds: 5),
       );
+      await client.abortSync();
 
       final poison = Random().nextInt(2 ^ 32);
       currentPoison = poison;

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -48,6 +48,7 @@ void main() {
       await client.login(LoginType.mLoginPassword,
           identifier: AuthenticationUserIdentifier(user: 'test'),
           password: '1234');
+      await client.abortSync();
     });
     tearDown(() async {
       await client.logout();


### PR DESCRIPTION
This does various fixes throughout our tests to speed them up as well as prevents us from doing redundant work on sync.

1. Removes a 5 second sleep from the initial sync. There is no need for that and if we want to test something with such a delay, we should do that explicitly instead of in every test.
2. Deduplicates OTK uploads. This means we don't redundantly create OTKs when our upload key request is slower than the next sync. This might cause delays in OTK uploads until the next sync after an upload succeeds, but might also fix a few edge cases, where we may have overwritten our own OTKs multiple times and caused UTDs.
3. Removes a few key uploads in the common tests. We used to only ever return 20 stored OTKs (or null) in sync, which caused us to generate new keys and waste CPU cycles. This only affects our tests.
4. The last commit fixes a few tests that failed now regularly, because the next sync isn't delayed by 5s. I mostly replaced those cases with explicitly cancelling the background sync loop, which is pretty much equivalent to delaying the next sync for 5s in the common case of tests taking less than 5s. There are probably a few more race conditions still hiding, so possibly the tests will be a bit unstable for a while, but those tend to be rather easy to fix and should make the tests more stable in general in the long term.

All in all this makes the tests complete in 45s where before it took around 5 minutes on my machine.