### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,7 +21,7 @@ jobs:
   dart:
     permissions:
       contents: read
-    uses: famedly/frontend-ci-templates/.github/workflows/dart.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/dart.yml@e8167567258899ed2a5bcc7fe04c79ad78f87967
     with:
       env_file: ".github/workflows/versions.env"
     secrets:
@@ -30,13 +30,13 @@ jobs:
   general:
     permissions:
       contents: read
-    uses: famedly/frontend-ci-templates/.github/workflows/general.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/general.yml@e8167567258899ed2a5bcc7fe04c79ad78f87967
 
   reuse-compliance-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - name: Check licenses
         uses: fsfe/reuse-action@6ac5c823270d369f01e3c491c708f706f2bdc355
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Check licenses
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@6ac5c823270d369f01e3c491c708f706f2bdc355
 
   e2ee_test:
     runs-on: ubuntu-latest
@@ -127,7 +127,7 @@ jobs:
           genhtml merged.info -o merged
           echo $(lcov --summary merged.info | grep 'lines......:') >> $GITHUB_STEP_SUMMARY
       - name: Codecov - Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ca0a928a4cb3911011e868128a5cd90437c12db1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./merged.info, ./coverage/lcov.info, ./coverage_without_olm/lcov.info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: famedly/frontend-ci-templates/.github/workflows/publish-pub.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/publish-pub.yml@e8167567258899ed2a5bcc7fe04c79ad78f87967
     with:
       env_file: ".github/workflows/versions.env"
 


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.