### PR TITLE
#2287 feat: add additionalFields support to AuthenticationData for UIA stages 

### DIFF
--- a/lib/matrix_api_lite/model/auth/authentication_data.dart
+++ b/lib/matrix_api_lite/model/auth/authentication_data.dart
@@ -26,17 +26,22 @@ class AuthenticationData {
   // https://github.com/matrix-org/matrix-doc/issues/3370
   String? type;
   String? session;
+  Map<String, Object?>? additionalFields;
 
-  AuthenticationData({this.type, this.session});
+  AuthenticationData({this.type, this.session, this.additionalFields});
 
   AuthenticationData.fromJson(Map<String, Object?> json)
       : type = json['type'] as String?,
-        session = json['session'] as String?;
+        session = json['session'] as String?,
+        additionalFields = json;
 
   Map<String, Object?> toJson() {
     final data = <String, Object?>{};
     if (type != null) data['type'] = type;
     if (session != null) data['session'] = session;
+    if (additionalFields != null) {
+      data.addAll(additionalFields!);
+    }
     return data;
   }
 }


### PR DESCRIPTION
Allow AuthenticationData to include arbitrary fields required by
Matrix User-Interactive Authentication (UIA) stages.

Some authentication stages such as `m.login.recaptcha` require
additional parameters (e.g. `response`) that are not currently
supported by the AuthenticationData model.

This change adds `additionalFields` so the SDK can send stage-specific
parameters as required by the Matrix Client-Server API.

Spec reference:
https://spec.matrix.org/v1.17/client-server-api/#user-interactive-authentication-api
https://spec.matrix.org/v1.17/client-server-api/#google-recaptcha