### PR TITLE
fix: don't remove local participant on group call reconnection

### DIFF
--- a/lib/src/voip/group_call_session.dart
+++ b/lib/src/voip/group_call_session.dart
@@ -345,7 +345,10 @@ class GroupCallSession {
                 .remove('$groupCallId|$application|$scope');
           }
 
+          // rejoin the call and share the key with the existing participants
+          anyLeft.remove(localParticipant);
           await sendMemberStateEvent();
+          await backend.preShareKey(this);
         }
 
         final nonLocalAnyLeft = Set<CallParticipant>.from(anyLeft)


### PR DESCRIPTION
For https://github.com/famedly/product-management/issues/3546

Can test at https://github.com/famedly/call/pull/94