### PR TITLE
refactor: Handle Room Account Data outside of Room Event Updates

### DIFF
--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -129,6 +129,8 @@ abstract class DatabaseApi {
 
   Future storeAccountData(String type, Map<String, Object?> content);
 
+  Future storeRoomAccountData(BasicRoomEvent event);
+
   Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client);
 
   Future<SSSSCache?> getSSSSCache(String type);

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1096,6 +1096,15 @@ class HiveCollectionsDatabase extends DatabaseApi {
   }
 
   @override
+  Future<void> storeRoomAccountData(BasicRoomEvent event) async {
+    await _roomAccountDataBox.put(
+      TupleKey(event.roomId ?? '', event.type).toString(),
+      copyMap(event.toJson()),
+    );
+    return;
+  }
+
+  @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
@@ -1243,17 +1252,6 @@ class HiveCollectionsDatabase extends DatabaseApi {
         stateMap[stateKey] = eventUpdate.content;
         await _roomStateBox.put(key, stateMap);
       }
-    }
-
-    // Store a room account data event
-    if (eventUpdate.type == EventUpdateType.accountData) {
-      await _roomAccountDataBox.put(
-        TupleKey(
-          eventUpdate.roomID,
-          eventUpdate.content['type'],
-        ).toString(),
-        eventUpdate.content,
-      );
     }
   }
 

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1059,6 +1059,15 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
+  Future<void> storeRoomAccountData(BasicRoomEvent event) async {
+    await _roomAccountDataBox.put(
+      TupleKey(event.roomId ?? '', event.type).toString(),
+      event.toJson(),
+    );
+    return;
+  }
+
+  @override
   Future<void> storeEventUpdate(EventUpdate eventUpdate, Client client) async {
     final tmpRoom = client.getRoomById(eventUpdate.roomID) ??
         Room(id: eventUpdate.roomID, client: client);
@@ -1213,17 +1222,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
         await roomStateBox.put(key, eventUpdate.content);
       }
-    }
-
-    // Store a room account data event
-    if (eventUpdate.type == EventUpdateType.accountData) {
-      await _roomAccountDataBox.put(
-        TupleKey(
-          eventUpdate.roomID,
-          eventUpdate.content['type'],
-        ).toString(),
-        eventUpdate.content,
-      );
     }
   }
 

--- a/lib/src/utils/event_update.dart
+++ b/lib/src/utils/event_update.dart
@@ -26,9 +26,6 @@ enum EventUpdateType {
   /// Messages that have been fetched when requesting past history
   history,
 
-  /// Updates to account data
-  accountData,
-
   /// The state of an invite
   inviteState,
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -282,7 +282,7 @@ void main() {
 
       final eventUpdateList = await eventUpdateListFuture;
 
-      expect(eventUpdateList.length, 18);
+      expect(eventUpdateList.length, 13);
 
       expect(eventUpdateList[0].content['type'], 'm.room.member');
       expect(eventUpdateList[0].roomID, '!726s6s6q:example.com');
@@ -308,28 +308,35 @@ void main() {
       expect(eventUpdateList[5].roomID, '!726s6s6q:example.com');
       expect(eventUpdateList[5].type, EventUpdateType.timeline);
 
-      expect(eventUpdateList[6].content['type'], LatestReceiptState.eventType);
-      expect(eventUpdateList[6].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[6].type, EventUpdateType.accountData);
+      expect(eventUpdateList[6].content['type'], 'm.room.member');
+      expect(eventUpdateList[6].roomID, '!calls:example.com');
+      expect(eventUpdateList[6].type, EventUpdateType.state);
 
-      expect(eventUpdateList[7].content['type'], 'm.tag');
-      expect(eventUpdateList[7].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[7].type, EventUpdateType.accountData);
+      expect(eventUpdateList[7].content['type'], 'm.room.member');
+      expect(eventUpdateList[7].roomID, '!calls:example.com');
+      expect(eventUpdateList[7].type, EventUpdateType.state);
 
       expect(
-        eventUpdateList[8].content['type'],
+        matrix
+            .getRoomById('!726s6s6q:example.com')
+            ?.roomAccountData['org.example.custom.room.config']
+            ?.type,
         'org.example.custom.room.config',
       );
-      expect(eventUpdateList[8].roomID, '!726s6s6q:example.com');
-      expect(eventUpdateList[8].type, EventUpdateType.accountData);
-
-      expect(eventUpdateList[9].content['type'], 'm.room.member');
-      expect(eventUpdateList[9].roomID, '!calls:example.com');
-      expect(eventUpdateList[9].type, EventUpdateType.state);
-
-      expect(eventUpdateList[10].content['type'], 'm.room.member');
-      expect(eventUpdateList[10].roomID, '!calls:example.com');
-      expect(eventUpdateList[10].type, EventUpdateType.state);
+      expect(
+        matrix
+            .getRoomById('!726s6s6q:example.com')
+            ?.roomAccountData[LatestReceiptState.eventType]
+            ?.type,
+        LatestReceiptState.eventType,
+      );
+      expect(
+        matrix
+            .getRoomById('!726s6s6q:example.com')
+            ?.roomAccountData['m.tag']
+            ?.type,
+        'm.tag',
+      );
 
       expect(
         matrix

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -254,6 +254,14 @@ void main() {
           client,
         );
 
+        await database.storeRoomAccountData(
+          BasicRoomEvent(
+            content: {'foo': 'bar'},
+            type: 'm.test',
+            roomId: roomid,
+          ),
+        );
+
         await database.storeEventUpdate(
           EventUpdate(
             roomID: roomid,
@@ -276,6 +284,8 @@ void main() {
         expect(room, isNotNull);
 
         expect(room?.name, 'start');
+
+        expect(room?.roomAccountData['m.test']?.content, {'foo': 'bar'});
 
         await database.storeEventUpdate(
           EventUpdate(


### PR DESCRIPTION
This also makes sure that
room account data does not
get unnecessarily serialized
and deserialized before
storing it in the database.
For this it changes the
code flow at multiple
places.