### PR TITLE
feat: Store sending files in file cache for 30 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage_badge.svg
 coverage.xml
 TEST-report.*
 rust
+.tmp_files
 
 # IntelliJ related
 *.iml

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -124,6 +124,10 @@ abstract class DatabaseApi {
     int? limit,
   });
 
+  /// Get a file from the app's file cache which is usually an mxcUri. This is
+  /// also used for caching not-yet-sent files. Those are cached under an Uri
+  /// with this format:
+  /// `cache://file/<TRANSACTION_ID>` or `cache://thumbnail/<TRANSACTION_ID>`
   Future<Uint8List?> getFile(Uri mxcUri);
 
   Future storeFile(Uri mxcUri, Uint8List bytes, int time);

--- a/lib/src/database/database_file_storage_stub.dart
+++ b/lib/src/database/database_file_storage_stub.dart
@@ -6,17 +6,22 @@ mixin DatabaseFileStorage {
   late final Uri? fileStorageLocation;
   late final Duration? deleteFilesAfterDuration;
 
+  final Map<Uri, Uint8List> _cache = {};
+
   Future<void> storeFile(Uri mxcUri, Uint8List bytes, int time) async {
-    return;
+    if (mxcUri.scheme != 'cache') return;
+    _cache[mxcUri] = bytes;
   }
 
   Future<Uint8List?> getFile(Uri mxcUri) async {
-    return null;
+    return _cache[mxcUri];
   }
 
   Future<void> deleteOldFiles(int savedAt) async {
-    return;
+    return; // Not supported. Cache is cleared on every app restart anyway.
   }
 
-  Future<bool> deleteFile(Uri mxcUri) async => false;
+  Future<bool> deleteFile(Uri mxcUri) async {
+    return _cache.remove(mxcUri) != null;
+  }
 }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -438,7 +438,76 @@ class Event extends MatrixEvent {
     room.client.onCancelSendEvent.add(eventId);
   }
 
+  Future<MatrixFile?> _getCachedFile({bool getThumbnail = false}) async {
+    if (transactionId == null) return null;
+
+    final filename = content.tryGet<String>('filename')!;
+
+    if (getThumbnail) {
+      final thumbnailBytes = await room.client.database.getFile(
+        Uri(
+          scheme: 'cache',
+          host: 'thumbnail',
+          path: transactionId,
+        ),
+      );
+      if (thumbnailBytes != null) {
+        return MatrixImageFile(
+          bytes: thumbnailBytes,
+          name: filename,
+          mimeType: thumbnailMimetype,
+          width: thumbnailInfoMap.tryGet<int>('w'),
+          height: thumbnailInfoMap.tryGet<int>('h'),
+        );
+      }
+    }
+
+    final fileBytes = await room.client.database.getFile(
+      Uri(
+        scheme: 'cache',
+        host: 'file',
+        path: transactionId,
+      ),
+    );
+    if (fileBytes == null) {
+      await cancelSend();
+      throw Exception('Can not try to send again. File is no longer cached.');
+    }
+    return switch (messageType) {
+      MessageTypes.Video => MatrixVideoFile(
+          bytes: fileBytes,
+          name: filename,
+          mimeType: attachmentMimetype,
+          duration: infoMap.tryGet<int>('duration'),
+          width: infoMap.tryGet<int>('w'),
+          height: infoMap.tryGet<int>('h'),
+        ),
+      MessageTypes.Audio => MatrixAudioFile(
+          bytes: fileBytes,
+          name: filename,
+          mimeType: attachmentMimetype,
+          duration: infoMap.tryGet<int>('duration'),
+        ),
+      MessageTypes.Image => MatrixImageFile(
+          bytes: fileBytes,
+          name: filename,
+          mimeType: attachmentMimetype,
+          width: infoMap.tryGet<int>('w'),
+          height: infoMap.tryGet<int>('h'),
+          blurhash: infoMap.tryGet<String>('xyz.amorgan.blurhash'),
+        ),
+      MessageTypes.File || _ => MatrixFile(
+          bytes: fileBytes,
+          name: filename,
+          mimeType: attachmentMimetype,
+        ),
+    };
+  }
+
   /// Try to send this event again. Only works with events of status -1.
