### PR TITLE
feat: Support fallback for threads in Event.getReplyEvent()

### DIFF
--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -2862,5 +2862,49 @@ void main() {
         matrixEvent.toJson(),
       );
     });
+
+    test('getReplyEvent fallback', () async {
+      final event = Event.fromJson(
+        {
+          'content': {
+            'msgtype': 'text',
+            'body': 'Hello world',
+            'm.relates_to': {
+              'rel_type': 'm.thread',
+              'event_id': '\$root',
+              'm.in_reply_to': {'event_id': '\$target'},
+              'is_falling_back': true,
+            },
+          },
+          'event_id': '\$143273582443PhrSn:example.org',
+          'origin_server_ts': 1432735824653,
+          'room_id': room.id,
+          'sender': '@example:example.org',
+          'type': 'm.room.message',
+          'unsigned': {'age': 1234},
+          'redacts': 'abcd',
+          'prev_content': <String, Object?>{
+            'foo': 'bar',
+          },
+        },
+        room,
+      );
+      expect(event.relationshipType, RelationshipTypes.thread);
+      expect(event.relationshipEventId, '\$root');
+      final targetEvent = Event(
+        eventId: '\$target',
+        senderId: '@example:example.org',
+        type: 'm.room.message',
+        content: {
+          'msgtype': 'text',
+          'body': 'Hello world',
+        },
+        originServerTs: DateTime.now(),
+        room: room,
+      );
+      final timeline =
+          Timeline(room: room, chunk: TimelineChunk(events: [targetEvent]));
+      expect(await event.getReplyEvent(timeline), targetEvent);
+    });
   });
 }


### PR DESCRIPTION
Supports fallback for threads according to https://spec.matrix.org/v1.14/client-server-api/#fallback-for-unthreaded-clients