### PR TITLE
refactor: Do not handle ephemerals as EventUpdates

### DIFF
--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -155,8 +155,7 @@ class Encryption {
   }
 
   Future<void> handleEventUpdate(EventUpdate update) async {
-    if (update.type == EventUpdateType.ephemeral ||
-        update.type == EventUpdateType.history) {
+    if (update.type == EventUpdateType.history) {
       return;
     }
     if (update.content['type'].startsWith('m.key.verification.') ||

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2703,7 +2703,7 @@ class Client extends MatrixApi {
     final List<ReceiptEventContent> receipts = [];
 
     for (final event in events) {
-      await _handleRoomEvents(room, [event], EventUpdateType.ephemeral);
+      room.setEphemeral(event);
 
       // Receipt events are deltas between two states. We will create a
       // fake room account data event for this and store the difference
@@ -2808,7 +2808,7 @@ class Client extends MatrixApi {
         }
       }
       _updateRoomsByEventUpdate(room, update);
-      if (type != EventUpdateType.ephemeral && store) {
+      if (store) {
         await database?.storeEventUpdate(update, this);
       }
       if (encryptionEnabled) {
@@ -2981,9 +2981,6 @@ class Client extends MatrixApi {
       case EventUpdateType.accountData:
         room.roomAccountData[eventUpdate.content['type']] =
             BasicRoomEvent.fromJson(eventUpdate.content);
-        break;
-      case EventUpdateType.ephemeral:
-        room.setEphemeral(BasicRoomEvent.fromJson(eventUpdate.content));
         break;
       case EventUpdateType.history:
       case EventUpdateType.decryptedTimelineQueue:

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1080,9 +1080,6 @@ class HiveCollectionsDatabase extends DatabaseApi {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
-
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
 

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1042,9 +1042,6 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
-
     // In case of this is a redaction event
     if (eventUpdate.content['type'] == EventTypes.Redaction) {
       final tmpRoom = client.getRoomById(eventUpdate.roomID) ??

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1043,8 +1043,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
-    // Ephemerals should not be stored
-    if (eventUpdate.type == EventUpdateType.ephemeral) return;
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
 

--- a/lib/src/utils/event_update.dart
+++ b/lib/src/utils/event_update.dart
@@ -29,9 +29,6 @@ enum EventUpdateType {
   /// Updates to account data
   accountData,
 
-  /// Ephemeral events like receipts
-  ephemeral,
-
   /// The state of an invite
   inviteState,
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -282,7 +282,7 @@ void main() {
 
       final eventUpdateList = await eventUpdateListFuture;
 
-      expect(eventUpdateList.length, 20);
+      expect(eventUpdateList.length, 18);
 
       expect(eventUpdateList[0].content['type'], 'm.room.member');
       expect(eventUpdateList[0].roomID, '!726s6s6q:example.com');
@@ -308,36 +308,52 @@ void main() {
       expect(eventUpdateList[5].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[5].type, EventUpdateType.timeline);
 
-      expect(eventUpdateList[6].content['type'], 'm.typing');
+      expect(eventUpdateList[6].content['type'], LatestReceiptState.eventType);
       expect(eventUpdateList[6].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[6].type, EventUpdateType.ephemeral);
+      expect(eventUpdateList[6].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[7].content['type'], 'm.receipt');
+      expect(eventUpdateList[7].content['type'], 'm.tag');
       expect(eventUpdateList[7].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[7].type, EventUpdateType.ephemeral);
+      expect(eventUpdateList[7].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[8].content['type'], LatestReceiptState.eventType);
+      expect(
+        eventUpdateList[8].content['type'],
+        'org.example.custom.room.config',
+      );
       expect(eventUpdateList[8].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[8].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[9].content['type'], 'm.tag');
-      expect(eventUpdateList[9].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[9].type, EventUpdateType.accountData);
+      expect(eventUpdateList[9].content['type'], 'm.room.member');
+      expect(eventUpdateList[9].roomID, '!calls:example.com');
+      expect(eventUpdateList[9].type, EventUpdateType.state);
+
+      expect(eventUpdateList[10].content['type'], 'm.room.member');
+      expect(eventUpdateList[10].roomID, '!calls:example.com');
+      expect(eventUpdateList[10].type, EventUpdateType.state);
 
       expect(
-        eventUpdateList[10].content['type'],
-        'org.example.custom.room.config',
+        matrix
+            .getRoomById('!726s6s6q:example.com')
+            ?.ephemerals['m.typing']
+            ?.content,
+        {
+          'user_ids': ['@alice:example.com'],
+        },
       );
-      expect(eventUpdateList[10].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[10].type, EventUpdateType.accountData);
 
-      expect(eventUpdateList[11].content['type'], 'm.room.member');
-      expect(eventUpdateList[11].roomID, '!calls:example.com');
-      expect(eventUpdateList[11].type, EventUpdateType.state);
-
-      expect(eventUpdateList[12].content['type'], 'm.room.member');
-      expect(eventUpdateList[12].roomID, '!calls:example.com');
-      expect(eventUpdateList[12].type, EventUpdateType.state);
+      expect(
+        matrix
+            .getRoomById('!726s6s6q:example.com')
+            ?.ephemerals['m.receipt']
+            ?.content,
+        {
+          '\$7365636s6r6432:example.com': {
+            'm.read': {
+              '@alice:example.com': {'ts': 1436451550453},
+            },
+          },
+        },
+      );
 
       await matrix.onToDeviceEvent.close();
 


### PR DESCRIPTION
This handles room ephemerals
directly and not as room
event updates, which saves
one unnecessary step to json serialize and
deserialize. Handling those
as room event updates had
no benefit anyway so this
should speed up performance.