### PR TITLE
don't reset wellknown cache on Client initialization

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -137,7 +137,7 @@ class Client extends MatrixApi {
   /// [wellKnown] cache will be invalidated.
   @override
   set homeserver(Uri? homeserver) {
-    if (homeserver?.host != this.homeserver?.host) {
+    if (this.homeserver != null && homeserver?.host != this.homeserver?.host) {
       _wellKnown = null;
       unawaited(database?.storeWellKnown(null));
     }


### PR DESCRIPTION
Without this null check the cache for the well-known data gets deleted everytime the Client gets initialized, making it useless across app restarts.