### PR TITLE
fix: Remove avatar crashes with invalid uri

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1614,7 +1614,7 @@ class Client extends MatrixApi {
       await setProfileField(
         userID!,
         'avatar_url',
-        {'avatar_url': Uri.parse('')},
+        {'avatar_url': ''},
       );
       return;
     }


### PR DESCRIPTION
We should send an empty string
there as the comment mentions.
Uri.parse around it was just a
typo.