### PR TITLE
refactor: Add file info to placeholder before sending file event

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -744,6 +744,8 @@ class Room {
                     'msgtype': file.msgType,
                     'body': file.name,
                     'filename': file.name,
+                    'info': file.info,
+                    if (extraContent != null) ...extraContent,
                   },
                   type: EventTypes.Message,
                   eventId: txid,


### PR DESCRIPTION
This should display the placeholder for the sending file event better. Especially for images and videos which will directly have the correct width and height