### PR TITLE
feat: ensure direct chats have only 2 members before sending verification requests

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -451,7 +451,8 @@ class Client extends MatrixApi {
   Map<String, dynamic> get directChats =>
       _accountData['m.direct']?.content ?? {};
 
-  /// Returns the (first) room ID from the store which is a private chat with the user [userId].
+  /// Returns the first room ID from the store (the room with the latest event)
+  /// which is a private chat with the user [userId].
   /// Returns null if there is none.
   String? getDirectChatFromUserId(String userId) {
     final directChats = _accountData['m.direct']?.content[userId];

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1273,6 +1273,23 @@ void main() {
     });
     test('startDirectChat', () async {
       await matrix.startDirectChat('@alice:example.com', waitForSync: false);
+
+      expect(
+        json.decode(
+          FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.last,
+        ),
+        {
+          'initial_state': [
+            {
+              'content': {'algorithm': 'm.megolm.v1.aes-sha2'},
+              'type': 'm.room.encryption',
+            }
+          ],
+          'invite': ['@alice:example.com'],
+          'is_direct': true,
+          'preset': 'trusted_private_chat',
+        },
+      );
     });
 
     test('createGroupChat', () async {


### PR DESCRIPTION
Closes https://github.com/famedly/matrix-dart-sdk/issues/248