### PR TITLE
refactor: Ignore leave room update for unknown rooms

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -601,16 +601,6 @@ class FakeMatrixApi extends BaseClient {
           'timeline': {
             'events': [
               {
-                'sender': '@bob:example.com',
-                'type': 'm.room.member',
-                'state_key': '@bob:example.com',
-                'content': {'membership': 'join'},
-                'prev_content': {'membership': 'invite'},
-                'origin_server_ts': 1417731086795,
-                'event_id': '\$7365636s6r6432:example.com',
-                'unsigned': {'foo': 'bar'},
-              },
-              {
                 'sender': '@alice:example.com',
                 'type': 'm.room.message',
                 'content': {'body': 'I am a fish', 'msgtype': 'm.text'},

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2736,6 +2736,10 @@ class Client extends MatrixApi {
           await _handleRoomEvents(room, state, EventUpdateType.inviteState);
         }
       }
+      if (syncRoomUpdate is LeftRoomUpdate && getRoomById(id) == null) {
+        Logs().d('Skip store LeftRoomUpdate for unknown room', id);
+        continue;
+      }
       await database.storeRoomUpdate(id, syncRoomUpdate, room.lastEvent, this);
     }
   }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -282,16 +282,13 @@ void main() {
 
       final eventUpdateList = await eventUpdateListFuture;
 
-      expect(eventUpdateList.length, 3);
+      expect(eventUpdateList.length, 2);
 
-      expect(eventUpdateList[0].type, 'm.room.member');
+      expect(eventUpdateList[0].type, 'm.room.message');
       expect(eventUpdateList[0].roomId, '!726s6s6q:example.com');
 
       expect(eventUpdateList[1].type, 'm.room.message');
-      expect(eventUpdateList[1].roomId, '!726s6s6q:example.com');
-
-      expect(eventUpdateList[2].type, 'm.room.message');
-      expect(eventUpdateList[2].roomId, '!726s6s6f:example.com');
+      expect(eventUpdateList[1].roomId, '!726s6s6f:example.com');
 
       expect(
         matrix

--- a/test/encryption/key_manager_test.dart
+++ b/test/encryption/key_manager_test.dart
@@ -186,6 +186,7 @@ void main() {
       sess = await client.encryption!.keyManager
           .createOutboundGroupSession(roomId);
       final room = client.getRoomById(roomId)!;
+      room.partial = false;
       final member = room.getState('m.room.member', '@alice:example.com');
       member!.content['membership'] = 'leave';
       room.summary.mJoinedMemberCount = room.summary.mJoinedMemberCount! - 1;


### PR DESCRIPTION
closes https://github.com/famedly/product-management/issues/3190

This adds a check before the storeRoomUpdate() call
if the room is actually known. This has the effect
that the call of forgetRoom() is skipped.

The reason for this is an edge case in the database
implementation when calling getAllKeys(). This
somehow can corrupt the keys-cache and lead to
some problems. I wasn't able to fix this problem
yet so this refactoring is more a good-enough
workaround for now to not trigger it on an
initial sync. I plan to fix it with a different
approach which completely removes the keys-cache
in the future.

However this change leads to some problems in the
tests as they already rely on this edge case.