### PR TITLE
refactor: (BREAKING) Actually wipe ssss and cross signing when calling bootstrap wipe methods

### DIFF
--- a/lib/encryption/cross_signing.dart
+++ b/lib/encryption/cross_signing.dart
@@ -123,6 +123,19 @@ class CrossSigning {
                 key.identifier != client.deviceID,
       );
 
+  Future<void> wipe() async {
+    await client.accountDataLoading;
+    const crossSigningTypes = {
+      EventTypes.CrossSigningMasterKey,
+      EventTypes.CrossSigningSelfSigning,
+      EventTypes.CrossSigningUserSigning,
+    };
+    for (final type in crossSigningTypes) {
+      if (!client.accountData.containsKey(type)) continue;
+      await client.setAccountData(client.userID!, type, {});
+    }
+  }
+
   Future<void> sign(List<SignableKey> keys) async {
     final signedKeys = <MatrixSignableKey>[];
     Uint8List? selfSigningKey;

--- a/lib/encryption/ssss.dart
+++ b/lib/encryption/ssss.dart
@@ -301,6 +301,23 @@ class SSSS {
     }
   }
 
+  Future<void> wipeKey({String? keyId}) async {
+    keyId ??= defaultKeyId;
+    if (keyId == null) return;
+
+    await client.setAccountData(
+      client.userID!,
+      EventTypes.secretStorageKey(keyId),
+      {},
+    );
+    await client.setAccountData(
+      client.userID!,
+      EventTypes.SecretStorageDefaultKey,
+      {},
+    );
+    await clearCache();
+  }
+
   bool isSecret(String type) =>
       client.accountData[type]?.content['encrypted'] is Map;
 

--- a/lib/encryption/utils/bootstrap.dart
+++ b/lib/encryption/utils/bootstrap.dart
@@ -188,11 +188,12 @@ class Bootstrap {
     return keys;
   }
 
-  void wipeSsss(bool wipe) {
+  Future<void> wipeSsss(bool wipe) async {
     if (state != BootstrapState.askWipeSsss) {
       throw BootstrapBadStateException('Wrong State');
     }
     if (wipe) {
+      await encryption.ssss.wipeKey();
       state = BootstrapState.askNewSsss;
     } else if (encryption.ssss.defaultKeyId != null &&
         encryption.ssss.isKeyValid(encryption.ssss.defaultKeyId!)) {
@@ -348,6 +349,7 @@ class Bootstrap {
       throw BootstrapBadStateException();
     }
     if (wipe) {
+      await encryption.crossSigning.wipe();
       state = BootstrapState.askSetupCrossSigning;
     } else {
       await client.dehydratedDeviceSetup(newSsssKey!);

--- a/test/encryption/bootstrap_test.dart
+++ b/test/encryption/bootstrap_test.dart
@@ -50,7 +50,7 @@ void main() {
         bootstrap = client.encryption!.bootstrap(
           onUpdate: (bootstrap) async {
             if (bootstrap.state == BootstrapState.askWipeSsss) {
-              bootstrap.wipeSsss(true);
+              await bootstrap.wipeSsss(true);
             } else if (bootstrap.state == BootstrapState.askNewSsss) {
               await bootstrap.newSsss('foxies');
             } else if (bootstrap.state == BootstrapState.askWipeCrossSigning) {
@@ -106,7 +106,7 @@ void main() {
         bootstrap = client.encryption!.bootstrap(
           onUpdate: (bootstrap) async {
             if (bootstrap.state == BootstrapState.askWipeSsss) {
-              bootstrap.wipeSsss(false);
+              await bootstrap.wipeSsss(false);
             } else if (bootstrap.state == BootstrapState.askUseExistingSsss) {
               bootstrap.useExistingSsss(false);
             } else if (bootstrap.state == BootstrapState.askUnlockSsss) {
@@ -159,7 +159,7 @@ void main() {
         bootstrap = client.encryption!.bootstrap(
           onUpdate: (bootstrap) async {
             if (bootstrap.state == BootstrapState.askWipeSsss) {
-              bootstrap.wipeSsss(false);
+              await bootstrap.wipeSsss(false);
             } else if (bootstrap.state == BootstrapState.askUseExistingSsss) {
               bootstrap.useExistingSsss(false);
             } else if (bootstrap.state == BootstrapState.askUnlockSsss) {
@@ -239,7 +239,7 @@ void main() {
       bootstrap = client.encryption!.bootstrap(
         onUpdate: (bootstrap) async {
           if (bootstrap.state == BootstrapState.askWipeSsss) {
-            bootstrap.wipeSsss(false);
+            await bootstrap.wipeSsss(false);
           } else if (bootstrap.state == BootstrapState.askBadSsss) {
             askedBadSsss = true;
             bootstrap.ignoreBadSecrets(false);


### PR DESCRIPTION
Closes https://github.com/famedly/product-management/issues/3521

Before we have just done nothing
when calling wipeCrossSigning() or
wipeSsss() in bootstrap and just
skipped to setup new. While
wiping usually means we want to re-init something, this
could lead to an undesired
state. Maybe the
consumer wants to just wipe
everything but start from scratch
later. I also think this could
lead to the case that some
bootstrap setups are
corrupted as we leave the
old recovery keys in
account data forever and
never wipe them.

The new behavior sends an
empty json object instead which
is the same behavior, Element
seem to do.