### PR TITLE
refactor: Make converting linebreaks in markdowntohtml optional

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -107,6 +107,8 @@ class Client extends MatrixApi {
 
   String? get syncFilterId => _syncFilterId;
 
+  final bool convertLinebreaksInFormatting;
+
   final ComputeCallback? compute;
 
   @Deprecated('Use [nativeImplementations] instead')
@@ -233,6 +235,10 @@ class Client extends MatrixApi {
     /// support.
     this.customRefreshTokenLifetime,
     this.typingIndicatorTimeout = const Duration(seconds: 30),
+
+    /// When sending a formatted message, converting linebreaks in markdown to
+    /// <br/> tags:
+    this.convertLinebreaksInFormatting = true,
   })  : syncFilter = syncFilter ??
             Filter(
               room: RoomFilter(

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -646,6 +646,7 @@ class Room {
         event['body'],
         getEmotePacks: () => getImagePacksFlat(ImagePackUsage.emoticon),
         getMention: getMention,
+        convertLinebreaks: client.convertLinebreaksInFormatting,
       );
       // if the decoded html is the same as the body, there is no need in sending a formatted message
       if (HtmlUnescape().convert(html.replaceAll(RegExp(r'<br />\n?'), '\n')) !=


### PR DESCRIPTION
Element actually does not do
this and use the linebreaks
inside of their <p> tags. It
works for our new html
rendering as well which is
already in FluffyChat.