### PR TITLE
fix: BREAKING! missed initial updates for stream listener callbacks in P2P & mesh calls

### DIFF
--- a/lib/src/voip/README.md
+++ b/lib/src/voip/README.md
@@ -119,14 +119,25 @@ class MyVoipApp implements WebRTCDelegate {
   VideoRenderer createRenderer() => RTCVideoRenderer();
 
   @override
-  void playRingtone(){
+  Future<void> playRingtone() async {
       // play ringtone
   }
-  void stopRingtone() {
+  Future<void> stopRingtone() async {
       // stop ringtone
   }
 
-  void handleNewCall(CallSession session) {
+  Future<void> registerListeners(CallSession session) async {
+    // register all listeners here
+    session.onCallStreamsChanged.stream.listen((CallStateChange event) async {});
+    session.onCallReplaced.stream.listen((CallStateChange event) async {});
+    session.onCallHangupNotifierForGroupCalls.stream.listen((CallStateChange event) async {});
+    session.onCallStateChanged.stream.listen((CallStateChange event) async {});
+    session.onCallEventChanged.stream.listen((CallStateChange event) async {});
+    session.onStreamAdd.stream.listen((CallStateChange event) async {});
+    session.onStreamRemoved.stream.listen((CallStateChange event) async {});
+  }
+
+  Future<void> handleNewCall(CallSession session) async {
     // handle new call incoming or outgoing
     switch(session.direction) {
         case CallDirection.kIncoming:
@@ -138,7 +149,7 @@ class MyVoipApp implements WebRTCDelegate {
     }
   }
 
-  void handleCallEnded(CallSession session) {
+  Future<void> handleCallEnded(CallSession session) async {
     // handle call ended by local or remote
   }
 }
@@ -170,7 +181,7 @@ newCall.onCallStateChanged.stream.listen((state) {
 /// Then you can pop up the incoming call window at MyVoipApp.handleNewCall.
 class MyVoipApp implements WebRTCDelegate {
 ...
-  void handleNewCall(CallSession session) {
+  Future<void> handleNewCall(CallSession session) async {
       switch(session.direction) {
           case CallDirection.kOutgoing:
               // show outgoing call window
@@ -185,13 +196,13 @@ newCall.hangup();
 
 ### 4.Answer a incoming call
 
-When a new incoming call comes in, handleNewCall will be called, and the answering interface can pop up at this time, and use `onCallStateChanged` to listen to the call state.
+When a new incoming call comes in, registerListeners will be called right before handleNewCall is called, and the answering interface can pop up at this time, and use `onCallStateChanged` to listen to the call state.
 
 The incoming call window need display `answer` and `reject` buttons, by calling `newCall.answer();` or `newCall.reject();` to decide whether to connect the call.
 
 ```dart
 ...
-  void handleNewCall(CallSession newCall) {
+  Future<void> registerListeners(CallSession newCall) async {
       switch(newCall.direction) {
           case CallDirection.kIncoming:
               /// show incoming call window

--- a/lib/src/voip/models/webrtc_delegate.dart
+++ b/lib/src/voip/models/webrtc_delegate.dart
@@ -11,6 +11,7 @@ abstract class WebRTCDelegate {
   ]);
   Future<void> playRingtone();
   Future<void> stopRingtone();
+  Future<void> registerListeners(CallSession session);
   Future<void> handleNewCall(CallSession session);
   Future<void> handleCallEnded(CallSession session);
   Future<void> handleMissedCall(CallSession session);

--- a/test/webrtc_stub.dart
+++ b/test/webrtc_stub.dart
@@ -16,6 +16,11 @@ class MockWebRTCDelegate implements WebRTCDelegate {
       MockRTCPeerConnection();
 
   @override
+  Future<void> registerListeners(CallSession session) async {
+    Logs().i('registerListeners called in MockWebRTCDelegate');
+  }
+
+  @override
   Future<void> handleCallEnded(CallSession session) async {
     Logs().i('handleCallEnded called in MockWebRTCDelegate');
   }


### PR DESCRIPTION
I noticed that the SDK misses sending initial stream updates (in `onStreamAdd` and `onStreamRemove`) for both P2P and mesh calls in some cases. The easiest to reproduce would be an incoming P2P call where the `onStreamAdd` and `onStreamRemove` listeners are registered in `handleNewCall` VoIP method.

### Steps to reproduce
1. Start the flutter app in VS Code
2. Set a breakpoint within an if condition that check for the stream to not be local, inside the `onStreamAdd` callback
3. Start an outgoing call
4. Once the call is connected and the other person's media is shared, the debugger would stop at the breakpoint. This means that the `onStreamAdd` callback is working as expected.
5. Now, start the call from another device so that this device has an incoming call
6. Answer the call
7. Even after the call is connected, the debugger would NOT stop at the breakpoint. 

This is because, the remote stream is actually added even before the callback is registered inside the `handleNewCall` method.

Now, let's see where the remote stream is added in `CallSession`, in reverse order of invocation -

->  `_addRemoteStream()`
->  `_createPeerConnection()`
-> `_preparePeerConnection()`
-> `placeCallWithStreams()`          OR          -> `initWithInvite()`       OR              -> `initOutboundCall()`


And the top level method `initWithInvite()` is called in an incoming call before `delegate.handleNewCall` is called. The same for `initOutboundCall()` with outgoing call.

I thought of fixing this by adding a new intermediate WebRTCDelegate method where you can register callbacks before these methods are invoked. And that's what `registerListeners` will be used for.

For mesh calls, the same applies because it internally uses the same `CallSession`. So, I separated out the `onStreamAdd` and `onStreamRemove` callback registration and called it before the `placeCallWithStreams` method (in case a new member joins the call). For the case where you join a call, `onIncomingCallStart` stream controller in VoIP is used similar to the `handleNewCall`, so I created a new `onIncomingCallSetup` stream controller that's fired instead of the `registerListeners`. Then, use the `onIncomingCallSetup` callback to do the stream related callback registration.
