### PR TITLE
fix: Keep tofu state on key updates

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3554,6 +3554,12 @@ class Client extends MatrixApi {
                 if (oldKey != null) {
                   // be sure to save the verification status
                   entry.setDirectVerified(oldKey.directVerified);
+                  if (oldKey.trustOnFirstUseSince != null) {
+                    entry.trustOnFirstUse(
+                      since: oldKey.trustOnFirstUseSince,
+                      updateInDatabase: false,
+                    );
+                  }
                   entry.blocked = oldKey.blocked;
                   entry.validSignatures = oldKey.validSignatures;
                 }

--- a/lib/src/utils/device_keys_list.dart
+++ b/lib/src/utils/device_keys_list.dart
@@ -401,14 +401,19 @@ class CrossSigningKey extends SignableKey {
       keys.isNotEmpty &&
       ed25519Key != null;
 
-  Future<void> trustOnFirstUse({DateTime? since}) async {
+  Future<void> trustOnFirstUse({
+    DateTime? since,
+    bool updateInDatabase = true,
+  }) async {
     since ??= DateTime.now();
-    await client.database.setVerifiedUserCrossSigningKey(
-      verified,
-      userId,
-      publicKey!,
-      trustOnFirstUseSince: since,
-    );
+    if (updateInDatabase) {
+      await client.database.setVerifiedUserCrossSigningKey(
+        verified,
+        userId,
+        publicKey!,
+        trustOnFirstUseSince: since,
+      );
+    }
     _trustOnFirstUseSince = since;
   }
 


### PR DESCRIPTION
Same as blocked and directVerified state for cross signing keys, we should keep the tofu state on key updates.