### PR TITLE
refactor: Add option to always call auth metadata

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -1188,6 +1188,20 @@ class FakeMatrixApi extends BaseClient {
             'errcode': 'M_FORBIDDEN',
             'error': 'Blabla',
           },
+      '/client/v1/auth_metadata': (var req) => {
+            'authorization_endpoint':
+                'https://fakeserver.notexisting/oauth2/auth',
+            'code_challenge_methods_supported': ['S256'],
+            'grant_types_supported': ['authorization_code', 'refresh_token'],
+            'issuer': 'https://fakeserver.notexisting/',
+            'registration_endpoint':
+                'https://fakeserver.notexisting/oauth2/clients/register',
+            'response_modes_supported': ['query', 'fragment'],
+            'response_types_supported': ['code'],
+            'revocation_endpoint':
+                'https://fakeserver.notexisting/oauth2/revoke',
+            'token_endpoint': 'https://fakeserver.notexisting/oauth2/token',
+          },
       '/media/v3/preview_url?url=https%3A%2F%2Fmatrix.org&ts=10': (var req) => {
             'og:title': 'Matrix Blog Post',
             'og:description': 'This is a really cool blog post from matrix.org',

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -519,6 +519,13 @@ class Client extends MatrixApi {
       )> checkHomeserver(
     Uri homeserverUrl, {
     bool checkWellKnown = true,
+
+    /// Weither this method should also call `/auth_metadata` to fetch
+    /// Matrix native OIDC information. Defaults to if the `/versions` endpoint
+    /// returns version v1.15 or higher. Set to `true` to always call the
+    /// endpoint if your homeserver supports the endpoint while not fully
+    /// supporting version v1.15 yet.
+    bool? fetchAuthMetadata,
     Set<String>? overrideSupportedVersions,
   }) async {
     final supportedVersions =
@@ -555,10 +562,11 @@ class Client extends MatrixApi {
         );
       }
 
+      fetchAuthMetadata ??= versions.versions.any(
+        (v) => isVersionGreaterThanOrEqualTo(v, 'v1.15'),
+      );
       GetAuthMetadataResponse? authMetadata;
-      if (versions.versions.any(
-        (v) => isVersionGreaterThanOrEqualTo(v, 'v1.16'),
-      )) {
+      if (fetchAuthMetadata) {
         try {
           authMetadata = await getAuthMetadata();
         } on MatrixException catch (e, s) {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -531,9 +531,14 @@ void main() {
         database: await getDatabase(),
       );
 
-      await matrix.checkHomeserver(
+      final (_, _, _, authMetadata) = await matrix.checkHomeserver(
         Uri.parse('https://fakeserver.notexisting'),
         checkWellKnown: false,
+        fetchAuthMetadata: true,
+      );
+      expect(
+        authMetadata?.issuer.toString(),
+        'https://fakeserver.notexisting/',
       );
 
       final loginResp = await matrix.login(


### PR DESCRIPTION
This also makes sure we call
on v1.15 as there the endpoint
was actually introduced.
Also adds a unit test.