### PR TITLE
fix: AsyncCache is not invalidating on error

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -43,6 +43,7 @@ import 'package:matrix/src/utils/run_in_root.dart';
 import 'package:matrix/src/utils/sync_update_item_count.dart';
 import 'package:matrix/src/utils/try_get_push_rule.dart';
 import 'package:matrix/src/utils/versions_comparator.dart';
+import 'package:matrix/src/voip/utils/async_cache_try_fetch.dart';
 
 typedef RoomSorter = int Function(Room a, Room b);
 
@@ -1212,7 +1213,7 @@ class Client extends MatrixApi {
       AsyncCache<GetVersionsResponse>(const Duration(hours: 1));
 
   Future<bool> authenticatedMediaSupported() async {
-    final versionsResponse = await _versionsCache.fetch(() => getVersions());
+    final versionsResponse = await _versionsCache.tryFetch(() => getVersions());
     return versionsResponse.versions.any(
           (v) => isVersionGreaterThanOrEqualTo(v, 'v1.11'),
         ) ||
@@ -1232,8 +1233,8 @@ class Client extends MatrixApi {
   /// repository APIs, for example, proxies may enforce a lower upload size limit
   /// than is advertised by the server on this endpoint.
   @override
-  Future<MediaConfig> getConfig() =>
-      _serverConfigCache.fetch(() async => (await authenticatedMediaSupported())
+  Future<MediaConfig> getConfig() => _serverConfigCache
+      .tryFetch(() async => (await authenticatedMediaSupported())
           ? getConfigAuthed()
           // ignore: deprecated_member_use_from_same_package
           : super.getConfig());

--- a/lib/src/voip/utils/async_cache_try_fetch.dart
+++ b/lib/src/voip/utils/async_cache_try_fetch.dart
@@ -1,0 +1,32 @@
+/*
+ *   Famedly Matrix SDK
+ *   Copyright (C) 2019, 2020, 2021 Famedly GmbH
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:async/async.dart';
+
+extension AsyncCacheTryFetch<T> on AsyncCache<T> {
+  /// Makes sure that in case of an error the error is not stored forever and
+  /// blocking the cache but invalidates it.
+  Future<T> tryFetch(Future<T> Function() callback) async {
+    try {
+      return await fetch(callback);
+    } catch (_) {
+      invalidate();
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
This fixes for example that if a
fetch from an asynccache once
failed it never gets retried. So we
only want to cache results, not
exceptions/errors