### PR TITLE
fix: Do not send dozens of key request to device messages on timeline…

### DIFF
--- a/lib/msc_extensions/extension_timeline_export/timeline_export.dart
+++ b/lib/msc_extensions/extension_timeline_export/timeline_export.dart
@@ -162,12 +162,6 @@ extension TimelineExportExtension on Timeline {
             var event = Event.fromMatrixEvent(matrixEvent, room);
             if (event.type == EventTypes.Encrypted && encryption != null) {
               event = await encryption.decryptRoomEvent(event);
-              if (event.type == EventTypes.Encrypted &&
-                  event.messageType == MessageTypes.BadEncrypted &&
-                  event.content['can_request_session'] == true) {
-                // Await requestKey() here to ensure decrypted message bodies
-                await event.requestKey().catchError((_) {});
-              }
             }
             if (from != null && event.originServerTs.isBefore(from)) break;
             if (until != null && event.originServerTs.isAfter(until)) continue;


### PR DESCRIPTION
… export

This is super annoying. When we do a (legacy) search or a timeline export, we should not send dozens of key request to device messages to all other devices on a room export. It makes no sense. If the key is not in the key backup we don't have it and key requests shouldn't be sent automatically for an unknown amount of messages. `decryptRoomEvent()` already fetches the key from the key backup