### PR TITLE
feat: Implement most of MSC3911

### DIFF
--- a/lib/msc_extensions/msc_3911_linking_media/msc_3911_linking_media.dart
+++ b/lib/msc_extensions/msc_3911_linking_media/msc_3911_linking_media.dart
@@ -1,0 +1,160 @@
+/// Media linking MSC, that allows attaching media to events or profiles.
+/// https://github.com/matrix-org/matrix-spec-proposals/pull/3911
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart';
+
+import 'package:matrix/matrix_api_lite/generated/api.dart';
+
+/// Uploads MSC3911 restricted media, that needs to be attached on send.
+/// (Only difference to normal uploadContent is the url and the server behaviour.)
+///
+/// [filename] The name of the file being uploaded
+///
+/// [body]
+///
+/// [contentType] **Optional.** The content type of the file being uploaded.
+///
+/// Clients SHOULD always supply this header.
+///
+/// Defaults to `application/octet-stream` if it is not set.
+///
+///
+/// returns `content_uri`:
+/// The [`mxc://` URI](https://spec.matrix.org/unstable/client-server-api/#matrix-content-mxc-uris) to the uploaded content.
+extension Msc3911 on Api {
+  Future<Uri> uploadRestrictedContent(
+    Uint8List body, {
+    String? filename,
+    String? contentType,
+  }) async {
+    final requestUri = Uri(
+      path: '_matrix/client/unstable/org.matrix.msc3911/media/upload',
+      queryParameters: {
+        if (filename != null) 'filename': filename,
+      },
+    );
+    final request = Request('POST', baseUri!.resolveUri(requestUri));
+    request.headers['authorization'] = 'Bearer ${bearerToken!}';
+    if (contentType != null) request.headers['content-type'] = contentType;
+    request.bodyBytes = body;
+    final response = await httpClient.send(request);
+    final responseBody = await response.stream.toBytes();
+    if (response.statusCode != 200) unexpectedResponse(response, responseBody);
+    final responseString = utf8.decode(responseBody);
+    final json = jsonDecode(responseString);
+    return ((json['content_uri'] as String).startsWith('mxc://')
+        ? Uri.parse(json['content_uri'] as String)
+        : throw Exception('Uri not an mxc URI'));
+  }
+
+  /// This is a copy of sendMessage, but allows a user to attach media ids to the sent event according to MSC3911.
+  ///
+  /// [roomId] The room to send the event to.
+  ///
+  /// [eventType] The type of event to send.
+  ///
+  /// [txnId] The [transaction ID](https://spec.matrix.org/unstable/client-server-api/#transaction-identifiers) for this event. Clients should generate an
+  /// ID unique across requests with the same access token; it will be
+  /// used by the server to ensure idempotency of requests.
+  ///
+  /// [body]
+  ///
+  /// returns `event_id`:
+  /// A unique identifier for the event.
+  Future<String> sendRestrictedMediaMessage(
+    String roomId,
+    String eventType,
+    String txnId,
+    List<String>? attachedMediaIds,
+    Map<String, Object?> body,
+  ) async {
+    final Map<String, Object?> queryParameters = {};
+    if (attachedMediaIds != null) {
+      queryParameters['org.matrix.msc3911.attach_media'] = attachedMediaIds;
+    }
+
+    final requestUri = Uri(
+      path:
+          '_matrix/client/v3/rooms/${Uri.encodeComponent(roomId)}/send/${Uri.encodeComponent(eventType)}/${Uri.encodeComponent(txnId)}',
+      queryParameters: queryParameters,
+    );
+    final request = Request('PUT', baseUri!.resolveUri(requestUri));
+    request.headers['authorization'] = 'Bearer ${bearerToken!}';
+    request.headers['content-type'] = 'application/json';
+    request.bodyBytes = utf8.encode(jsonEncode(body));
+    const maxBodySize = 60000;
+    if (request.bodyBytes.length > maxBodySize) {
+      bodySizeExceeded(maxBodySize, request.bodyBytes.length);
+    }
+    final response = await httpClient.send(request);
+    final responseBody = await response.stream.toBytes();
+    if (response.statusCode != 200) unexpectedResponse(response, responseBody);
+    final responseString = utf8.decode(responseBody);
+    final json = jsonDecode(responseString);
+    return json['event_id'] as String;
+  }
+
+  /// State events can be sent using this endpoint.  These events will be
+  /// overwritten if `<room id>`, `<event type>` and `<state key>` all
+  /// match. This implements the attachedMediaIds needed by MSC3911, but
+  /// is otherwise identical to setRoomStateWithKey.
+  ///
+  /// Requests to this endpoint **cannot use transaction IDs**
+  /// like other `PUT` paths because they cannot be differentiated from the
+  /// `state_key`. Furthermore, `POST` is unsupported on state paths.
+  ///
+  /// The body of the request should be the content object of the event; the
+  /// fields in this object will vary depending on the type of event. See
+  /// [Room Events](https://spec.matrix.org/unstable/client-server-api/#room-events) for the `m.` event specification.
+  ///
+  /// If the event type being sent is `m.room.canonical_alias` servers
+  /// SHOULD ensure that any new aliases being listed in the event are valid
+  /// per their grammar/syntax and that they point to the room ID where the
+  /// state event is to be sent. Servers do not validate aliases which are
+  /// being removed or are already present in the state event.
+  ///
+  ///
+  /// [roomId] The room to set the state in
+  ///
+  /// [eventType] The type of event to send.
+  ///
+  /// [stateKey] The state_key for the state to send. Defaults to the empty string. When
+  /// an empty string, the trailing slash on this endpoint is optional.
+  ///
+  /// [body]
+  ///
+  /// returns `event_id`:
+  /// A unique identifier for the event.
+  Future<String> setRestrictedMediaRoomStateWithKey(
+    String roomId,
+    String eventType,
+    String stateKey,
+    List<String>? attachedMediaIds,
+    Map<String, Object?> body,
+  ) async {
+    final Map<String, Object?> queryParameters = {};
+    if (attachedMediaIds != null) {
+      queryParameters['org.matrix.msc3911.attach_media'] = attachedMediaIds;
+    }
+
+    final requestUri = Uri(
+      path:
+          '_matrix/client/v3/rooms/${Uri.encodeComponent(roomId)}/state/${Uri.encodeComponent(eventType)}/${Uri.encodeComponent(stateKey)}',
+      queryParameters: queryParameters,
+    );
+    final request = Request('PUT', baseUri!.resolveUri(requestUri));
+    request.headers['authorization'] = 'Bearer ${bearerToken!}';
+    request.headers['content-type'] = 'application/json';
+    request.bodyBytes = utf8.encode(jsonEncode(body));
+    final response = await httpClient.send(request);
+    final responseBody = await response.stream.toBytes();
+    if (response.statusCode != 200) unexpectedResponse(response, responseBody);
+    final responseString = utf8.decode(responseBody);
+    final json = jsonDecode(responseString);
+    return json['event_id'] as String;
+  }
+}

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -472,6 +472,7 @@ class Event extends MatrixEvent {
     return await room.sendEvent(
       content,
       txid: txid ?? transactionId ?? eventId,
+      attachedMediaIds: unsigned?.tryGetList<String>('attached_media_ids'),
     );
   }
 

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -846,7 +846,7 @@ class Event extends MatrixEvent {
 
     if (content case {'url': final String url}) {
       if (url.startsWith('mxc://')) {
-        final [server, mediaId] = Uri.parse(url).pathSegments;
+        final (:server, :mediaId) = Uri.parse(url).mxcParts;
         final newUri =
             (await client.copyRestrictedContent(server, mediaId)).toString();
         attachedMediaIds.add(newUri);
@@ -856,7 +856,7 @@ class Event extends MatrixEvent {
 
     if (content case {'file': {'url': final String url}}) {
       if (url.startsWith('mxc://')) {
-        final [server, mediaId] = Uri.parse(url).pathSegments;
+        final (:server, :mediaId) = Uri.parse(url).mxcParts;
         final newUri =
             (await client.copyRestrictedContent(server, mediaId)).toString();
         attachedMediaIds.add(newUri);
@@ -866,7 +866,7 @@ class Event extends MatrixEvent {
 
     if (content case {'info': {'thumbnail_url': final String url}}) {
       if (url.startsWith('mxc://')) {
-        final [server, mediaId] = Uri.parse(url).pathSegments;
+        final (:server, :mediaId) = Uri.parse(url).mxcParts;
         final newUri =
             (await client.copyRestrictedContent(server, mediaId)).toString();
         attachedMediaIds.add(newUri);
@@ -876,7 +876,7 @@ class Event extends MatrixEvent {
 
     if (content case {'info': {'file': {'thumbnail_file': final String url}}}) {
       if (url.startsWith('mxc://')) {
-        final [server, mediaId] = Uri.parse(url).pathSegments;
+        final (:server, :mediaId) = Uri.parse(url).mxcParts;
         final newUri =
             (await client.copyRestrictedContent(server, mediaId)).toString();
         attachedMediaIds.add(newUri);

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -1042,7 +1042,7 @@ class Event extends MatrixEvent {
 
     // return the html tags free body
     if (removeMarkdown == true) {
-      final html = markdown(body, convertLinebreaks: false);
+      final html = markdown_sync(body, convertLinebreaks: false);
       final document = parse(html);
       body = document.documentElement?.text.trim() ?? body;
     }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -25,6 +25,7 @@ import 'package:collection/collection.dart';
 import 'package:html_unescape/html_unescape.dart';
 
 import 'package:matrix/matrix.dart';
+import 'package:matrix/msc_extensions/msc_3911_linking_media/msc_3911_linking_media.dart';
 import 'package:matrix/src/models/timeline_chunk.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:matrix/src/utils/file_send_request_credentials.dart';
@@ -924,6 +925,10 @@ class Room {
       editEventId: editEventId,
       threadRootEventId: threadRootEventId,
       threadLastEventId: threadLastEventId,
+      attachedMediaIds: [
+        uploadResp.toString(),
+        if (thumbnail != null) thumbnailUploadResp.toString(),
+      ],
     );
     sendingFilePlaceholders.remove(txid);
     sendingFileThumbnails.remove(txid);
@@ -958,6 +963,7 @@ class Room {
     String type,
     Map<String, dynamic> content, {
     String? txid,
+    List<String>? attachedMediaIds,
   }) async {
     txid ??= client.generateUniqueTransactionId();
 
@@ -968,14 +974,26 @@ class Room {
             .encryptGroupMessagePayload(id, content, type: type)
         : content;
 
-    return await client.sendMessage(
-      id,
-      sendMessageContent.containsKey('ciphertext')
-          ? EventTypes.Encrypted
-          : type,
-      txid,
-      sendMessageContent,
-    );
+    final isRestrictedMediaSupported = await client.restrictedMediaSupported();
+
+    return isRestrictedMediaSupported
+        ? await client.sendRestrictedMediaMessage(
+            id,
+            sendMessageContent.containsKey('ciphertext')
+                ? EventTypes.Encrypted
+                : type,
+            txid,
+            attachedMediaIds,
+            sendMessageContent,
+          )
+        : await client.sendMessage(
+            id,
+            sendMessageContent.containsKey('ciphertext')
+                ? EventTypes.Encrypted
+                : type,
+            txid,
+            sendMessageContent,
+          );
   }
 
   String _stripBodyFallback(String body) {
@@ -1008,6 +1026,7 @@ class Room {
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
+    List<String>? attachedMediaIds,
   }) async {
     // Create new transaction id
     final String messageID;
@@ -1101,6 +1120,8 @@ class Room {
                   unsigned: {
                     messageSendingStatusKey: EventStatus.sending.intValue,
                     'transaction_id': messageID,
+                    if (attachedMediaIds != null)
+                      'attached_media_ids': attachedMediaIds,
                   },
                 ),
               ],
@@ -1129,6 +1150,7 @@ class Room {
           type,
           content,
           txid: messageID,
+          attachedMediaIds: attachedMediaIds,
         );
       } catch (e, s) {
         if (e is MatrixException &&
@@ -1997,14 +2019,27 @@ class Room {
     final uploadResp = file == null
         ? null
         : await client.uploadContent(file.bytes, filename: file.name);
-    return await client.setRoomStateWithKey(
-      id,
-      EventTypes.RoomAvatar,
-      '',
-      {
-        if (uploadResp != null) 'url': uploadResp.toString(),
-      },
-    );
+
+    final isRestrictedMediaSupported = await client.restrictedMediaSupported();
+
+    return isRestrictedMediaSupported
+        ? await client.setRestrictedMediaRoomStateWithKey(
+            id,
+            EventTypes.RoomAvatar,
+            '',
+            [if (uploadResp != null) uploadResp.toString()],
+            {
+              if (uploadResp != null) 'url': uploadResp.toString(),
+            },
+          )
+        : await client.setRoomStateWithKey(
+            id,
+            EventTypes.RoomAvatar,
+            '',
+            {
+              if (uploadResp != null) 'url': uploadResp.toString(),
+            },
+          );
   }
 
   /// The level required to ban a user.

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -664,7 +664,7 @@ class Room {
         convertLinebreaks: client.convertLinebreaksInFormatting,
         restrictedMediaSupported: await client.restrictedMediaSupported(),
         copyMedia: (String mediaUri) async {
-          final [server, mediaId] = Uri.parse(mediaUri).pathSegments;
+          final (:server, :mediaId) = Uri.parse(mediaUri).mxcParts;
           final newUri =
               (await client.copyRestrictedContent(server, mediaId)).toString();
           attachedMediaIds.add(newUri);

--- a/lib/src/utils/uri_extension.dart
+++ b/lib/src/utils/uri_extension.dart
@@ -21,6 +21,11 @@ import 'dart:core';
 import 'package:matrix/src/client.dart';
 
 extension MxcUriExtension on Uri {
+  ({String server, String mediaId}) get mxcParts => (
+        server: '$host${hasPort ? ':$port' : ''}',
+        mediaId: path.replaceFirst('/', ''),
+      );
+
   /// Transforms this `mxc://` Uri into a `http` resource, which can be used
   /// to download the content.
   ///

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -41,172 +41,175 @@ void main() {
       '@[">]': '@blah:example.org',
     };
     String? getMention(mention) => mentionMap[mention];
-    test('simple markdown', () {
+    test('simple markdown', () async {
       expect(
-        markdown('hey *there* how are **you** doing?'),
+        await markdown('hey *there* how are **you** doing?'),
         'hey <em>there</em> how are <strong>you</strong> doing?',
       );
-      expect(markdown('wha ~~strike~~ works!'), 'wha <del>strike</del> works!');
-    });
-    test('spoilers', () {
       expect(
-        markdown('Snape killed ||Dumbledoor||'),
+        await markdown('wha ~~strike~~ works!'),
+        'wha <del>strike</del> works!',
+      );
+    });
+    test('spoilers', () async {
+      expect(
+        await markdown('Snape killed ||Dumbledoor||'),
         'Snape killed <span data-mx-spoiler="">Dumbledoor</span>',
       );
       expect(
-        markdown('Snape killed ||Story|Dumbledoor||'),
+        await markdown('Snape killed ||Story|Dumbledoor||'),
         'Snape killed <span data-mx-spoiler="Story">Dumbledoor</span>',
       );
       expect(
-        markdown('Snape killed ||Some dumb loser|Dumbledoor||'),
+        await markdown('Snape killed ||Some dumb loser|Dumbledoor||'),
         'Snape killed <span data-mx-spoiler="Some dumb loser">Dumbledoor</span>',
       );
       expect(
-        markdown('Snape killed ||Some dumb loser|Dumbledoor **bold**||'),
+        await markdown('Snape killed ||Some dumb loser|Dumbledoor **bold**||'),
         'Snape killed <span data-mx-spoiler="Some dumb loser">Dumbledoor <strong>bold</strong></span>',
       );
       expect(
-        markdown('Snape killed ||Dumbledoor **bold**||'),
+        await markdown('Snape killed ||Dumbledoor **bold**||'),
         'Snape killed <span data-mx-spoiler="">Dumbledoor <strong>bold</strong></span>',
       );
     });
-    test('linebreaks', () {
-      expect(markdown('Heya!\nBeep'), 'Heya!<br/>Beep');
-      expect(markdown('Heya!\n\nBeep'), '<p>Heya!</p><p>Beep</p>');
-      expect(markdown('Heya!\n\n\nBeep'), '<p>Heya!</p><p><br/>Beep</p>');
+    test('linebreaks', () async {
+      expect(await markdown('Heya!\nBeep'), 'Heya!<br/>Beep');
+      expect(await markdown('Heya!\n\nBeep'), '<p>Heya!</p><p>Beep</p>');
+      expect(await markdown('Heya!\n\n\nBeep'), '<p>Heya!</p><p><br/>Beep</p>');
       expect(
-        markdown('Heya!\n\n\n\nBeep'),
+        await markdown('Heya!\n\n\n\nBeep'),
         '<p>Heya!</p><p><br/><br/>Beep</p>',
       );
       expect(
-        markdown('Heya!\n\n\n\nBeep\n\n'),
+        await markdown('Heya!\n\n\n\nBeep\n\n'),
         '<p>Heya!</p><p><br/><br/>Beep</p>',
       );
       expect(
-        markdown('\n\nHeya!\n\n\n\nBeep'),
+        await markdown('\n\nHeya!\n\n\n\nBeep'),
         '<p>Heya!</p><p><br/><br/>Beep</p>',
       );
       expect(
-        markdown('\n\nHeya!\n\n\n\nBeep\n '),
+        await markdown('\n\nHeya!\n\n\n\nBeep\n '),
         '<p>Heya!</p><p><br/><br/>Beep</p>',
       );
     });
-    test('Other block elements', () {
-      expect(markdown('# blah\n\nblubb'), '<h1>blah</h1><p>blubb</p>');
+    test('Other block elements', () async {
+      expect(await markdown('# blah\n\nblubb'), '<h1>blah</h1><p>blubb</p>');
     });
-    test('lists', () {
+    test('lists', () async {
       expect(
-        markdown('So we have:\n- foxies\n- cats\n- dogs'),
+        await markdown('So we have:\n- foxies\n- cats\n- dogs'),
         '<p>So we have:</p><ul><li>foxies</li><li>cats</li><li>dogs</li></ul>',
       );
     });
-    test('emotes', () {
+    test('emotes', () async {
       expect(
-        markdown(':fox:', getEmotePacks: () => emotePacks),
+        await markdown(':fox:', getEmotePacks: () => emotePacks),
         '<img data-mx-emoticon="" src="mxc://roomfox" alt=":fox:" title=":fox:" height="32" vertical-align="middle" />',
       );
       expect(
-        markdown(':user~fox:', getEmotePacks: () => emotePacks),
+        await markdown(':user~fox:', getEmotePacks: () => emotePacks),
         '<img data-mx-emoticon="" src="mxc://userfox" alt=":fox:" title=":fox:" height="32" vertical-align="middle" />',
       );
       expect(
-        markdown(':raccoon:', getEmotePacks: () => emotePacks),
+        await markdown(':raccoon:', getEmotePacks: () => emotePacks),
         '<img data-mx-emoticon="" src="mxc://raccoon" alt=":raccoon:" title=":raccoon:" height="32" vertical-align="middle" />',
       );
       expect(
-        markdown(':invalid:', getEmotePacks: () => emotePacks),
+        await markdown(':invalid:', getEmotePacks: () => emotePacks),
         ':invalid:',
       );
       expect(
-        markdown(':invalid:?!', getEmotePacks: () => emotePacks),
+        await markdown(':invalid:?!', getEmotePacks: () => emotePacks),
         ':invalid:?!',
       );
       expect(
-        markdown(':room~invalid:', getEmotePacks: () => emotePacks),
+        await markdown(':room~invalid:', getEmotePacks: () => emotePacks),
         ':room~invalid:',
       );
     });
-    test('pills', () {
+    test('pills', () async {
       expect(
-        markdown('Hey @sorunome:sorunome.de!'),
+        await markdown('Hey @sorunome:sorunome.de!'),
         'Hey <a href="https://matrix.to/#/@sorunome:sorunome.de">@sorunome:sorunome.de</a>!',
       );
       expect(
-        markdown('#fox:sorunome.de: you all are awesome'),
+        await markdown('#fox:sorunome.de: you all are awesome'),
         '<a href="https://matrix.to/#/#fox:sorunome.de">#fox:sorunome.de</a>: you all are awesome',
       );
       expect(
-        markdown('!blah:example.org'),
+        await markdown('!blah:example.org'),
         '<a href="https://matrix.to/#/!blah:example.org">!blah:example.org</a>',
       );
       expect(
-        markdown('https://matrix.to/#/#fox:sorunome.de'),
+        await markdown('https://matrix.to/#/#fox:sorunome.de'),
         '<a href="https://matrix.to/#/#fox:sorunome.de">https://matrix.to/#/#fox:sorunome.de</a>',
       );
       expect(
-        markdown('Hey @sorunome:sorunome.de:1234!'),
+        await markdown('Hey @sorunome:sorunome.de:1234!'),
         'Hey <a href="https://matrix.to/#/@sorunome:sorunome.de:1234">@sorunome:sorunome.de:1234</a>!',
       );
       expect(
-        markdown('Hey @sorunome:127.0.0.1!'),
+        await markdown('Hey @sorunome:127.0.0.1!'),
         'Hey <a href="https://matrix.to/#/@sorunome:127.0.0.1">@sorunome:127.0.0.1</a>!',
       );
       expect(
-        markdown('Hey @sorunome:[::1]!'),
+        await markdown('Hey @sorunome:[::1]!'),
         'Hey <a href="https://matrix.to/#/@sorunome:[::1]">@sorunome:[::1]</a>!',
       );
     });
-    test('mentions', () {
+    test('mentions', () async {
       expect(
-        markdown('Hey @Bob!', getMention: getMention),
+        await markdown('Hey @Bob!', getMention: getMention),
         'Hey <a href="https://matrix.to/#/@bob:example.org">@Bob</a>!',
       );
       expect(
-        markdown('How is @[Bob Ross] doing?', getMention: getMention),
+        await markdown('How is @[Bob Ross] doing?', getMention: getMention),
         'How is <a href="https://matrix.to/#/@bobross:example.org">@[Bob Ross]</a> doing?',
       );
       expect(
-        markdown('Hey @invalid!', getMention: getMention),
+        await markdown('Hey @invalid!', getMention: getMention),
         'Hey @invalid!',
       );
       expect(
-        markdown('Hey @Fox#123!', getMention: getMention),
+        await markdown('Hey @Fox#123!', getMention: getMention),
         'Hey <a href="https://matrix.to/#/@fox:example.org">@Fox#123</a>!',
       );
       expect(
-        markdown('Hey @[Fast Fox]#123!', getMention: getMention),
+        await markdown('Hey @[Fast Fox]#123!', getMention: getMention),
         'Hey <a href="https://matrix.to/#/@fastfox:example.org">@[Fast Fox]#123</a>!',
       );
       expect(
-        markdown('Hey @[">]!', getMention: getMention),
+        await markdown('Hey @[">]!', getMention: getMention),
         'Hey <a href="https://matrix.to/#/@blah:example.org">@[&quot;&gt;]</a>!',
       );
     });
-    test('latex', () {
+    test('latex', () async {
       expect(
-        markdown('meep \$\\frac{2}{3}\$'),
+        await markdown('meep \$\\frac{2}{3}\$'),
         'meep <span data-mx-maths="\\frac{2}{3}"><code>\\frac{2}{3}</code></span>',
       );
       expect(
-        markdown('meep \$hmm *yay*\$'),
+        await markdown('meep \$hmm *yay*\$'),
         'meep <span data-mx-maths="hmm *yay*"><code>hmm *yay*</code></span>',
       );
       expect(
-        markdown('you have \$somevar and \$someothervar'),
+        await markdown('you have \$somevar and \$someothervar'),
         'you have \$somevar and \$someothervar',
       );
       expect(
-        markdown('meep ||\$\\frac{2}{3}\$||'),
+        await markdown('meep ||\$\\frac{2}{3}\$||'),
         'meep <span data-mx-spoiler=""><span data-mx-maths="\\frac{2}{3}"><code>\\frac{2}{3}</code></span></span>',
       );
       expect(
-        markdown('meep `\$\\frac{2}{3}\$`'),
+        await markdown('meep `\$\\frac{2}{3}\$`'),
         'meep <code>\$\\frac{2}{3}\$</code>',
       );
     });
-    test('Code blocks', () {
+    test('Code blocks', () async {
       expect(
-        markdown(
+        await markdown(
           '```dart\nvoid main(){\nprint(something);\n}\n```',
           convertLinebreaks: true,
         ),
@@ -214,16 +217,16 @@ void main() {
       );
 
       expect(
-        markdown(
+        await markdown(
           'The first \n codeblock\n```dart\nvoid main(){\nprint(something);\n}\n```\nAnd the second code block\n```js\nmeow\nmeow\n```',
           convertLinebreaks: true,
         ),
         '<p>The first<br/>codeblock</p><pre><code class="language-dart">void main(){\nprint(something);\n}\n</code></pre><p>And the second code block</p><pre><code class="language-js">meow\nmeow\n</code></pre>',
       );
     });
-    test('Checkboxes', () {
+    test('Checkboxes', () async {
       expect(
-        markdown(
+        await markdown(
           '- [ ] Check 1\n- [x] Check 2\n- Normal list item',
           convertLinebreaks: true,
         ),


### PR DESCRIPTION
This implements uploading restricted media (but not the create media async uploads, since they are not used by the SDK currently).

Additionally this implements using restricted media for setting the room avatar and sending media message.

Currently missing are:
- Attaching media on reactions and editing messages with inline media.

When forwarding events, these should be passed through `Event.copyMediaInContent`. Otherwise no changes to clients should be needed.