### PR TITLE
fix: incorrect filename when caption is used in body of event

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -792,9 +792,11 @@ class Event extends MatrixEvent {
         throw ('Unable to decrypt file');
       }
     }
+
+    final filename = content.tryGet<String>('filename') ?? body;
     return MatrixFile(
       bytes: uint8list,
-      name: body,
+      name: filename,
       mimeType: attachmentMimetype,
     );
   }


### PR DESCRIPTION
"body: If filename is not set or the value of both properties are identical, this is the filename of the original upload. Otherwise, this is a caption for the file."

refer https://spec.matrix.org/latest/client-server-api/#mfile