### PR TITLE
feat: Add deleteDeviceDisplayName() method to matrix API

### DIFF
--- a/lib/matrix_api_lite/matrix_api.dart
+++ b/lib/matrix_api_lite/matrix_api.dart
@@ -184,6 +184,17 @@ class MatrixApi extends Api {
     return;
   }
 
+  /// Variant of updateDevice operation that deletes the device displayname by
+  /// setting `display_name: null`.
+  Future<void> deleteDeviceDisplayName(String deviceId) async {
+    await request(
+      RequestType.PUT,
+      '/client/v3/devices/${Uri.encodeComponent(deviceId)}',
+      data: {'display_name': null},
+    );
+    return;
+  }
+
   /// This API provides credentials for the client to use when initiating
   /// calls.
   @override


### PR DESCRIPTION
Closes https://github.com/famedly/matrix-dart-sdk/issues/2034

We had the same problem with the set push kind to `null` method so I just used the same way to fix it.