### PR TITLE
fix(voip): skip enableGroupCalls() for direct-chat rooms

### DIFF
--- a/lib/src/voip/voip.dart
+++ b/lib/src/voip/voip.dart
@@ -1064,7 +1064,7 @@ class VoIP {
     // does not cause it.
     await room.postLoad();
 
-    if (!room.groupCallsEnabledForEveryone) {
+    if (!room.isDirectChat && !room.groupCallsEnabledForEveryone) {
       await room.enableGroupCalls();
     }
 


### PR DESCRIPTION
For 1:1 DM rooms, `fetchOrCreateGroupCall()` was unconditionally calling `enableGroupCalls()` which fired an `m.room.power_levels` state event, visibly changing room permissions on the first call. DM rooms don't need this activation check — both users can always call each other.

Skip the `enableGroupCalls()` call when `room.isDirectChat` is true.