### PR TITLE
refactor: Escape HTML tags before markdown rendering

### DIFF
--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -212,7 +212,13 @@ String markdown(
   bool convertLinebreaks = true,
 }) {
   var ret = markdownToHtml(
-    text.replaceNewlines(),
+    text
+        .replaceAllMapped(
+          // Replace HTML tags
+          RegExp(r'<([^>]*)>'),
+          (match) => '&lt;${match.group(1)}&gt;',
+        )
+        .replaceNewlines(),
     extensionSet: ExtensionSet.gitHubFlavored,
     blockSyntaxes: [
       BlockLatexSyntax(),

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -220,6 +220,10 @@ void main() {
         ),
         '<p>The first<br/>codeblock</p><pre><code class="language-dart">void main(){\nprint(something);\n}\n</code></pre><p>And the second code block</p><pre><code class="language-js">meow\nmeow\n</code></pre>',
       );
+      expect(
+        markdown('Test <m> *unescaped*'),
+        'Test &lt;m&gt; <em>unescaped</em>',
+      );
     });
     test('Checkboxes', () {
       expect(


### PR DESCRIPTION
Closes https://github.com/famedly/product-management/issues/3446