### PR TITLE
fix: Katex markdown syntax

### DIFF
--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -151,7 +151,9 @@ class BlockLatexSyntax extends BlockSyntax {
 
   @override
   Node parse(BlockParser parser) {
-    final childLines = parseChildLines(parser);
+    final childLines = parseChildLines(parser)
+        .map((line) => line?.content)
+        .whereType<String>();
     // we use .substring(2) as childLines will *always* contain the first two '$$'
     final latex = childLines.join('\n').trim().substring(2).trim();
     final element = Element('div', [

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -225,6 +225,15 @@ void main() {
         'Test &lt;m&gt; <em>unescaped</em>',
       );
     });
+    test('Math', () {
+      expect(
+        markdown('\$\$ a+b=c'),
+        '<div data-mx-maths="a+b=c"><pre><code>a+b=c</code></pre></div>',
+      );
+      const unescapedAsciiChars =
+          '! #\$%*+,-./0123456789:;=?`ABCDEFGHIJKLMNOPQRSTUVWXYZ[~]^_@abcdefghijklmnopqrstuvwxyz{¬}| ÜÖÄüöäß§´²³';
+      expect(markdown(unescapedAsciiChars), unescapedAsciiChars);
+    });
     test('Checkboxes', () {
       expect(
         markdown(


### PR DESCRIPTION
closes https://github.com/famedly/product-management/issues/3727