### PR TITLE
refactor: Do not unnecessarily serialize and deserialize json for every account data object

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2474,10 +2474,10 @@ class Client extends MatrixApi {
       onPresenceChanged.add(cachedPresence);
       await database?.storePresence(newPresence.senderId, cachedPresence);
     }
-    for (final newAccountData in sync.accountData ?? []) {
+    for (final newAccountData in sync.accountData ?? <BasicEvent>[]) {
       await database?.storeAccountData(
         newAccountData.type,
-        jsonEncode(newAccountData.content),
+        newAccountData.content,
       );
       accountData[newAccountData.type] = newAccountData;
       // ignore: deprecated_member_use_from_same_package

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -127,7 +127,7 @@ abstract class DatabaseApi {
     String syncFilterId,
   );
 
-  Future storeAccountData(String type, String content);
+  Future storeAccountData(String type, Map<String, Object?> content);
 
   Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client);
 

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1073,8 +1073,11 @@ class HiveCollectionsDatabase extends DatabaseApi {
   }
 
   @override
-  Future<void> storeAccountData(String type, String content) async {
-    await _accountDataBox.put(type, copyMap(jsonDecode(content)));
+  Future<void> storeAccountData(
+    String type,
+    Map<String, Object?> content,
+  ) async {
+    await _accountDataBox.put(type, copyMap(content));
     return;
   }
 

--- a/lib/src/database/hive_database.dart
+++ b/lib/src/database/hive_database.dart
@@ -1032,10 +1032,13 @@ class FamedlySdkHiveDatabase extends DatabaseApi with ZoneTransactionMixin {
   }
 
   @override
-  Future<void> storeAccountData(String type, String content) async {
+  Future<void> storeAccountData(
+    String type,
+    Map<String, Object?> content,
+  ) async {
     await _accountDataBox.put(
       type.toHiveKey,
-      convertToJson(jsonDecode(content)),
+      convertToJson(content),
     );
     return;
   }

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1036,8 +1036,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> storeAccountData(String type, String content) async {
-    await _accountDataBox.put(type, jsonDecode(content));
+  Future<void> storeAccountData(
+    String type,
+    Map<String, Object?> content,
+  ) async {
+    await _accountDataBox.put(type, content);
     return;
   }
 

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -192,11 +192,11 @@ void main() {
         await database.getAccountData();
       });
       test('storeAccountData', () async {
-        await database.storeAccountData('m.test', '{"foo":"bar"}');
+        await database.storeAccountData('m.test', {'foo': 'bar'});
         final events = await database.getAccountData();
         expect(events.values.single.type, 'm.test');
 
-        await database.storeAccountData('m.abc+de', '{"foo":"bar"}');
+        await database.storeAccountData('m.abc+de', {'foo': 'bar'});
         final events2 = await database.getAccountData();
         expect(
           events2.values.any((element) => element.type == 'm.abc+de'),
@@ -208,7 +208,7 @@ void main() {
 
         await database.storeAccountData(
           'm.huge_data_test',
-          jsonEncode(hugeDataObject),
+          hugeDataObject,
         );
 
         final events = await database.getAccountData();
@@ -694,7 +694,7 @@ void main() {
         final database = await getMatrixSdkDatabase(null);
         await database.storeAccountData(
           'm.test.data',
-          jsonEncode({'foo': 'bar'}),
+          {'foo': 'bar'},
         );
         await database.delete();
 


### PR DESCRIPTION
This changes the database
api a little bit so that it does
not unnecessarily serialize
and deserialize all
account data objects. Should
improve the performance of
the SDK.

Please note that in the hive
database(s) we create a
copy of the json map before
storing it. That is not necessary
for the matrix sdk database
as there the json map gets
serialized to a String anyway
inside.