### PR TITLE
fix: Actually throw error on failed download

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 
@@ -1230,6 +1231,8 @@ class FakeMatrixApi extends BaseClient {
                 'matrix:image:size': 102400,
               },
       '/media/v3/config': (var req) => {'m.upload.size': 50000000},
+      '/client/v1/media/download/example.org/abcd1234ascii': (var req) =>
+          Uint8List(100),
       '/client/v1/media/config': (var req) => {'m.upload.size': 50000000},
       '/.well-known/matrix/client': (var req) => {
             'm.homeserver': {'base_url': 'https://fakeserver.notexisting'},

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -858,6 +858,11 @@ class Event extends MatrixEvent {
 
         final response = await httpClient.send(request);
 
+        if (response.statusCode >= 400) {
+          room.client
+              .unexpectedResponse(response, await response.stream.toBytes());
+        }
+
         return await response.stream.toBytesWithProgress(onDownloadProgress);
       };
       uint8list =

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -2520,7 +2520,7 @@ void main() async {
         onDownloadProgress: progressList.add,
       );
       await client.dispose();
-      expect(progressList, [112]);
+      expect(progressList, [201]);
     });
     test('downloadAndDecryptAttachment store', tags: 'olm', () async {
       final FILE_BUFF = Uint8List.fromList([0]);


### PR DESCRIPTION
Right now it writes the error message into a file and acts like the download was completed which leads to funny files.

closes https://github.com/krille-chan/fluffychat/issues/2900