### PR TITLE
refactor(BREAKING): Require client to be initialized for getEventByPushNotification()

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1855,10 +1855,8 @@ class Client extends MatrixApi {
   /// Fetches the corresponding Event object from a notification including a
   /// full Room object with the sender User object in it. Returns null if this
   /// push notification is not corresponding to an existing event.
-  /// The client does **not** need to be initialized first. If it is not
-  /// initialized, it will only fetch the necessary parts of the database. This
-  /// should make it possible to run this parallel to another client with the
-  /// same client name.
+  /// The client **must** be initialized and looged in or will otherwise
+  /// throw an exception!
   /// This also checks if the given event has a readmarker and returns null
   /// in this case.
   Future<Event?> getEventByPushNotification(
@@ -1867,15 +1865,7 @@ class Client extends MatrixApi {
     Duration timeoutForServerRequests = const Duration(seconds: 8),
     bool returnNullIfSeen = true,
   }) async {
-    // Get access token if necessary:
-    if (!isLogged()) {
-      final clientInfoMap = await database.getClient(clientName);
-      final token = clientInfoMap?.tryGet<String>('token');
-      if (token == null) {
-        throw Exception('Client is not logged in.');
-      }
-      accessToken = token;
-    }
+    if (!isLogged()) throw Exception('Client is not logged in.');
 
     await ensureNotSoftLoggedOut();
 


### PR DESCRIPTION
Before we have (in theory) supported that the client does not need to be initialized to call client.getEventByPushNotification() with the intention to allow multiple isolates. However this has never been used (or tested) in any of our clients (thanks to fcm_shared_isolate) and probably never worked. Also suggesting to not need to initialize might more harm than actually been useful. Initializing a client is now possible without waiting for all rooms or other data to be loaded so can be done in very short time.

The current implementation also had the problem that it only loads the token, not the refresh token or refresh token expires in datetime. Instead of duplicating all these logic or abstracting it, I'd find it more clean to remove this "feature" and require to initialize the client before, avoiding confusion, for the sake of simplicity and more intuitive behavior of the SDK.