### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/lib/encryption.dart
+++ b/lib/encryption.dart
@@ -17,7 +17,7 @@
  */
 
 /// Matrix SDK encryption specific extension
-library encryption;
+library;
 
 export 'encryption/encryption.dart';
 export 'encryption/key_manager.dart';

--- a/lib/matrix.dart
+++ b/lib/matrix.dart
@@ -17,7 +17,7 @@
  */
 
 /// Matrix SDK written in pure Dart.
-library matrix;
+library;
 
 export 'matrix_api_lite.dart';
 

--- a/lib/matrix_api_lite.dart
+++ b/lib/matrix_api_lite.dart
@@ -21,7 +21,8 @@
 * SOFTWARE.
 */
 
-library matrix_api_lite;
+/// Lightweight wrapper around the raw matrix API.
+library;
 
 export 'matrix_api_lite/generated/model.dart';
 export 'matrix_api_lite/matrix_api.dart';

--- a/lib/msc_extensions/extension_recent_emoji/recent_emoji.dart
+++ b/lib/msc_extensions/extension_recent_emoji/recent_emoji.dart
@@ -1,4 +1,5 @@
-library extension_recent_emoji;
+/// Extension to synchronize the recently used widgets with Element clients
+library;
 
 import 'package:matrix/matrix.dart';
 

--- a/lib/msc_extensions/msc_1236_widgets/msc_1236_widgets.dart
+++ b/lib/msc_extensions/msc_1236_widgets/msc_1236_widgets.dart
@@ -1,4 +1,5 @@
-library msc_1236_widgets;
+/// Extensions related to widgets in a room. Widgets are not part of the Matrix specification yet.
+library;
 
 import 'package:matrix/matrix.dart';
 

--- a/lib/msc_extensions/msc_2835_uia_login/msc_2835_uia_login.dart
+++ b/lib/msc_extensions/msc_2835_uia_login/msc_2835_uia_login.dart
@@ -1,4 +1,5 @@
-library msc_2835_uia_login;
+/// Experimental login method using User Interactive Authentication
+library;
 
 import 'dart:convert';
 

--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -1,4 +1,6 @@
-library msc_3814_dehydrated_devices;
+/// Extensions for the experimental dehydrated devices MSC, which allows
+/// receiving encrypted messages while you have no devices signed in.
+library;
 
 import 'dart:convert';
 import 'dart:math';

--- a/lib/src/utils/crypto/subtle.dart
+++ b/lib/src/utils/crypto/subtle.dart
@@ -1,9 +1,6 @@
 // Copyright (c) 2020 Famedly GmbH
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-@JS()
-library subtle;
-
 import 'dart:async';
 import 'dart:js_util';
 import 'dart:typed_data';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   image: ^4.0.15
   js: ^0.6.3
   markdown: ^7.1.1
-  mime: ^1.0.0
+  mime: ">=1.0.0 <3.0.0"
   olm: ^2.0.2
   random_string: ^2.3.1
   sdp_transform: ^0.3.2
@@ -40,7 +40,7 @@ dev_dependencies:
   enhanced_enum_generator: ^0.2.4
   file: ">=6.1.1 <8.0.0"
   import_sorter: ^4.6.0
-  lints: ^4.0.0
+  lints: ^5.0.0
   path: ^1.9.0
-  sqflite_common_ffi: 2.3.2+1 # v2.3.3 doesn't support dart v3.2.x
+  sqflite_common_ffi: ^2.3.2+1 # sqflite_common_ffi aggressively requires newer dart versions
   test: ^1.15.7


### PR DESCRIPTION
The library annotations are a new lint and we have no need to specify a custom library name anywhere. The JS annoation on the library also did nothing, since it doesn't default to the library name in dart and only modifies the prefix of functions if you pass in a custom name.

The sqflite_common_ffi I removed the upper constraint, which allows us to use a newer version if our dart version is new enough, but I left it at the original version because there is no need to require a higher minimum currently.