### PR TITLE
fix: Do not load timeline while sync is processed

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1525,14 +1525,16 @@ class Room {
   }) async {
     await postLoad();
 
-    List<Event> events;
+    var events = <Event>[];
 
     if (!isArchived) {
-      events = await client.database?.getEventList(
-            this,
-            limit: limit,
-          ) ??
-          <Event>[];
+      await client.database?.transaction(() async {
+        events = await client.database?.getEventList(
+              this,
+              limit: limit,
+            ) ??
+            <Event>[];
+      });
     } else {
       final archive = client.getArchiveRoomFromCache(id);
       events = archive?.timeline.events.toList() ?? [];


### PR DESCRIPTION
This sometimes lead to the
problem that the timeline misses
the newest messages. Especially
when opening the app from a
notification this can happen.