### PR TITLE
chore: bump version to v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.1.1] 7th Feb 2026
+
+- fix: handle UIA case for unexpectedResponse during exception + tests
+
 ## [6.1.0] 6th Feb 2026
 
 - build: Update vodozemac to 0.5.0 (Christian Kußowski)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: matrix
 description: Matrix Dart SDK
-version: 6.1.0
+version: 6.1.1
 homepage: https://famedly.com
 repository: https://github.com/famedly/matrix-dart-sdk.git
 issue_tracker: https://github.com/famedly/matrix-dart-sdk/issues


### PR DESCRIPTION
Has changes from https://github.com/famedly/matrix-dart-sdk/commit/d93726cbb6d1cb55a41477f5157b41e539423095 which is a follow-up for https://github.com/famedly/matrix-dart-sdk/commit/b57f4d8ebffb6a39674c400b2b062b8d71e84645 that could introduce UIA bugs