### PR TITLE
fix: Replies in threads

### DIFF
--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -79,7 +79,7 @@ void main() async {
       expect(event.formattedText, formatted_body);
       expect(event.body, body);
       expect(event.type, EventTypes.Message);
-      expect(event.relationshipType, RelationshipTypes.reply);
+      expect(event.inReplyToEventId(), '\$1234:example.com');
       jsonObj['state_key'] = '';
       final state = Event.fromJson(jsonObj, room);
       expect(state.eventId, id);
@@ -178,8 +178,8 @@ void main() async {
       };
       event = Event.fromJson(jsonObj, room);
       expect(event.messageType, MessageTypes.Text);
-      expect(event.relationshipType, RelationshipTypes.reply);
-      expect(event.relationshipEventId, '1234');
+      expect(event.inReplyToEventId(), '1234');
+      expect(event.relationshipEventId, null);
     });
 
     test('relationship types', () async {
@@ -212,8 +212,22 @@ void main() async {
         },
       };
       event = Event.fromJson(jsonObj, room);
-      expect(event.relationshipType, RelationshipTypes.reply);
-      expect(event.relationshipEventId, 'def');
+      expect(event.inReplyToEventId(), 'def');
+      expect(event.relationshipEventId, null);
+
+      jsonObj['content']['m.relates_to'] = {
+        'rel_type': 'm.thread',
+        'event_id': '\$root',
+        'm.in_reply_to': {
+          'event_id': '\$target',
+        },
+        'is_falling_back': true,
+      };
+      event = Event.fromJson(jsonObj, room);
+      expect(event.relationshipType, RelationshipTypes.thread);
+      expect(event.inReplyToEventId(), '\$target');
+      expect(event.inReplyToEventId(includingFallback: false), null);
+      expect(event.relationshipEventId, '\$root');
     });
 
     test('redact', () async {


### PR DESCRIPTION
This fixes the situation that an event can be
a reply and in a thread. Before we have seen reply
as an relationshipType but this does conflict with
the concept of threads, where an event can be
of relationship type "thread" but also be a reply
with being a fallback or not.

## Some thoughts:

We have `Event.getReplyEvent()` and `Event.relationshipType`. And there are three different cases:

1. Normal replies
2. Thread events with reply fallback (`is_falling_back = true`)
3. Reply in a thread (`is_falling_back = false`)

##### Expected return for `Event.relationshipType`:
1. `RelationshipType.reply`
2. `RelationshipType.thread`
3. What should this be? Actually it is both. So maybe we should remove `RelationshipType.reply` and replace it with a `Event.isReply`

We should remove the `RelationshipType.reply` which is actually not a relationshiptype according to the matrix spec. Instead we should add a new getter `Event.inReplyToEventId({bool includingFallback = true})` where we can also say if we want to include fallbacks or not.