### PR TITLE
fix: reuse a deviceId if available

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -681,7 +681,7 @@ class Client extends MatrixApi {
       identifier: identifier,
       password: password,
       token: token,
-      deviceId: deviceId,
+      deviceId: deviceId ?? deviceID,
       initialDeviceDisplayName: initialDeviceDisplayName,
       // ignore: deprecated_member_use
       user: user,


### PR DESCRIPTION
This fixes the bug where if a soft logout fails, we don't get a new deviceID

https://spec.matrix.org/latest/client-server-api/#soft-logout

> [Changed in v1.3] A client that receives such a response can try to [refresh its access token](https://spec.matrix.org/v1.15/client-server-api/#refreshing-access-tokens), if it has a refresh token available. If it does not have a refresh token available, or refreshing fails with soft_logout: true, the client can acquire a new access token by specifying the device ID it is already using to the login API.