+  /// If this is a file event and the file was not uploaded yet and the file is
+  /// not found in the cache locally, this throws a
+  /// `FileNoLongerInCacheException`.
   Future<String?> sendAgain({String? txid}) async {
     if (!status.isError) return null;
 
@@ -449,12 +518,10 @@ class Event extends MatrixEvent {
       MessageTypes.Audio,
       MessageTypes.File,
     }.contains(messageType)) {
-      final file = room.sendingFilePlaceholders[eventId];
-      if (file == null) {
-        await cancelSend();
-        throw Exception('Can not try to send again. File is no longer cached.');
-      }
-      final thumbnail = room.sendingFileThumbnails[eventId];
+      final file = await _getCachedFile();
+      final thumbnail = await _getCachedFile(getThumbnail: true);
+      if (file == null) throw FileNoLongerInCacheException();
+
       final credentials = FileSendRequestCredentials.fromJson(unsigned ?? {});
       final inReplyTo = credentials.inReplyTo == null
           ? null
@@ -462,7 +529,7 @@ class Event extends MatrixEvent {
       return await room.sendFileEvent(
         file,
         txid: txid ?? transactionId,
-        thumbnail: thumbnail,
+        thumbnail: thumbnail as MatrixImageFile,
         inReplyTo: inReplyTo,
         editEventId: credentials.editEventId,
         shrinkImageMaxDimension: credentials.shrinkImageMaxDimension,
@@ -754,8 +821,8 @@ class Event extends MatrixEvent {
     if (![EventTypes.Message, EventTypes.Sticker].contains(type)) {
       throw ("This event has the type '$type' and so it can't contain an attachment.");
     }
-    if (status.isSending) {
-      final localFile = room.sendingFilePlaceholders[eventId];
+    if (!status.isSent) {
+      final localFile = await _getCachedFile(getThumbnail: getThumbnail);
       if (localFile != null) return localFile;
     }
     final database = room.client.database;
@@ -1213,3 +1280,5 @@ enum FileSendingStatus {
   encrypting,
   uploading,
 }
+
+class FileNoLongerInCacheException implements Exception {}

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -834,9 +834,6 @@ class Room {
     return sendEvent(event, txid: txid);
   }
 
-  final Map<String, MatrixFile> sendingFilePlaceholders = {};
-  final Map<String, MatrixImageFile> sendingFileThumbnails = {};
-
   /// Sends a [file] to this room after uploading it. Returns the mxc uri of
   /// the uploaded file. If [waitUntilSent] is true, the future will wait until
   /// the message event has received the server. Otherwise the future will only
@@ -866,9 +863,17 @@ class Room {
     bool displayPendingEvent = true,
   }) async {
     txid ??= client.generateUniqueTransactionId();
-    sendingFilePlaceholders[txid] = file;
+    await client.database.storeFile(
+      Uri(scheme: 'cache', host: 'file', path: txid),
+      file.bytes,
+      DateTime.now().millisecondsSinceEpoch,
+    );
     if (thumbnail != null) {
-      sendingFileThumbnails[txid] = thumbnail;
+      await client.database.storeFile(
+        Uri(scheme: 'cache', host: 'thumbnail', path: txid),
+        thumbnail.bytes,
+        DateTime.now().millisecondsSinceEpoch,
+      );
     }
 
     // Create a fake Event object as a placeholder for the uploading file:
@@ -1063,8 +1068,14 @@ class Room {
       threadLastEventId: threadLastEventId,
       displayPendingEvent: displayPendingEvent,
     );
-    sendingFilePlaceholders.remove(txid);
-    sendingFileThumbnails.remove(txid);
+    await client.database.deleteFile(
+      Uri(scheme: 'cache', host: 'file', path: txid),
+    );
+    if (thumbnail != null) {
+      await client.database.deleteFile(
+        Uri(scheme: 'cache', host: 'thumbnail', path: txid),
+      );
+    }
     return eventId;
   }
 

--- a/test/fake_database.dart
+++ b/test/fake_database.dart
@@ -16,6 +16,9 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import 'dart:io';
+
+import 'package:path/path.dart' as path_joiner;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:matrix/matrix.dart';
@@ -26,12 +29,22 @@ Future<DatabaseApi> getDatabase({String? databasePath}) =>
 // ignore: deprecated_member_use_from_same_package
 Future<MatrixSdkDatabase> getMatrixSdkDatabase({
   String? path,
-}) async =>
-    MatrixSdkDatabase.init(
-      'unit_test.${DateTime.now().millisecondsSinceEpoch}',
-      database: await databaseFactoryFfi.openDatabase(
-        path ?? ':memory:',
-        options: OpenDatabaseOptions(singleInstance: false),
-      ),
-      sqfliteFactory: databaseFactoryFfi,
-    );
+}) async {
+  final directory = await Directory(
+    path_joiner.join(
+      Directory.current.path,
+      '.tmp_files',
+      DateTime.now().toIso8601String(),
+    ),
+  ).create(recursive: true);
+  return MatrixSdkDatabase.init(
+    'unit_test.${DateTime.now().millisecondsSinceEpoch}',
+    database: await databaseFactoryFfi.openDatabase(
+      path ?? ':memory:',
+      options: OpenDatabaseOptions(singleInstance: false),
+    ),
+    sqfliteFactory: databaseFactoryFfi,
+    fileStorageLocation: directory.uri,
+    maxFileSize: 1000,
+  );
+}

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -54,7 +54,9 @@ void main() {
   group('Room', () {
     Logs().level = Level.error;
     test('Login', () async {
-      matrix = await getClient();
+      matrix = await getClient(
+        sendTimelineEventTimeout: const Duration(seconds: 10),
+      );
       await matrix.abortSync();
     });
 
@@ -1383,18 +1385,43 @@ void main() {
       });
     });
 
-    // Not working because there is no real file to test it...
-    /*test('sendImageEvent', () async {
-      final File testFile = File.fromUri(Uri.parse("fake/path/file.jpeg"));
-      final dynamic resp =
-          await room.sendImageEvent(testFile, txid: "testtxid");
-      expect(resp, "42");
-    });*/
-
     test('sendFileEvent', () async {
-      final testFile = MatrixFile(bytes: Uint8List(0), name: 'file.jpeg');
+      var testFile = MatrixFile(bytes: Uint8List(0), name: 'file.jpeg');
       final resp = await room.sendFileEvent(testFile, txid: 'testtxid');
       expect(resp.toString(), '\$event12');
+      expect(
+        await room.client.database.getFile(
+          Uri(
+            scheme: 'cache',
+            host: 'file',
+            path: 'testtxid',
+          ),
+        ),
+        null, // It is sent so shouldn't be in cache anymore
+      );
+
+      const txnid = 'test_send_file_txnid';
+      testFile = MatrixFile(bytes: Uint8List(0), name: 'crash.jpeg');
+      FakeMatrixApi
+          .currentApi!.api['POST']!['/media/v3/upload?filename=crash.jpeg'] = {
+        'errcode': 'M_UNKNOWN',
+        'error': 'Boom!',
+      };
+
+      try {
+        await room.sendFileEvent(testFile, txid: 'test_send_file_txnid');
+      } catch (_) {}
+
+      expect(
+        await room.client.database.getFile(
+          Uri(
+            scheme: 'cache',
+            host: 'file',
+            path: txnid,
+          ),
+        ),
+        testFile.bytes,
+      );
     });
 
     test('pushRuleState', () async {
@@ -1972,7 +1999,7 @@ void main() {
                 'start': 't47429-4392820_219380_26003_2265',
               };
       final searchResult = await room.searchEvents(searchFunc: (_) => true);
-      expect(searchResult.events.length, 18);
+      expect(searchResult.events.length, 19);
       expect(searchResult.nextBatch, 't47409-4357353_219380_26003_2265');
       expect(searchResult.searchedUntil!.millisecondsSinceEpoch, 1432735824653);
       expect(


### PR DESCRIPTION
This makes it possible to retry sending a file event even after the app got restarted. It replaces the current in-memory-cache for sending files with using the existing store file methods in the database.

I've tested it with FluffyChat where it works like a charm :)

Tested on:

- [x] FluffyChat Android
- [x] FluffyChat macOS
- [x] FluffyChat Web (still only stores in memory but now with better error message)