### PR TITLE
Release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [6.1.0] 6th Feb 2026
+
+- build: Update vodozemac to 0.5.0 (Christian Kußowski)
+- chore: Add tests for OIDC refresh and logout (Christian Kußowski)
+- chore: better default body for unknown message format in calcUnlocalizedBody (Karthikeyan S)
+- chore: Store oidc client id (Christian Kußowski)
+- feat: Logout with oidc (Christian Kußowski)
+- feat: Refresh token with matrix native oidc (Christian Kußowski)
+- fix: Room.searchEvents() returns empty list if all events are cached in db (Christian Kußowski)
+- refactor: Always try deserialize error as matrixexception (Christian Kußowski)
+
 ## [6.0.0] 21st Jan 2026
 
 - feat: add an option to intercept log events (#2233) (Yash Garg)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: matrix
 description: Matrix Dart SDK
-version: 6.0.0
+version: 6.1.0
 homepage: https://famedly.com
 repository: https://github.com/famedly/matrix-dart-sdk.git
 issue_tracker: https://github.com/famedly/matrix-dart-sdk/issues


### PR DESCRIPTION
Since the publish step wasn't done yet and the changes after v6.0.0 don't seem to contain breaking changes (but still relevant feature changes), we go for v6.1.0 instead of v7.0.0