### PR TITLE
feat: improve commands_extension

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -98,7 +98,7 @@ class Client extends MatrixApi {
   DateTime? _accessTokenExpiresAt;
 
   // For CommandsClientExtension
-  final Map<String, FutureOr<String?> Function(CommandArgs)> commands = {};
+  final Map<String, CommandExecutionCallback> commands = {};
   final Filter syncFilter;
 
   final NativeImplementations nativeImplementations;

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -625,6 +625,7 @@ class Room {
     String msgtype = MessageTypes.Text,
     String? threadRootEventId,
     String? threadLastEventId,
+    StringBuffer? commandStdout,
   }) {
     if (parseCommands) {
       return client.parseAndRunCommand(
@@ -635,6 +636,7 @@ class Room {
         txid: txid,
         threadRootEventId: threadRootEventId,
         threadLastEventId: threadLastEventId,
+        stdout: commandStdout,
       );
     }
     final event = <String, dynamic>{

--- a/test/commands_test.dart
+++ b/test/commands_test.dart
@@ -395,7 +395,7 @@ void main() {
       await room.sendTextEvent('/dm @alice:example.com --no-encryption');
       expect(
           json.decode(
-            FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.first,
+            FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.last,
           ),
           {
             'invite': ['@alice:example.com'],
@@ -406,12 +406,15 @@ void main() {
 
     test('create', () async {
       FakeMatrixApi.calledEndpoints.clear();
-      await room.sendTextEvent('/create @alice:example.com --no-encryption');
+      await room.sendTextEvent('/create New room --no-encryption');
       expect(
         json.decode(
-          FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.first,
+          FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.last,
         ),
-        {'preset': 'private_chat'},
+        {
+          'name': 'New room',
+          'preset': 'private_chat',
+        },
       );
     });
 
@@ -525,6 +528,22 @@ void main() {
       await room.sendTextEvent('/cuddle');
       final sent = getLastMessagePayload();
       expect(sent, CuteEventContent.cuddle);
+    });
+
+    test('client - clearcache', () async {
+      await client.parseAndRunCommand(null, '/clearcache');
+      expect(client.prevBatch, null);
+    });
+
+    test('client - missing room - discardsession', () async {
+      Object? error;
+      try {
+        await client.parseAndRunCommand(null, '/discardsession');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error is RoomCommandException, isTrue);
     });
 
     test('dispose client', () async {


### PR DESCRIPTION
While implementing some custom commands, I stumbled across some issues with the current command runner :

1. Currently, even Client-level commands such as `/join`, `/dm` etc. require to be entered with a `Room` present as parameter
2. Currently, commands have no way to provide output, such as a success message, some reference to e.g. a newly created room or any other information since the return parameter is currently usually an eventId used by the clients to confirm sending a message was successful.
3. Currently, \[matrix\] clients have no way to catch exceptions specific to the command execution, such as a missing or invalid parameter etc.

I have the following proposals to address these issues in the SDK's command execution :

- unify behavior of all message sending related command
- add a `StringBuffer` as stdout-like output buffer for commands
- create a `typedef` for the command function signature
- create a common exception type for command execution
- enable commands to run on Client-level rather than Room-level
- BREAKING: `Client.addCommand` signature now takes an optional `StringBuffer` as second parameter
