### PR TITLE
fix: no user feedback if client.getConfig() takes some time

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -771,6 +771,7 @@ class Room {
         },
       ),
     );
+    await _handleFakeSync(syncUpdate);
 
     MatrixFile uploadFile = file; // ignore: omit_local_variable_types
     // computing the thumbnail in case we can
@@ -779,7 +780,6 @@ class Room {
       syncUpdate.rooms!.join!.values.first.timeline!.events!.first
               .unsigned![fileSendingStatusKey] =
           FileSendingStatus.generatingThumbnail.name;
-      await _handleFakeSync(syncUpdate);
       thumbnail ??= await file.generateThumbnail(
         nativeImplementations: client.nativeImplementations,
         customImageResizer: client.customImageResizer,


### PR DESCRIPTION
When sending a file in an environment with bad internet where Client.getConfig() takes some
seconds, the user does not get
any feedback at all.
This change now makes sure that
the user always sees the pending
event in the timeline before anything
else is done in the room.sendFileEvent method.