### PR TITLE
chore: better default body for unknown message format in calcUnlocalizedBody

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -325,7 +325,7 @@ class Event extends MatrixEvent {
   String get body {
     if (redacted) return 'Redacted';
     if (text != '') return text;
-    return type;
+    return 'Unknown message format of type "$type"';
   }
 
   /// Use this to get a plain-text representation of the event, stripping things

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -1565,7 +1565,7 @@ void main() async {
         },
         room,
       );
-      expect(event2.body, 'm.room.message');
+      expect(event2.body, 'Unknown message format of type "${event2.type}"');
     });
 
     group('unlocalized body reply stripping', () {
@@ -1637,8 +1637,7 @@ void main() async {
         editHtml: false,
       );
       testUnlocalizedBody(
-        // not sure we actually want m.room.message here and not an empty string
-        expectation: 'm.room.message',
+        expectation: 'Unknown message format of type "${EventTypes.Message}"',
         plaintextBody: false,
         body: '',
         formattedBody: '<b>formatted body</b>',
@@ -1649,7 +1648,7 @@ void main() async {
         editHtml: false,
       );
       testUnlocalizedBody(
-        expectation: 'm.room.message',
+        expectation: 'Unknown message format of type "${EventTypes.Message}"',
         plaintextBody: false,
         body: null,
         formattedBody: '<b>formatted body</b>',
@@ -1660,7 +1659,7 @@ void main() async {
         editHtml: false,
       );
       testUnlocalizedBody(
-        expectation: 'm.room.message',
+        expectation: 'Unknown message format of type "${EventTypes.Message}"',
         plaintextBody: false,
         body: 5,
         formattedBody: '<b>formatted body</b>',


### PR DESCRIPTION
Closes https://github.com/famedly/product-management/issues/2506