### PR TITLE
fix: Trim plaintext after removeMarkdown

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -955,10 +955,8 @@ class Event extends MatrixEvent {
     // return the html tags free body
     if (removeMarkdown == true) {
       final html = markdown(body, convertLinebreaks: false);
-      final document = parse(
-        html,
-      );
-      body = document.documentElement?.text ?? body;
+      final document = parse(html);
+      body = document.documentElement?.text.trim() ?? body;
     }
     return body;
   }

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -1274,10 +1274,10 @@ void main() {
         {
           'content': {
             'body':
-                '# Title\nsome text and [link](https://example.com)\nokay and this is **important**',
+                '> Quote\n# Title\nsome text and [link](https://example.com)\nokay and this is **important**',
             'format': 'org.matrix.custom.html',
             'formatted_body':
-                '<h1>Title</h1>\n<p>some text and <a href="https://example.com">link</a><br>okay and this is <strong>important</strong></p>\n',
+                '<blockquote><p>Quote</p></blockquote><h1>Title</h1>\n<p>some text and <a href="https://example.com">link</a><br>okay and this is <strong>important</strong></p>\n',
             'msgtype': 'm.text',
           },
           'event_id': '\$143273582443PhrSn:example.org',
@@ -1294,7 +1294,7 @@ void main() {
           MatrixDefaultLocalizations(),
           removeMarkdown: true,
         ),
-        'Title\nsome text and link\nokay and this is important',
+        'Quote\n\nTitle\nsome text and link\nokay and this is important',
       );
       expect(
         await event.calcLocalizedBody(
@@ -1302,7 +1302,7 @@ void main() {
           removeMarkdown: true,
           plaintextBody: true,
         ),
-        'Title\nsome text and 🔗link\nokay and this is important',
+        'Quote\n\nTitle\nsome text and 🔗link\nokay and this is important',
       );
       expect(
         await event.calcLocalizedBody(
@@ -1310,7 +1310,7 @@ void main() {
           removeMarkdown: true,
           withSenderNamePrefix: true,
         ),
-        'Example: Title\nsome text and link\nokay and this is important',
+        'Example: Quote\n\nTitle\nsome text and link\nokay and this is important',
       );
       expect(
         await event.calcLocalizedBody(
@@ -1319,7 +1319,7 @@ void main() {
           plaintextBody: true,
           withSenderNamePrefix: true,
         ),
-        'Example: Title\nsome text and 🔗link\nokay and this is important',
+        'Example: Quote\n\nTitle\nsome text and 🔗link\nokay and this is important',
       );
 
       event = Event.fromJson(


### PR DESCRIPTION
Closes https://github.com/famedly/app/issues/6394