### PR TITLE
refactor: Disable concurrency in unit tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-thread_count=$(getconf _NPROCESSORS_ONLN)
-
 if [ -n "$NO_OLM" ]; then
     tagFlag="-x olm"
 fi
 
-dart test --concurrency=$thread_count --coverage=coverage_dir $tagFlag
+dart test --coverage=coverage_dir $tagFlag
 TEST_CODE=$?
 
 # lets you do more stuff like reporton


### PR DESCRIPTION
Those make the tests fail randomly and I can actually not measure any performance improvements. This makes sense because the bottleneck is the pbkdf2 method which runs single core anyway. Should fix that the CI is randomly failing sometimes.

Comparison:

```sh
# thread_count=$(getconf _NPROCESSORS_ONLN) # On my machine: 10
# dart test --coverage=coverage_dir  114.35s user 7.61s system 224% cpu 54.426 total
# dart test --concurrency=$thread_count --coverage=coverage_dir  131.55s user 11.06s system 257% cpu 55.404 total
```

In CI before:

> succeeded 3 days ago in 4m 52s

After:

> succeeded now in 5m 33s

So we lose 41 seconds in speed but it makes the tests more predictable. If no one has a better idea, I'd suggest to go forward with this approach.
