### PR TITLE
Implement MSC3861 Matrix Native OIDC

### DIFF
--- a/doc/oidc-login.md
+++ b/doc/oidc-login.md
@@ -1,0 +1,72 @@
+Follow these steps to login with Matrix native OIDC. Your app must be
+capable of opening a website (e.g. in an in-app-browser or for web clients in a new tab)
+and retrieve a redirect URI. We recommend investigating into a package
+like [flutter_web_auth_2](https://pub.dev/packages/flutter_web_auth_2) for
+this task.
+
+> Disclaimer: Support is still in a MSC and therefore considered as beta.
+
+### Step 1: Fetch the auth metadata
+
+You first need to fetch the auth metadata from a given homeserver. The
+homeserver must support the `/auth_metadata` endpoint which was introduced
+in the Matrix Spec 1.15:
+
+```dart
+final (_,_,_,authMetadata) = await client.checkHomserver(Uri.https('matrix.org'));
+```
+
+### Step 2: Dynamic Client registration
+
+You need to register an OIDC client first. There you can specify some
+metadata about your client:
+
+```dart
+final oidcClientData = await client.registerOidcClient(
+    redirectUris: [Uri.parse('http://localhost:123456')],
+    applicationType: OidcApplicationType.native,
+    clientInformation: OidcClientInformation(clientUri: Uri.https('my-client-website.com')),
+);
+```
+
+### Step 3: Create a new OIDC Login session
+
+This prepares the code verifier and state.
+
+```dart
+final session = await client.initOidcLoginSession(
+    oidcClientData: oidcClientData,
+    redirectUri: Uri.parse('http://localhost:123456'),
+);
+```
+
+### Step 4: Open a browser in your app and get the code returned
+
+If you are using Flutter you can use a package like [flutter_web_auth_2](https://pub.dev/packages/flutter_web_auth_2):
+
+```dart
+final returnUrlString = await FlutterWebAuth2.authenticate(
+    url: session.authenticationUri.toString(),
+);
+
+final returnUrl = Uri.parse(returnUrlString);
+
+final queryParameters = returnUrl.hasFragment
+    ? Uri.parse(returnUrl.fragment).queryParameters
+    : returnUrl.queryParameters;
+
+final code = queryParameters['code'] as String;
+final state = queryParameters['state'] as String;
+```
+
+### Step 5: Login with OIDC
+
+Now that you have the `code` you can just login:
+
+```dart
+await client.oidcLogin(
+    session: session,
+    code: code,
+    state: state,
+);
+```

--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -135,6 +135,10 @@ class FakeMatrixApi extends BaseClient {
       );
     }
 
+    if ({'/oauth2/clients/register'}.contains(action)) {
+      statusCode = 201;
+    }
+
     if (!{
           '/client/v3/refresh',
           '/client/v3/login',
@@ -1821,7 +1825,7 @@ class FakeMatrixApi extends BaseClient {
       '/client/v3/rooms/!5345234234%3Aexample.com/messages?from=t_1234a&dir=b&limit=30&filter=%7B%22lazy_load_members%22%3Atrue%7D':
           (var req) => archivesMessageResponse,
       '/client/versions': (var req) => {
-            'versions': ['v1.1', 'v1.2', 'v1.11'],
+            'versions': ['v1.1', 'v1.2', 'v1.11', 'v1.15'],
             'unstable_features': {'m.lazy_load_members': true},
           },
       '/client/v3/login': (var req) => {
@@ -2214,6 +2218,30 @@ class FakeMatrixApi extends BaseClient {
           },
     },
     'POST': {
+      '/oauth2/token': (var req) => {
+            'access_token': '2YotnFZFEjr1zCsicMWpAA',
+            'token_type': 'Bearer',
+            'expires_in': 299,
+            'refresh_token': 'tGz3JOkF0XG5Qx2TlKWIA',
+            'scope':
+                'urn:matrix:client:api:* urn:matrix:client:device:AAABBBCCCDDD',
+          },
+      '/oauth2/clients/register': (var req) {
+        final jsonReq = jsonDecode(req);
+        return {
+          'client_id': '1234',
+          'client_name': jsonReq['client_name'],
+          'client_uri': jsonReq['client_uri'],
+          'logo_uri': jsonReq['logo_uri'],
+          'tos_uri': jsonReq['tos_uri'],
+          'policy_uri': jsonReq['policy_uri'],
+          'redirect_uris': jsonReq['redirect_uris'],
+          'token_endpoint_auth_method': jsonReq['token_endpoint_auth_method'],
+          'response_types': jsonReq['code'],
+          'grant_types': jsonReq['grant_types'],
+          'application_type': jsonReq['web'],
+        };
+      },
       '/client/v3/refresh': (var req) => {
             'access_token': 'a_new_token',
             'expires_in_ms': 1000 * 60 * 5,

--- a/lib/matrix.dart
+++ b/lib/matrix.dart
@@ -85,6 +85,8 @@ export 'msc_extensions/msc_4140_delayed_events/api.dart';
 export 'msc_extensions/msc_3381_polls/models/poll_event_content.dart';
 export 'msc_extensions/msc_3381_polls/poll_event_extension.dart';
 export 'msc_extensions/msc_3381_polls/poll_room_extension.dart';
+export 'msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart';
+export 'msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart';
 
 export 'src/utils/web_worker/web_worker_stub.dart'
     if (dart.library.js_interop) 'src/utils/web_worker/web_worker.dart';

--- a/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
+++ b/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:vodozemac/vodozemac.dart' as vod;
+
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/crypto/crypto.dart';
+
+extension Msc2964OidcLoginFlow on Client {
+  /// Initializes a new OIDC Login session by creating a state, a code verifier
+  /// and an authorization URI.
+  /// It needs an already created OIDC Client from `Client.registerOidcClient()`
+  /// and the `authMetadata` from `Client.checkHomeserver()`.
+  /// Use the authorization URI to open it in browser and fetch `code` and
+  /// `state` from the query parameters of the redirect URI to login with
+  /// `Client.oidcLogin()`.
+  Future<OidcLoginSession> initOidcLoginSession({
+    required OidcClientData oidcClientData,
+    required Uri redirectUri,
+    String? deviceId,
+    Set<String>? scopes,
+    int codeVerifierBytesLength = 32,
+    OidcResponseMode? responseMode,
+    String? prompt,
+  }) async {
+    final authMetadata = await getAuthMetadata();
+    deviceId ??= generateRandomDeviceId();
+    scopes ??= {
+      'openid',
+      //'urn:matrix:client:api:*',
+      //'urn:matrix:device:$deviceId',
+      // For some reason MAS crashes when not using the msc prefixed scopes:
+      'urn:matrix:org.matrix.msc2967.client:api:*',
+      'urn:matrix:org.matrix.msc2967.client:device:$deviceId',
+    };
+    responseMode ??= redirectUri.scheme == 'https'
+        ? OidcResponseMode.fragment
+        : OidcResponseMode.query;
+
+    final state = base64UrlEncodeNoPadding(secureRandomBytes(32));
+    final codeVerifier =
+        base64UrlEncodeNoPadding(secureRandomBytes(codeVerifierBytesLength));
+    final codeChallenge = base64UrlEncodeNoPadding(
+      vod.CryptoUtils.sha256(input: ascii.encode(codeVerifier)),
+    );
+    final authenticationUri = authMetadata.authorizationEndpoint.replace(
+      queryParameters: {
+        'client_id': oidcClientData.clientId,
+        'response_type': 'code',
+        'redirect_uri': redirectUri.toString(),
+        'scope': scopes.join(' '),
+        'code_challenge': codeChallenge,
+        'code_challenge_method': 'S256',
+        'response_mode': responseMode.name,
+        'state': state,
+        if (prompt != null) 'prompt': prompt,
+      },
+    );
+
+    return OidcLoginSession(
+      oidcClientData: oidcClientData,
+      authenticationUri: authenticationUri,
+      redirectUri: redirectUri,
+      codeVerifier: codeVerifier,
+      state: state,
+    );
+  }
+
+  /// Performs a login with OIDC. It needs an `OidcLoginSession` from
+  /// `Client.initOidcLoginSession()` and the `code` and `state` from the
+  /// query parameters of the returned URL.
+  Future<void> oidcLogin({
+    required OidcLoginSession session,
+    required String code,
+    required String state,
+  }) async {
+    if (session.state != state) {
+      throw Exception(
+        'OIDC state differs from initial session. This could either be a bug or a man-in-the-middle attack.',
+      );
+    }
+    final body = <String, String>{
+      'grant_type': 'authorization_code',
+      'code': code,
+      'redirect_uri': session.redirectUri.toString(),
+      'client_id': session.oidcClientData.clientId,
+      'code_verifier': session.codeVerifier,
+    };
+    final authMetadata = await getAuthMetadata();
+    final response = await httpClient.post(
+      authMetadata.tokenEndpoint,
+      body: body,
+      headers: {'content-type': 'application/x-www-form-urlencoded'},
+    );
+    if (response.statusCode != 200) {
+      unexpectedResponse(
+        response,
+        response.bodyBytes,
+      );
+    }
+    final responseString = utf8.decode(response.bodyBytes);
+    final json = jsonDecode(responseString);
+    await init(
+      newHomeserver: homeserver,
+      newToken: json['access_token'],
+      newRefreshToken: json['refresh_token'],
+      newTokenExpiresAt:
+          DateTime.now().add(Duration(milliseconds: json['expires_in'] as int)),
+    );
+  }
+}
+
+class OidcLoginSession {
+  final OidcClientData oidcClientData;
+  final Uri authenticationUri, redirectUri;
+  final String codeVerifier, state;
+
+  OidcLoginSession({
+    required this.oidcClientData,
+    required this.authenticationUri,
+    required this.redirectUri,
+    required this.codeVerifier,
+    required this.state,
+  });
+}
+
+enum OidcResponseMode { fragment, query }
+
+String base64UrlEncodeNoPadding(List<int> bytes) {
+  return base64UrlEncode(bytes).replaceAll('=', ''); // URL-safe & unpadded
+}
+
+String generateRandomDeviceId() {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  final random = Random.secure();
+  return List.generate(10, (_) => letters[random.nextInt(letters.length)])
+      .join();
+}

--- a/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
+++ b/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
@@ -19,7 +19,7 @@ extension Msc2966OidcDynamicClientRegistration on Client {
     Map<String, OidcClientInformation>? localizedClientInformation,
     String tokenEndpointAuthMethod = 'none',
     List<String> responseTypes = const ['code'],
-    List<String> grandTypes = const ['authorization_code', 'refresh_token'],
+    List<String> grantTypes = const ['authorization_code', 'refresh_token'],
     Map<String, Object?>? additionalProperties,
   }) async {
     final authMetadata = await getAuthMetadata();
@@ -55,7 +55,7 @@ extension Msc2966OidcDynamicClientRegistration on Client {
       'redirect_uris': redirectUris.map((uri) => uri.toString()).toList(),
       'token_endpoint_auth_method': tokenEndpointAuthMethod,
       'response_types': responseTypes,
-      'grand_types': grandTypes,
+      'grant_types': grantTypes,
       'application_type': applicationType.name,
       ...clientInformation.toJson(),
       if (localizedClientInformation != null)

--- a/test/msc_extensions/mxc_3861_oidc_test.dart
+++ b/test/msc_extensions/mxc_3861_oidc_test.dart
@@ -1,0 +1,92 @@
+import 'package:test/test.dart';
+import 'package:vodozemac/vodozemac.dart' as vod;
+
+import 'package:matrix/matrix.dart';
+import '../fake_database.dart';
+
+void main() {
+  group('MXC 3861 OIDC', tags: 'olm', () {
+    test('Test OIDC Login Flow', () async {
+      await vod.init(
+        wasmPath: './pkg/',
+        libraryPath: './rust/target/debug/',
+      );
+      final client = Client(
+        logLevel: Level.verbose,
+        'testclient',
+        httpClient: FakeMatrixApi(),
+        database: await getDatabase(),
+        onSoftLogout: (client) => client.refreshAccessToken(),
+      );
+      FakeMatrixApi.client = client;
+      await client.checkHomeserver(
+        Uri.parse('https://fakeServer.notExisting'),
+        checkWellKnown: false,
+      );
+      final redirectUri = Uri.http('localhost:123456');
+
+      // Uris must be based on Client Uri:
+      try {
+        await client.registerOidcClient(
+          redirectUris: [redirectUri],
+          applicationType: OidcApplicationType.native,
+          clientInformation: OidcClientInformation(
+            clientName: 'Test Client',
+            clientUri: Uri.https('matrix-client.invalid'),
+            logoUri: Uri.https('matrix.org', '/logo.png'),
+            tosUri: Uri.https('famedly.de', 'tos'),
+            policyUri: Uri.https('fluffy.chat', 'privacy'),
+          ),
+        );
+        fail('Should throw');
+      } catch (e) {
+        expect(e, isException);
+      }
+
+      // Uris must be https
+      try {
+        await client.registerOidcClient(
+          redirectUris: [redirectUri],
+          applicationType: OidcApplicationType.native,
+          clientInformation: OidcClientInformation(
+            clientName: 'Test Client',
+            clientUri: Uri.http('matrix-client.invalid'),
+            logoUri: null,
+            tosUri: null,
+            policyUri: null,
+          ),
+        );
+        fail('Should throw');
+      } catch (e) {
+        expect(e, isException);
+      }
+
+      final oidcClientData = await client.registerOidcClient(
+        redirectUris: [redirectUri],
+        applicationType: OidcApplicationType.native,
+        clientInformation: OidcClientInformation(
+          clientName: 'Test Client',
+          clientUri: Uri.https('matrix-client.invalid'),
+          logoUri: null,
+          tosUri: null,
+          policyUri: null,
+        ),
+      );
+      expect(oidcClientData.clientId, '1234');
+      expect(oidcClientData.clientInformation.clientName, 'Test Client');
+
+      final session = await client.initOidcLoginSession(
+        oidcClientData: oidcClientData,
+        redirectUri: redirectUri,
+      );
+
+      await client.oidcLogin(
+        session: session,
+        code: 'faketestcode',
+        state: session.state,
+      );
+
+      expect(client.isLogged(), true);
+    });
+  });
+}


### PR DESCRIPTION
Part of #2176 

### Features:
- [x] Login with OIDC
##### To be done in a follow up PR:
- [x] Logout
- [x] Token Refresh
Until logout and token refresh is implemented, the sdk will just use the Matrix Spec endpoints which should usually be forwarded to MAS anyway.