### PR TITLE
feat: gate LaTeX markdown parsing behind enableLatexMarkdown flag

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -114,6 +114,8 @@ class Client extends MatrixApi {
 
   final bool convertLinebreaksInFormatting;
 
+  final bool enableLatexMarkdown;
+
   final Duration sendTimelineEventTimeout;
 
   /// The timeout until a typing indicator gets removed automatically.
@@ -214,6 +216,7 @@ class Client extends MatrixApi {
     /// When sending a formatted message, converting linebreaks in markdown to
     /// <br/> tags:
     this.convertLinebreaksInFormatting = true,
+    this.enableLatexMarkdown = true,
     this.dehydratedDeviceDisplayName = 'Dehydrated Device',
     RoomSorter? customRoomSorter,
   })  : _database = database,

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -788,6 +788,7 @@ class Room {
         getEmotePacks: () => getImagePacksFlat(ImagePackUsage.emoticon),
         getMention: getMention,
         convertLinebreaks: client.convertLinebreaksInFormatting,
+        enableLatex: client.enableLatexMarkdown,
       );
       // if the decoded html is the same as the body, there is no need in sending a formatted message
       if (HtmlUnescape().convert(html.replaceAll(RegExp(r'<br />\n?'), '\n')) !=

--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -212,6 +212,7 @@ String markdown(
   Map<String, Map<String, String>> Function()? getEmotePacks,
   String? Function(String)? getMention,
   bool convertLinebreaks = true,
+  bool enableLatex = true,
 }) {
   var ret = markdownToHtml(
     text
@@ -223,7 +224,7 @@ String markdown(
         .replaceNewlines(),
     extensionSet: ExtensionSet.gitHubFlavored,
     blockSyntaxes: [
-      BlockLatexSyntax(),
+      if (enableLatex) BlockLatexSyntax(),
     ],
     inlineSyntaxes: [
       StrikethroughSyntax(),
@@ -231,7 +232,7 @@ String markdown(
       EmoteSyntax(getEmotePacks),
       PillSyntax(),
       MentionSyntax(getMention),
-      InlineLatexSyntax(),
+      if (enableLatex) InlineLatexSyntax(),
     ],
   );
 

--- a/test/markdown_test.dart
+++ b/test/markdown_test.dart
@@ -204,6 +204,16 @@ void main() {
         'meep <code>\$\\frac{2}{3}\$</code>',
       );
     });
+    test('enableLatex gates LaTeX parsing', () {
+      expect(
+        markdown('meep \$\\frac{2}{3}\$', enableLatex: true),
+        contains('data-mx-maths'),
+      );
+      expect(
+        markdown('meep \$\\frac{2}{3}\$', enableLatex: false),
+        isNot(contains('data-mx-maths')),
+      );
+    });
     test('Code blocks', () {
       expect(
         markdown(


### PR DESCRIPTION
## Description
Messages containing `$` were incorrectly treated as LaTeX math delimiters and rendered as `<code>` elements with double-escaped HTML entities.

## Changes
- Added `enableLatexMarkdown` flag on `Client` (defaults to `true`) to control LaTeX parsing
- Gated `InlineLatexSyntax` and `BlockLatexSyntax` behind this flag
- Added regression test to ensure proper gating behavior