### PR TITLE
fix: null check on Client.userID in Client.checkHomeserver

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -583,7 +583,10 @@ class Client extends MatrixApi {
   @override
   Future<DiscoveryInformation> getWellknown() async {
     final wellKnownResponse = await httpClient.get(
-      Uri.https(userID!.domain!, '/.well-known/matrix/client'),
+      Uri.https(
+        userID?.domain ?? homeserver!.host,
+        '/.well-known/matrix/client',
+      ),
     );
     final wellKnown = DiscoveryInformation.fromJson(
       jsonDecode(utf8.decode(wellKnownResponse.bodyBytes))


### PR DESCRIPTION
Recent changes in the SDK introduced to use the userID as primary source for the well-known URI. Sadly this only works if the user is already logged in. In order to make use of the `checkHomeserver` method, clients first pass a `homeserver` which is applied to the `Client` instance. The `checkHomeserver` method will then call `getWellKnown` before the MXID is actually known, the `Client.userID` is `null` thus.

Steps to reproduce :

- open https://fluffychat.im/web
- enter a homeserver URI (e.g. example.org) that does delegate the homeserver to a subdomain (e.g. matrix.example.org)
- see an error message

Potential regressions : well-known resolution won't work if the client provides the actual homeserver address (matrix.example.org) while the well-known is hosted on the base URI (example.org). But since that was never supported before, I feel like this is fine. In most cases, either the client already provides the correct homeserver URI if it's known or the user enters the domain they know and the getWellKnown method will resolve the matrix homeserver URI.