### PR TITLE
Throw error on failed reaction send

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1128,7 +1128,10 @@ class Room {
           await _handleFakeSync(syncUpdate);
           completer.complete();
           _sendingQueue.remove(completer);
-          if (e is EventTooLarge) rethrow;
+          if (e is EventTooLarge ||
+              (e is MatrixException && e.error == MatrixError.M_FORBIDDEN)) {
+            rethrow;
+          }
           return null;
         } else {
           Logs()


### PR DESCRIPTION
Part of https://github.com/famedly/product-management/issues/2656. This will throw the error if we failed to send the reaction. 