### PR TITLE
refactor: No longer set timeline event as state event

### DIFF
--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -308,9 +308,6 @@ class Encryption {
         );
       }
       if (event.type != EventTypes.Encrypted && store) {
-        if (updateType != EventUpdateType.history) {
-          event.room.setState(event);
-        }
         await client.database.storeEventUpdate(
           event.room.id,
           event,


### PR DESCRIPTION
We did this in the past to store the lastEvent but we now have a dedicated slot in our Room JSON structure for the persistent storage.