### PR TITLE
fix: No roomId in BasicRoomEvent stores roomaccountdata silently wrong

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2670,7 +2670,7 @@ class Client extends MatrixApi {
         final accountData = syncRoomUpdate.accountData;
         if (accountData != null && accountData.isNotEmpty) {
           for (final event in accountData) {
-            await database?.storeRoomAccountData(event);
+            await database?.storeRoomAccountData(room.id, event);
             room.roomAccountData[event.type] = event;
           }
         }
@@ -2739,7 +2739,7 @@ class Client extends MatrixApi {
         roomId: room.id,
         content: receiptStateContent.toJson(),
       );
-      await database?.storeRoomAccountData(event);
+      await database?.storeRoomAccountData(room.id, event);
       room.roomAccountData[event.type] = event;
     }
   }

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -134,7 +134,7 @@ abstract class DatabaseApi {
 
   Future storeAccountData(String type, Map<String, Object?> content);
 
-  Future storeRoomAccountData(BasicRoomEvent event);
+  Future storeRoomAccountData(String roomId, BasicRoomEvent event);
 
   Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client);
 

--- a/lib/src/database/hive_collections_database.dart
+++ b/lib/src/database/hive_collections_database.dart
@@ -1096,9 +1096,9 @@ class HiveCollectionsDatabase extends DatabaseApi {
   }
 
   @override
-  Future<void> storeRoomAccountData(BasicRoomEvent event) async {
+  Future<void> storeRoomAccountData(String roomId, BasicRoomEvent event) async {
     await _roomAccountDataBox.put(
-      TupleKey(event.roomId ?? '', event.type).toString(),
+      TupleKey(roomId, event.type).toString(),
       copyMap(event.toJson()),
     );
     return;

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1084,9 +1084,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> storeRoomAccountData(BasicRoomEvent event) async {
+  Future<void> storeRoomAccountData(String roomId, BasicRoomEvent event) async {
     await _roomAccountDataBox.put(
-      TupleKey(event.roomId ?? '', event.type).toString(),
+      TupleKey(roomId, event.type).toString(),
       event.toJson(),
     );
     return;

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -256,6 +256,7 @@ void main() {
         );
 
         await database.storeRoomAccountData(
+          roomid,
           BasicRoomEvent(
             content: {'foo': 'bar'},
             type: 'm.test',


### PR DESCRIPTION
Little follow up for the
EventUpdate refactoring.
Turned out that the roomId
is sometimes null in
BasicRoomEvent so we should
pass it manually.