### PR TITLE
fix: unescaped property keys in push rule evaluator + tests

### DIFF
--- a/lib/src/utils/pushrule_evaluator.dart
+++ b/lib/src/utils/pushrule_evaluator.dart
@@ -82,7 +82,8 @@ class _PatternCondition {
     if (tempField == null) {
       throw 'No field to match pattern on!';
     }
-    field = tempField;
+    // Unescape \. to . per Matrix spec for property access paths
+    field = tempField.replaceAll(r'\.', '.');
 
     var tempPat = condition.pattern;
     if (tempPat == null) {
@@ -126,7 +127,8 @@ class _EventPropertyCondition {
     if (tempField == null) {
       throw 'No field to check event property on!';
     }
-    field = tempField;
+    // Unescape \. to . per Matrix spec for property access paths
+    field = tempField.replaceAll(r'\.', '.');
 
     final tempValue = condition.value;
     if (![String, int, bool, Null].contains(tempValue.runtimeType)) {


### PR DESCRIPTION
Something I found while working on https://github.com/famedly/matrix-dart-sdk/pull/2219.

The push rule evaluator didn't match the notification event even though it had room mention. If you look at https://spec.matrix.org/latest/client-server-api/#default-override-rules specifically `.m.rule.is_user_mention` and `.m.rule.is_room_mention`, they have "content.m\\.mentions.user_ids" and "content.m\\.mentions.room" as keys respectively. With the current logic we use to flatten the json at `pushrule_evaluator.dart`, we flatten the entire event without any escape symbol in between.

The event:
```
{
    "event_id": "$original_event",
    "type": "m.room.message",
    "content": {
        "body": "Hello Alice!",
        "m.mentions": {
            "user_ids": ["@alice:example.org"]
        }
    }
}
```
Becomes:
```
{
    "event_id": "$original_event",
    "type": "m.room.message",
    "content.body": "Hello Alice!",
    "content.m.mentions.user_ids": ["@alice:example.org"]
}
```

And this doesn't match here - https://github.com/famedly/matrix-dart-sdk/blob/14f011901d1798428fe09207527f517399402960/lib/src/utils/pushrule_evaluator.dart#L139 because the field will be `"content.m\.mentions.user_ids"`

<img width="846" height="376" alt="v client • Tiksstrotneien" src="https://github.com/user-attachments/assets/219efdd5-c226-4c15-93c0-c8cd98dc7e9b" />

### Why we didn't catch it before?

Maybe because the rules before v1.7 didn't have 2 escape symbols for `key` in the spec:

<img width="1001" height="719" alt="image" src="https://github.com/user-attachments/assets/ff1afaa0-02b3-47e6-ba11-f9ab84f69fec" />
