### PR TITLE
fix(webrtc): resolve remote stream attachment issue and concurrent modification error

### DIFF
--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -397,7 +397,12 @@ class CallSession {
     if (direction == CallDirection.kOutgoing) {
       setCallState(CallState.kConnecting);
       await pc!.setRemoteDescription(answer);
-      for (final candidate in _remoteCandidates) {
+
+      // Copy the list before iterating because `await` can yield execution,
+      // allowing `_remoteCandidates` to be modified elsewhere,
+      // which would cause a concurrent modification error
+      final candidates = List.of(_remoteCandidates);
+      for (final candidate in candidates) {
         await pc!.addCandidate(candidate);
       }
     }

--- a/lib/src/voip/models/call_events.dart
+++ b/lib/src/voip/models/call_events.dart
@@ -70,7 +70,7 @@ class CallReplaces {
 }
 
 // TODO: Change to "sdp_stream_metadata" when MSC3077 is merged
-const String sdpStreamMetadataKey = 'org.matrix.msc3077.sdp_stream_metadata';
+const String sdpStreamMetadataKey = 'sdp_stream_metadata';
 
 /// https://github.com/matrix-org/matrix-doc/blob/dbkr/msc2747/proposals/2747-voip-call-transfer.md#capability-advertisment
 /// https://github.com/matrix-org/matrix-doc/blob/dbkr/msc2746/proposals/2746-reliable-voip.md#add-dtmf


### PR DESCRIPTION
## Summary
This PR fixes issues in the WebRTC video call flow where the remote stream was not properly attached, resulting in missing video/audio on the receiver side.

## Issues
- Remote stream was `null` due to incorrect SDP metadata key
- Concurrent modification error when iterating ICE candidates during async processing

## Changes
- Updated `sdpStreamMetadataKey` from:
  - `org.matrix.msc3077.sdp_stream_metadata`
  → to:
  - `sdp_stream_metadata`
- Fixed concurrent modification issue by iterating over a copied list of `_remoteCandidates`

## Impact
- Remote media stream now attaches correctly
- Prevents runtime crash: `Concurrent modification during iteration`
- Improves stability of WebRTC signaling and ICE candidate handling

## Notes
- The key change aligns with the expected stable SDP metadata format (post-MSC3077)
- Candidate handling is now safe for async execution

## Testing
- Verified video call connects successfully
- Remote video/audio stream is properly rendered
- No concurrent modification errors during ICE candidate processing