### PR TITLE
refactor: Always try deserialize error as matrixexception

### DIFF
--- a/lib/matrix_api_lite/matrix_api.dart
+++ b/lib/matrix_api_lite/matrix_api.dart
@@ -47,12 +47,15 @@ class MatrixApi extends Api {
 
   @override
   Never unexpectedResponse(http.BaseResponse response, Uint8List body) {
-    if (response.statusCode >= 400 && response.statusCode < 500) {
-      final resp = json.decode(utf8.decode(body));
-      if (resp is Map<String, Object?>) {
-        throw MatrixException.fromJson(resp);
-      }
+    MatrixException? matrixException;
+    try {
+      matrixException =
+          MatrixException.fromJson(json.decode(utf8.decode(body)));
+    } catch (_) {} // Is not a MatrixException!
+    if (matrixException != null && matrixException.raw.containsKey('errcode')) {
+      throw matrixException;
     }
+
     super.unexpectedResponse(response, body);
   }
 


### PR DESCRIPTION
Actually only error codes below 500 should be Matrix Exception but in reality Synapse sends them formatted as MatrixException sometimes also with 500 or 502 error code.

closes https://github.com/famedly/product-management/issues/3712