### PR TITLE
refactor: Use Event instead of EventUpdate for pending decryption event queue and for decrypt events in general

### DIFF
--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -314,12 +314,12 @@ class Encryption {
     bool store = false,
     EventUpdateType updateType = EventUpdateType.timeline,
   }) async {
-    if (event.type != EventTypes.Encrypted || event.redacted) {
-      return event;
-    }
-    final content = event.parsedRoomEncryptedContent;
-    final sessionId = content.sessionId;
     try {
+      if (event.type != EventTypes.Encrypted || event.redacted) {
+        return event;
+      }
+      final content = event.parsedRoomEncryptedContent;
+      final sessionId = content.sessionId;
       if (client.database != null &&
           sessionId != null &&
           !(keyManager

--- a/lib/src/utils/event_update.dart
+++ b/lib/src/utils/event_update.dart
@@ -16,8 +16,6 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import 'package:matrix/matrix.dart';
-
 enum EventUpdateType {
   /// Newly received events from /sync
   timeline,
@@ -58,28 +56,4 @@ class EventUpdate {
     required this.type,
     required this.content,
   });
-
-  Future<EventUpdate> decrypt(Room room, {bool store = false}) async {
-    final encryption = room.client.encryption;
-    if (content['type'] != EventTypes.Encrypted ||
-        !room.client.encryptionEnabled ||
-        encryption == null) {
-      return this;
-    }
-    try {
-      final decrpytedEvent = await encryption.decryptRoomEvent(
-        Event.fromJson(content, room),
-        store: store,
-        updateType: type,
-      );
-      return EventUpdate(
-        roomID: roomID,
-        type: type,
-        content: decrpytedEvent.toJson(),
-      );
-    } catch (e, s) {
-      Logs().e('[LibOlm] Could not decrypt megolm event', e, s);
-      return this;
-    }
-  }
 }


### PR DESCRIPTION
This should removes an
unnecessary step of
json serialization and deserialization and should
therefore improve performance.
Gets rid of some unnecessary
code as well.

Related to https://github.com/famedly/product-management/issues/1875