### PR TITLE
fix: override server sent group call leave if we know we are still in a group call

### DIFF
--- a/lib/src/voip/models/delayed_event_canceller.dart
+++ b/lib/src/voip/models/delayed_event_canceller.dart
@@ -1,0 +1,13 @@
+// A model which holds the delayed event and it's timer
+
+import 'dart:async';
+
+class DelayedEventCanceller {
+  final String delayedEventId;
+  final Timer restartTimer;
+
+  DelayedEventCanceller({
+    required this.delayedEventId,
+    required this.restartTimer,
+  });
+}

--- a/lib/src/voip/models/matrixrtc_call_event.dart
+++ b/lib/src/voip/models/matrixrtc_call_event.dart
@@ -120,6 +120,7 @@ enum GroupCallState {
   localCallFeedInitialized,
   entering,
   entered,
+  leaving,
   ended
 }
 

--- a/lib/src/voip/voip.dart
+++ b/lib/src/voip/voip.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:core';
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:sdp_transform/sdp_transform.dart' as sdp_transform;
 import 'package:webrtc_interface/webrtc_interface.dart';
 
@@ -10,6 +11,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:matrix/src/utils/crypto/crypto.dart';
 import 'package:matrix/src/voip/models/call_options.dart';
+import 'package:matrix/src/voip/models/delayed_event_canceller.dart';
 import 'package:matrix/src/voip/models/voip_id.dart';
 import 'package:matrix/src/voip/utils/stream_helper.dart';
 
@@ -37,6 +39,11 @@ class VoIP {
 
   Map<VoipId, GroupCallSession> get groupCalls => _groupCalls;
   final Map<VoipId, GroupCallSession> _groupCalls = {};
+
+  // The delayed event id to cancel membership for that groupcall
+  // key is '$groupCallId|$application|$scope'
+  @internal
+  final delayedEventCancellers = <String, DelayedEventCanceller>{};
 
   /// The stream is used to prepare for incoming peer calls in a mesh call
   /// For example, registering listeners

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   image: ^4.0.15
   markdown: ^7.1.1
+  meta: ^1.17.0
   mime: ">=1.0.0 <3.0.0"
   path: ^1.9.1
   random_string: ^2.3.1


### PR DESCRIPTION


fix: this also improves multiple group calls in the same room by supporting delayed events for every call we are participating in