### PR TITLE
fix: Megolm sessions become invalid after restarting client

### DIFF
--- a/lib/encryption/key_manager.dart
+++ b/lib/encryption/key_manager.dart
@@ -289,8 +289,7 @@ class KeyManager {
         dbSess.sessionId != sessionId) {
       return null;
     }
-    roomInboundGroupSessions[sessionId] = dbSess;
-    return sess;
+    return roomInboundGroupSessions[sessionId] = dbSess;
   }
 
   Map<String, Map<String, bool>> _getDeviceKeyIdMap(
@@ -348,6 +347,8 @@ class KeyManager {
       sess.outboundGroupSession!.session_id(),
     );
     if (inboundSess == null) {
+      Logs().w('No inbound megolm session found for outbound session!');
+      assert(inboundSess != null);
       wipe = true;
     }
 


### PR DESCRIPTION
This bug seems to be in the
sdk for 5 years already without
anyone noticing. The method
loadInboundGroupSession
seems to return the wrong
variable when loading the
session from the key. While
the outboundgroupsession
loading method relies on
an inbound group session, it
silently marks the outbound
group session as invalid on
every restart and creates a
new one. This means we never
reuse megolm sessions after
restarting the client.

Fixing this will probably reduce
the amount of megolm sessions
used in a conversation by a lot
which could improve the
performance and make the
key backup more reliable.

Closes https://github.com/famedly/product-management/issues/2840

It looks like the bug was introduced 3 years ago while doing the null safe migration. Before the method looked like this:

```dart
  /// Loads an inbound group session
  Future<SessionKey> loadInboundGroupSession(
      String roomId, String sessionId, String senderKey) async {
    if (roomId == null || sessionId == null || senderKey == null) {
      return null;
    }
    if (_inboundGroupSessions.containsKey(roomId) &&
        _inboundGroupSessions[roomId].containsKey(sessionId)) {
      final sess = _inboundGroupSessions[roomId][sessionId];
      if (sess.senderKey != senderKey && sess.senderKey.isNotEmpty) {
        return null; // sender keys do not match....better not do anything
      }
      return sess; // nothing to do
    }
    final session =
        await client.database?.getInboundGroupSession(roomId, sessionId);
    if (session == null) {
      return null;
    }
    final sess = SessionKey.fromDb(session, client.userID);
    if (!_inboundGroupSessions.containsKey(roomId)) {
      _inboundGroupSessions[roomId] = <String, SessionKey>{};
    }
    if (!sess.isValid ||
        (sess.senderKey.isNotEmpty && sess.senderKey != senderKey)) {
      return null;
    }
    _inboundGroupSessions[roomId][sessionId] = sess;
    return sess;
  }
  ```

So here when returning `sess` this variable actually hold the old inbound group session. After null safety migration it returned the wrong `sess`.