### PR TITLE
feat: Allow init with access token

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -1352,7 +1352,7 @@ class FakeMatrixApi extends BaseClient {
             },
           },
       '/client/v3/account/whoami': (var req) =>
-          {'user_id': 'alice@example.com'},
+          {'user_id': 'alice@example.com', 'device_id': 'ABCDEFGH'},
       '/client/v3/capabilities': (var req) => {
             'capabilities': {
               'm.change_password': {'enabled': false},

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -524,6 +524,22 @@ void main() {
       FakeMatrixApi.currentApi?.api = oldapi!;
     });
 
+    test('init() with access token', () async {
+      final client = Client(
+        'testclient',
+        httpClient: FakeMatrixApi(),
+        database: await getDatabase(),
+      );
+      await client.init(
+        newToken: 'abcd1234',
+        newHomeserver: Uri.parse('https://fakeserver.notexisting'),
+      );
+      expect(client.isLogged(), true);
+      expect(client.userID, 'alice@example.com');
+      expect(client.deviceID, 'ABCDEFGH');
+      await client.dispose();
+    });
+
     test('Login', () async {
       matrix = Client(
         'testclient',


### PR DESCRIPTION
Makes it possible to just init
with an access token and a
homeserver uri and the init()
method would just call /whoami
to fetch the missing data.
Makes it easier to login with
Matrix native OIDC