### PR TITLE
feat: add refresh token handling http client

### DIFF
--- a/lib/matrix.dart
+++ b/lib/matrix.dart
@@ -63,6 +63,7 @@ export 'src/utils/matrix_file.dart';
 export 'src/utils/matrix_id_string_extension.dart';
 export 'src/utils/matrix_localizations.dart';
 export 'src/utils/native_implementations.dart';
+export 'src/utils/matrix_refresh_token_client.dart';
 export 'src/utils/room_enums.dart';
 export 'src/utils/room_member_change_type.dart';
 export 'src/utils/push_notification.dart';

--- a/lib/src/utils/matrix_refresh_token_client.dart
+++ b/lib/src/utils/matrix_refresh_token_client.dart
@@ -1,0 +1,71 @@
+import 'package:http/http.dart' hide Client;
+
+import 'package:matrix/matrix.dart';
+
+/// a [BaseClient] implementation handling [Client.onSoftLogout]
+///
+/// This client wrapper takes matrix [Client] as parameter and handles token
+/// rotation.
+///
+/// Before dispatching any request, it will check whether the [Client] supports
+/// token refresh by checking [Client.accessTokenExpiresAt]. Token rotation is
+/// done when :
+/// - refresh is supported ([Client.accessTokenExpiresAt])
+/// - we are actually initialized ([Client.onSync.value])
+/// - the request is to the homeserver rather than e.g. IDP ([BaseRequest.url])
+/// - the request is authenticated ([BaseRequest.headers])
+/// - we're logged in ([Client.isLogged])
+///
+/// In this case, [Client.ensureNotSoftLoggedOut] is awaited before running
+/// [BaseClient.send]. If the [Client.bearerToken] was changed meanwhile,
+/// the [BaseRequest] is being adjusted.
+class MatrixRefreshTokenClient extends BaseClient {
+  MatrixRefreshTokenClient({
+    required this.inner,
+    required this.client,
+  });
+
+  /// the matrix [Client] to handle token rotation for
+  final Client client;
+
+  /// the inner [BaseClient] to dispatch requests with
+  final BaseClient inner;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    Request? req;
+    if ( // only refresh if
+        // refresh is supported
+        client.accessTokenExpiresAt != null &&
+            // we are actually initialized
+            client.onSync.value != null &&
+            // the request is to the homeserver rather than e.g. IDP
+            request.url.host == client.homeserver?.host &&
+            // the request is authenticated
+            request.headers
+                .map((k, v) => MapEntry(k.toLowerCase(), v))
+                .containsKey('authorization') &&
+            // and last but not least we're logged in
+            client.isLogged()) {
+      try {
+        await client.ensureNotSoftLoggedOut();
+      } catch (e) {
+        Logs().w('Could not rotate token before dispatching HTTP request.', e);
+      }
+      // in every case ensure we run with the latest bearer token to avoid
+      // race conditions
+      finally {
+        final headers = request.headers;
+        // hours wasted : unknown :facepalm:
+        headers.removeWhere((k, _) => k.toLowerCase() == 'authorization');
+        headers['Authorization'] = 'Bearer ${client.bearerToken!}';
+        req = Request(request.method, request.url);
+        req.headers.addAll(headers);
+        if (request is Request) {
+          req.bodyBytes = request.bodyBytes;
+        }
+      }
+    }
+    return inner.send(req ?? request);
+  }
+}


### PR DESCRIPTION
Sorry for once again coming up with a random PR ... Can I kindly ask you to check whether this implementation matches your expectations about handling soft-logout in more advanced use cases ?

This will especially be relevant for end users once #2024 might be shipped to client developers.

- implement a `MatrixRefreshTokenClient` to await token refresh before dispatching http requests
- improve documentation about soft logout logic
- fix dartdoc locations about soft logout

Fixes: #2027