### PR TITLE
add to space - m.space.parent error handling

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -2492,9 +2492,17 @@ class Room {
       if (order != null) 'order': order,
       if (suggested != null) 'suggested': suggested,
     });
-    await client.setRoomStateWithKey(roomId, EventTypes.SpaceParent, id, {
-      'via': via,
-    });
+    try {
+      await client.setRoomStateWithKey(roomId, EventTypes.SpaceParent, id, {
+        'via': via,
+      });
+    } catch (e) {
+      if (e is MatrixException && e.error == MatrixError.M_FORBIDDEN) {
+        Logs().i('Added room to space. Could not set parent event in room.');
+        return;
+      }
+      rethrow;
+    }
     return;
   }
 


### PR DESCRIPTION
Adding a log line instead of throwing an error when trying to add a space parent, since adding the child was successful that should be enough