### PR TITLE
Change dynamic to Object in operator of User

### DIFF
--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -185,7 +185,7 @@ class User extends Event {
       room.canChangePowerLevel && powerLevel < room.ownPowerLevel;
 
   @override
-  bool operator ==(dynamic other) => (other is User &&
+  bool operator ==(Object other) => (other is User &&
       other.id == id &&
       other.room == room &&
       other.membership == membership);


### PR DESCRIPTION
## Reason 
   To be able to mock the User class we need to change the type of `other` in operator == from dynamic to Object