### PR TITLE
fix: expiresIn from OIDC is in seconds not milliseconds

### DIFF
--- a/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
+++ b/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
@@ -106,9 +106,8 @@ extension Msc2964OidcLoginFlow on Client {
       newHomeserver: homeserver,
       newToken: oidcAuthResponse.accessToken,
       newRefreshToken: oidcAuthResponse.refreshToken,
-      newTokenExpiresAt: expiresIn == null
-          ? null
-          : DateTime.now().add(Duration(milliseconds: expiresIn)),
+      newTokenExpiresAt:
+          expiresIn == null ? null : DateTime.now().add(expiresIn),
       newOidcClientId: session.oidcClientData.clientId,
     );
   }
@@ -164,7 +163,7 @@ extension Msc2964OidcLoginFlow on Client {
 class OidcAuthResponse {
   final String accessToken, tokenType;
   final String? refreshToken, scope;
-  final int? expiresIn;
+  final Duration? expiresIn;
 
   OidcAuthResponse({
     required this.accessToken,
@@ -180,7 +179,9 @@ class OidcAuthResponse {
         tokenType: json['token_type'] as String,
         refreshToken: json['refresh_token'] as String?,
         scope: json['scope'] as String?,
-        expiresIn: json['expires_in'] as int?,
+        expiresIn: json['expires_in'] is int
+            ? Duration(seconds: json['expires_in'] as int)
+            : null,
       );
 }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -297,7 +297,9 @@ class Client extends MatrixApi {
             accessToken: legacyFormat.accessToken,
             tokenType: 'Bearer',
             refreshToken: legacyFormat.refreshToken,
-            expiresIn: legacyFormat.expiresInMs,
+            expiresIn: legacyFormat.expiresInMs == null
+                ? null
+                : Duration(milliseconds: legacyFormat.expiresInMs!),
             scope: null,
           ),
         ),
@@ -307,10 +309,9 @@ class Client extends MatrixApi {
     };
 
     accessToken = tokenResponse.accessToken;
-    final expiresInMs = tokenResponse.expiresIn;
-    final tokenExpiresAt = expiresInMs == null
-        ? null
-        : DateTime.now().add(Duration(milliseconds: expiresInMs));
+    final expiresIn = tokenResponse.expiresIn;
+    final tokenExpiresAt =
+        expiresIn == null ? null : DateTime.now().add(expiresIn);
     _accessTokenExpiresAt = tokenExpiresAt;
     await database.updateClient(
       homeserverUrl,


### PR DESCRIPTION
This fixes that the SDK assumed that expiresIn is in milliseconds like with the legacy refresh token endpoint from matrix. In fact it makes it more robust by making the expiresIn field in the response model a Duration.