### PR TITLE
fix: set prev_batch first time from sync response correctly

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -331,6 +331,31 @@ class FakeMatrixApi extends BaseClient {
     };
   }
 
+  // since direction is b, the start and end are reversed
+  static const Map<String, dynamic> emptyHistoryResponse = {
+    'start': 'simpleHistoryResponse', // next_batch
+    'end': null, // prev_batch
+    'chunk': [],
+    'state': [],
+  };
+  static const Map<String, dynamic> simpleHistoryResponse = {
+    'start': '1', // next_batch
+    'end': 'emptyHistoryResponse', // prev_batch
+    'chunk': [
+      {
+        'content': {'body': '0'},
+        'type': 'm.room.message',
+        'event_id': '0',
+        'room_id': 'new_room_id',
+        'sender': '@example:example.org',
+        'origin_server_ts': 1432735824653,
+        'unsigned': {'age': 1234},
+        'state_key': '',
+      },
+    ],
+    'state': [],
+  };
+
   static const Map<String, dynamic> messagesResponsePast = {
     'start': 't47429-4392820_219380_26003_2265',
     'end': 't47409-4357353_219380_26003_2265',
@@ -1724,6 +1749,10 @@ class FakeMatrixApi extends BaseClient {
             'origin_server_ts': 1432735824653,
             'unsigned': {'age': 1234},
           },
+      '/client/v3/rooms/new_room_id/messages?from=emptyHistoryResponse&dir=b&limit=30&filter=%7B%22lazy_load_members%22%3Atrue%7D':
+          (var req) => emptyHistoryResponse,
+      '/client/v3/rooms/new_room_id/messages?from=1&dir=b&limit=30&filter=%7B%22lazy_load_members%22%3Atrue%7D':
+          (var req) => simpleHistoryResponse,
       '/client/v3/rooms/!localpart%3Aserver.abc/messages?from=1234&dir=b&to=1234&limit=10&filter=%7B%22lazy_load_members%22%3Atrue%7D':
           (var req) => messagesResponsePast,
       '/client/v3/rooms/!localpart%3Aserver.abc/messages?from=&dir=b&limit=10&filter=%7B%22lazy_load_members%22%3Atrue%7D':

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2984,14 +2984,18 @@ class Client extends MatrixApi {
                 (chatUpdate.unreadNotifications?.highlightCount ?? 0) ||
             chatUpdate.summary != null ||
             chatUpdate.timeline?.prevBatch != null)) {
+      /// [InvitedRoomUpdate] doesn't have prev_batch, so we want to set it in case
+      /// the room first appeared in sync update when membership was invite.
+      if (rooms[roomIndex].membership == Membership.invite &&
+          chatUpdate.timeline?.prevBatch != null) {
+        rooms[roomIndex].prev_batch = chatUpdate.timeline?.prevBatch;
+      }
       rooms[roomIndex].membership = membership;
       rooms[roomIndex].notificationCount =
           chatUpdate.unreadNotifications?.notificationCount ?? 0;
       rooms[roomIndex].highlightCount =
           chatUpdate.unreadNotifications?.highlightCount ?? 0;
-      if (chatUpdate.timeline?.prevBatch != null) {
-        rooms[roomIndex].prev_batch = chatUpdate.timeline?.prevBatch;
-      }
+
       final summary = chatUpdate.summary;
       if (summary != null) {
         final roomSummaryJson = rooms[roomIndex].summary.toJson()


### PR DESCRIPTION
Should fix what https://github.com/famedly/matrix-dart-sdk/pull/2055 intended to do. Thanks @td-famedly for the test files.