### PR TITLE
chore: Increase timeout for create key

### DIFF
--- a/lib/encryption/ssss.dart
+++ b/lib/encryption/ssss.dart
@@ -281,7 +281,7 @@ class SSSS {
             info: content.passphrase!,
           ),
         ),
-      ).timeout(Duration(seconds: 10));
+      ).timeout(Duration(seconds: 30));
     } else {
       // we need to just generate a new key from scratch
       privateKey = Uint8List.fromList(uc.secureRandomBytes(ssssKeyLength));


### PR DESCRIPTION
A timeout here makes sense but 10 seconds is not that much and can already get hitted on low performing devices. 30 Seconds makes more sense and is a default which is used in a lot of other places as well.