### PR TITLE
refactor: Add name property to ssss key and pass through keyId for opening

### DIFF
--- a/lib/encryption/ssss.dart
+++ b/lib/encryption/ssss.dart
@@ -228,7 +228,7 @@ class SSSS {
 
   /// Creates a new secret storage key, optional encrypts it with [passphrase]
   /// and stores it in the user's `accountData`.
-  Future<OpenSSSS> createKey([String? passphrase]) async {
+  Future<OpenSSSS> createKey([String? passphrase, String? name]) async {
     Uint8List privateKey;
     final content = SecretStorageKeyContent();
     if (passphrase != null) {
@@ -256,6 +256,7 @@ class SSSS {
     content.iv = encrypted.iv;
     content.mac = encrypted.mac;
     content.algorithm = AlgorithmTypes.secretStorageV1AesHmcSha2;
+    content.name = name;
 
     const keyidByteLength = 24;
 

--- a/lib/encryption/utils/bootstrap.dart
+++ b/lib/encryption/utils/bootstrap.dart
@@ -204,13 +204,13 @@ class Bootstrap {
     }
   }
 
-  void useExistingSsss(bool use) {
+  void useExistingSsss(bool use, {String? keyIdentifier}) {
     if (state != BootstrapState.askUseExistingSsss) {
       throw BootstrapBadStateException('Wrong State');
     }
     if (use) {
       try {
-        newSsssKey = encryption.ssss.open(encryption.ssss.defaultKeyId);
+        newSsssKey = encryption.ssss.open(keyIdentifier);
         state = BootstrapState.openExistingSsss;
       } catch (e, s) {
         Logs().e('[Bootstrapping] Error open SSSS', e, s);
@@ -258,14 +258,14 @@ class Bootstrap {
     state = BootstrapState.askNewSsss;
   }
 
-  Future<void> newSsss([String? passphrase]) async {
+  Future<void> newSsss([String? passphrase, String? name]) async {
     if (state != BootstrapState.askNewSsss) {
       throw BootstrapBadStateException('Wrong State');
     }
     state = BootstrapState.loading;
     try {
       Logs().v('Create key...');
-      newSsssKey = await encryption.ssss.createKey(passphrase);
+      newSsssKey = await encryption.ssss.createKey(passphrase, name);
       if (oldSsssKeys != null) {
         // alright, we have to re-encrypt old secrets with the new key
         final secrets = analyzeSecrets();

--- a/lib/matrix_api_lite/model/events/secret_storage_key_content.dart
+++ b/lib/matrix_api_lite/model/events/secret_storage_key_content.dart
@@ -34,6 +34,7 @@ class SecretStorageKeyContent {
   String? iv;
   String? mac;
   String? algorithm;
+  String? name;
 
   SecretStorageKeyContent();
 
@@ -43,7 +44,8 @@ class SecretStorageKeyContent {
             : null)(json.tryGet('passphrase')),
         iv = json.tryGet('iv'),
         mac = json.tryGet('mac'),
-        algorithm = json.tryGet('algorithm');
+        algorithm = json.tryGet('algorithm'),
+        name = json.tryGet('name');
 
   Map<String, Object?> toJson() {
     final data = <String, Object?>{};
@@ -51,6 +53,7 @@ class SecretStorageKeyContent {
     if (iv != null) data['iv'] = iv;
     if (mac != null) data['mac'] = mac;
     if (algorithm != null) data['algorithm'] = algorithm;
+    if (name != null) data['name'] = name;
     return data;
   }
 }

--- a/test/encryption/ssss_test.dart
+++ b/test/encryption/ssss_test.dart
@@ -501,11 +501,13 @@ void main() {
 
       test('createKey', () async {
         // with passphrase
-        var newKey = await client.encryption!.ssss.createKey('test');
+        var newKey =
+            await client.encryption!.ssss.createKey('test', 'key_name');
         expect(client.encryption!.ssss.isKeyValid(newKey.keyId), true);
         var testKey = client.encryption!.ssss.open(newKey.keyId);
         await testKey.unlock(passphrase: 'test');
         await testKey.setPrivateKey(newKey.privateKey!);
+        expect(testKey.keyData.name, 'key_name');
 
         // without passphrase
         newKey = await client.encryption!.ssss.createKey();


### PR DESCRIPTION
Makes it possible to set a `name` for
the SSSS key which is specified in the
spec but has never been implemented
here.

Also makes it possible to
set the key ID when using an existing
SSSS in bootstrap. by default it still
uses the default key ID so this is
not a breaking change.