### PR TITLE
fix: Retry refresh token on io exception

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2372,11 +2372,7 @@ class Client extends MatrixApi {
   Future<void>? _handleSoftLogoutFuture;
 
   Future<void> _handleSoftLogout() async {
-    final onSoftLogout = this.onSoftLogout;
-    if (onSoftLogout == null) {
-      await logout();
-      return;
-    }
+    final onSoftLogout = this.onSoftLogout ?? (_) => refreshAccessToken();
 
     _handleSoftLogoutFuture ??= () async {
       onLoginStateChanged.add(LoginState.softLoggedOut);
@@ -2400,8 +2396,7 @@ class Client extends MatrixApi {
     Duration expiresIn = const Duration(minutes: 1),
   ]) async {
     final tokenExpiresAt = accessTokenExpiresAt;
-    if (onSoftLogout != null &&
-        tokenExpiresAt != null &&
+    if (tokenExpiresAt != null &&
         tokenExpiresAt.difference(DateTime.now()) <= expiresIn) {
       await _handleSoftLogout();
     }


### PR DESCRIPTION

This also uses a default for soft logout if we get soft logged out but the SDK consumer hasn't set the soft logout callback. In case of Matrix native OIDC this makes sense now as with oidc you can not set anymore if you want to use refresh tokens or not, you just get forced to use it and the SDK now instantly logs you out if you don't set it.

Tested it on FluffyChat and works fine
there.