### PR TITLE
chore: BREAKING rename timeCreated to latestEventReceivedTime in Room

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2998,8 +2998,8 @@ class Client extends MatrixApi {
             a.notificationCount != b.notificationCount) {
           return b.notificationCount.compareTo(a.notificationCount);
         } else {
-          return b.timeCreated.millisecondsSinceEpoch
-              .compareTo(a.timeCreated.millisecondsSinceEpoch);
+          return b.latestEventReceivedTime.millisecondsSinceEpoch
+              .compareTo(a.latestEventReceivedTime.millisecondsSinceEpoch);
         }
       };
 

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -437,8 +437,9 @@ class Room {
   @Deprecated('Use `getLocalizedDisplayname()` instead')
   String get displayname => getLocalizedDisplayname();
 
-  /// When the last message received.
-  DateTime get timeCreated => lastEvent?.originServerTs ?? DateTime.now();
+  /// When was the last event received.
+  DateTime get latestEventReceivedTime =>
+      lastEvent?.originServerTs ?? DateTime.now();
 
   /// Call the Matrix API to change the name of this room. Returns the event ID of the
   /// new m.room.name event.

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -257,7 +257,7 @@ void main() {
       );
       expect(room.lastEvent?.eventId, '12345');
       expect(room.lastEvent?.body, 'abc');
-      expect(room.timeCreated, room.lastEvent?.originServerTs);
+      expect(room.latestEventReceivedTime, room.lastEvent?.originServerTs);
     });
 
     test('lastEvent is set properly', () async {


### PR DESCRIPTION
Something that has been bugging me for some time.