### PR TITLE
fix(CachedStreamController): set _lastError with error parameter instead of value property

### DIFF
--- a/lib/src/utils/cached_stream_controller.dart
+++ b/lib/src/utils/cached_stream_controller.dart
@@ -21,7 +21,7 @@ class CachedStreamController<T> {
   }
 
   void addError(Object error, [StackTrace? stackTrace]) {
-    _lastError = value;
+    _lastError = error;
     _streamController.addError(error, stackTrace);
   }
 


### PR DESCRIPTION
I noticed that the `addError` method of the `CachedStreamController` class sets the current `_value` as the `_lastError` instead of using the provider `error` parameter, I am not 100% sure if this is a desired fix but just in case here it is :) Thanks and best regards