### PR TITLE
feat: New searchEvents method in room

### DIFF
--- a/lib/src/timeline.dart
+++ b/lib/src/timeline.dart
@@ -610,7 +610,7 @@ class Timeline {
     }
   }
 
-  @Deprecated('Use [startSearch] instead.')
+  @Deprecated('Use [Room.searchEvent] instead.')
   Stream<List<Event>> searchEvent({
     String? searchTerm,
     int requestHistoryCount = 100,
@@ -637,6 +637,7 @@ class Timeline {
   /// ignore [searchTerm].
   /// Returns the List of Events and the next prevBatch at the end of the
   /// search.
+  @Deprecated('Use [Room.searchEvent] instead.')
   Stream<(List<Event>, String?)> startSearch({
     String? searchTerm,
     int requestHistoryCount = 100,

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -1845,6 +1845,108 @@ void main() {
       );
     });
 
+    test('searchEvents', () async {
+      FakeMatrixApi.currentApi!.api['GET']![
+              '/client/v3/rooms/!localpart%3Aserver.abc/messages?from&dir=b&limit=1000&filter=%7B%22types%22%3A%5B%22m.room.message%22%2C%22m.room.encrypted%22%5D%7D'] =
+          (_) => {
+                'chunk': [
+                  {
+                    'content': {
+                      'body': 'This is an example text message',
+                      'format': 'org.matrix.custom.html',
+                      'formatted_body':
+                          '<b>This is an example text message</b>',
+                      'msgtype': 'm.text',
+                    },
+                    'event_id': '\$history1',
+                    'origin_server_ts': 1432735824653,
+                    'room_id': '!636q39766251:example.com',
+                    'sender': '@example:example.org',
+                    'type': 'm.room.message',
+                    'unsigned': {
+                      'age': 1234,
+                      'membership': 'join',
+                    },
+                  },
+                  {
+                    'content': {
+                      'name': 'The room name',
+                    },
+                    'event_id': '\$history2',
+                    'origin_server_ts': 1432735824653,
+                    'room_id': '!636q39766251:example.com',
+                    'sender': '@example:example.org',
+                    'state_key': '',
+                    'type': 'm.room.name',
+                    'unsigned': {
+                      'age': 1234,
+                      'membership': 'join',
+                    },
+                  },
+                  {
+                    'content': {
+                      'body': 'Gangnam Style',
+                      'info': {
+                        'duration': 2140786,
+                        'h': 320,
+                        'mimetype': 'video/mp4',
+                        'size': 1563685,
+                        'thumbnail_info': {
+                          'h': 300,
+                          'mimetype': 'image/jpeg',
+                          'size': 46144,
+                          'w': 300,
+                        },
+                        'thumbnail_url':
+                            'mxc://example.org/FHyPlCeYUSFFxlgbQYZmoEoe',
+                        'w': 480,
+                      },
+                      'msgtype': 'm.video',
+                      'url': 'mxc://example.org/a526eYUSFFxlgbQYZmo442',
+                    },
+                    'event_id': '\$history3',
+                    'origin_server_ts': 1432735824653,
+                    'room_id': '!636q39766251:example.com',
+                    'sender': '@example:example.org',
+                    'type': 'm.room.message',
+                    'unsigned': {
+                      'age': 1234,
+                      'membership': 'join',
+                    },
+                  }
+                ],
+                'end': 't47409-4357353_219380_26003_2265',
+                'start': 't47429-4392820_219380_26003_2265',
+              };
+      final searchResult = await room.searchEvents(searchFunc: (_) => true);
+      expect(searchResult.events.length, 18);
+      expect(searchResult.nextBatch, 't47409-4357353_219380_26003_2265');
+      expect(searchResult.searchedUntil!.millisecondsSinceEpoch, 1432735824653);
+      expect(
+        searchResult.events.any(
+          (event1) => searchResult.events.any(
+            (event2) => event1 != event2 && event1.eventId == event2.eventId,
+          ),
+        ),
+        false,
+        reason: 'No events are duplicated',
+      );
+
+      FakeMatrixApi.currentApi!.api['GET']![
+              '/client/v3/rooms/!localpart%3Aserver.abc/messages?from=t47409-4357353_219380_26003_2265&dir=b&limit=1000&filter=%7B%22types%22%3A%5B%22m.room.message%22%2C%22m.room.encrypted%22%5D%7D'] =
+          (_) => {
+                'start': 't47409-4357353_219380_26003_2265',
+                'chunk': [],
+              };
+      final secondResult = await room.searchEvents(
+        searchFunc: (_) => true,
+        nextBatch: searchResult.nextBatch,
+      );
+      expect(secondResult.events.isEmpty, true);
+      expect(secondResult.searchedUntil, null);
+      expect(secondResult.nextBatch, null);
+    });
+
     test('logout', () async {
       await matrix.logout();
     });


### PR DESCRIPTION

So this tries a new approach for searching events in encrypted rooms. Searching events in encrypted rooms is hard. We actually need to download the whole timeline. Instead of a stream we now try a simpler API where we just have a Future which returns the found events, plus a next batch and a DateTime of until we have investigated the room timeline. This leads to a user experience like this:

https://github.com/user-attachments/assets/1c378969-06be-4544-b0fb-389012ca1db0

This fixes that:

- [x] Sometimes events are duplicated in the search
- [x] Events remain in memory and after a longer search the app gets laggy
- [x] When we perform a longer search without a result we still get user feedback
