### PR TITLE
chore: Add hint to init vodozemac also in native implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,22 @@ For Flutter you can use [flutter_vodozemac](https://pub.dev/packages/flutter_vod
 just needs to be initialized **once**:
 
 ```dart
-import 'package:flutter_vodozemac/flutter_vodozemac' as vod;
+import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 
 // ...
 
 await vod.init();
 
-final client = Client(/*...*/);
+final client = Client('Matrix Client',
+    // ...
+    // ...
+    nativeImplementations: NativeImplementationsIsolate(
+        compute,
+        // Also init in NativeImplemenetations if you use it there:
+        vodozemacInit: () => vod.init(),
+    ),
+    // ...
+);
 ```
 
 This should work on Android, iOS, macOS, Linux and Windows.

--- a/doc/end-to-end-encryption.md
+++ b/doc/end-to-end-encryption.md
@@ -27,3 +27,20 @@ final client = Client(/*...*/);
 This should work on Android, iOS, macOS, Linux and Windows.
 
 For web you need to compile vodozemac to wasm. [Please refer to the Vodozemac bindings documentation](https://pub.dev/packages/vodozemac#build-for-web).
+
+### Using Vodozemac with NativeImplementations
+
+When using NativeImplementations you have to initialize Vodozemac there as well.
+Just pass the same init function to it:
+
+```dart
+final client = Client('Matrix Client',
+    // ...
+    // ...
+    nativeImplementations: NativeImplementationsIsolate(
+        compute,
+        vodozemacInit: () => vod.init(),
+    ),
+    // ...
+);
+```


### PR DESCRIPTION
Fixes https://github.com/famedly/matrix-dart-sdk/issues/2108