### PR TITLE
fix: priorize direct chat MXIDs over empty hero user list

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -249,8 +249,10 @@ class Room {
     }
 
     final directChatMatrixID = this.directChatMatrixID;
-    final heroes = summary.mHeroes ??
-        (directChatMatrixID == null ? [] : [directChatMatrixID]);
+    final heroes = summary.mHeroes ?? [];
+    if (directChatMatrixID != null && heroes.isEmpty) {
+      heroes.add(directChatMatrixID);
+    }
     if (heroes.isNotEmpty) {
       final result = heroes
           .where(


### PR DESCRIPTION
I ran into a funny bug : 

- you get a new invite for a direct chat (in my case sent from Element)
- join the invite
- kill your client before ever loading the hero user
- your chat will for ever be called "Empty chat"

I figured out I ran into a state issue where the summary's `mHeros` was an empty list (not null !) but a direct chat user actually exists. The `Room.getLocalizedDisplayname` method now returns `Empty chat` as even an empty hero list is prioritized over a direct chat MXID. Right now, the direct chat MXID is only used if there is not even a hero list set.

I'd propose to simply override the hero list with the direct chat MXID in case the list is empty.