### PR TITLE
feat: Add onProgress for upload and download methods

### DIFF
--- a/lib/src/utils/multipart_request_progress.dart
+++ b/lib/src/utils/multipart_request_progress.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+class MultipartRequest extends http.MultipartRequest {
+  MultipartRequest(
+    super.method,
+    super.url, {
+    this.onProgress,
+  });
+
+  final void Function(int bytes)? onProgress;
+
+  @override
+  http.ByteStream finalize() {
+    final byteStream = super.finalize();
+    if (onProgress == null) return byteStream;
+
+    final total = contentLength;
+    int bytes = 0;
+
+    final t = StreamTransformer.fromHandlers(
+      handleData: (List<int> data, EventSink<List<int>> sink) {
+        bytes += data.length;
+        onProgress?.call(bytes);
+        if (total >= bytes) {
+          sink.add(data);
+        }
+      },
+    );
+    final stream = byteStream.transform(t);
+    return http.ByteStream(stream);
+  }
+}
+
+extension ToBytesWithProgress on http.ByteStream {
+  /// Collects the data of this stream in a [Uint8List].
+  Future<Uint8List> toBytesWithProgress(void Function(int)? onProgress) {
+    var length = 0;
+    final completer = Completer<Uint8List>();
+    final sink = ByteConversionSink.withCallback(
+      (bytes) => completer.complete(Uint8List.fromList(bytes)),
+    );
+    listen(
+      (bytes) {
+        sink.add(bytes);
+        onProgress?.call(length += bytes.length);
+      },
+      onError: completer.completeError,
+      onDone: sink.close,
+      cancelOnError: true,
+    );
+    return completer.future;
+  }
+}

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1488,13 +1488,18 @@ void main() {
     });
     test('upload', () async {
       final client = await getClient();
-      final response =
-          await client.uploadContent(Uint8List(0), filename: 'file.jpeg');
+      final onProgressMap = <int>[];
+      final response = await client.uploadContent(
+        Uint8List(0),
+        filename: 'file.jpeg',
+        onProgress: onProgressMap.add,
+      );
       expect(response.toString(), 'mxc://example.com/AQwafuaFswefuhsfAFAgsw');
       expect(
         await client.database.getFile(response) != null,
         client.database.supportsFileStoring,
       );
+      expect(onProgressMap, [74, 183, 183, 185, 261]);
       await client.dispose(closeDatabase: true);
     });
 

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -2485,6 +2485,30 @@ void main() async {
         await room.client.dispose(closeDatabase: true);
       },
     );
+
+    test('downloadAndDecryptAttachment from server', () async {
+      final client = await getClient();
+      final event = Event(
+        room: client.rooms.first,
+        eventId: 'test',
+        originServerTs: DateTime.now(),
+        senderId: client.userID!,
+        content: {
+          'body': 'ascii.txt',
+          'filename': 'ascii.txt',
+          'info': {'mimetype': 'application/msword', 'size': 6},
+          'msgtype': 'm.file',
+          'url': 'mxc://example.org/abcd1234ascii',
+        },
+        type: EventTypes.Message,
+      );
+      final progressList = <int>[];
+      await event.downloadAndDecryptAttachment(
+        onDownloadProgress: progressList.add,
+      );
+      await client.dispose();
+      expect(progressList, [112]);
+    });
     test('downloadAndDecryptAttachment store', tags: 'olm', () async {
       final FILE_BUFF = Uint8List.fromList([0]);
       var serverHits = 0;


### PR DESCRIPTION
Closes https://github.com/famedly/matrix-dart-sdk/issues/290

Tested with FluffyChat. I was able to display progress of uploading and downloading files.