### PR TITLE
refactor: Do not handle leave rooms on initial sync

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2483,7 +2483,7 @@ class Client extends MatrixApi {
       // room both in invite and leave. If you get an invite and then leave, it
       // will only be included in leave.
       final leave = sync.rooms?.leave;
-      if (leave != null) {
+      if (leave != null && prevBatch != null) {
         await _handleRooms(leave, direction: direction);
       }
       final invite = sync.rooms?.invite;


### PR DESCRIPTION
This saves some ressources as
we do not need to delete rooms
as long as the database is empty anyway.
Also for some reason this fixes
an edge case where the keys
cache in the sqlite box gets
corrupted. It is unfortunate
that I wasn't able to find the
root cause or be able to reproduce
it. Wasted 4 hours now.

Closes https://github.com/famedly/product-management/issues/3190