### PR TITLE
fix(voip): snapshot _remoteCandidates to avoid concurrent-modification in onAnswerReceived

### DIFF
--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -382,7 +382,7 @@ class CallSession {
     if (direction == CallDirection.kOutgoing) {
       setCallState(CallState.kConnecting);
       await pc!.setRemoteDescription(answer);
-      for (final candidate in _remoteCandidates) {
+      for (final candidate in _remoteCandidates.toList()) {
         await pc!.addCandidate(candidate);
       }
     }
@@ -864,7 +864,7 @@ class CallSession {
       setCallState(CallState.kCreateAnswer);
 
       final answer = await pc!.createAnswer({});
-      for (final candidate in _remoteCandidates) {
+      for (final candidate in _remoteCandidates.toList()) {
         await pc!.addCandidate(candidate);
       }
 


### PR DESCRIPTION
## Problem

`CallSession.onAnswerReceived` (and `onNegotiateReceived`) apply buffered ICE candidates with:

```dart
for (final candidate in _remoteCandidates) {
  await pc!.addCandidate(candidate);
}
```

Because the loop `await`s inside a `for-in` over `_remoteCandidates`, an incoming trickle-ICE event during the await can mutate the same list — `_remoteCandidates.add(...)` in the candidate handler, or `_remoteCandidates.clear()` on hangup/restart. That throws:

```
Unhandled Exception: Concurrent modification during iteration: Instance(length:0) of '_GrowableList'.
#0  ListIterator.moveNext (dart:_internal/iterable.dart:365)
#1  CallSession.onAnswerReceived (package:matrix/src/voip/call_session.dart:400)
#2  VoIP.onCallAnswer (package:matrix/src/voip/voip.dart:621)
```

`onAnswerReceived` then aborts before applying the remaining candidates / sending `select_answer`, leaving the **caller's** ICE negotiation incomplete. On connections that rely on candidates arriving mid-loop (relay/TURN), the caller's media never fully connects — observed in production as frozen outgoing video. Reproduced live on an Android 16 device the instant the callee answered.

## Fix

Iterate a snapshot so concurrent `add`/`clear` can't break the loop:

```dart
for (final candidate in _remoteCandidates.toList()) {
  await pc!.addCandidate(candidate);
}
```

Applied to both candidate-draining loops (`onAnswerReceived` and `onNegotiateReceived`). No behavior change beyond removing the race — any candidates added during the loop are still buffered in `_remoteCandidates` and applied on the next negotiation pass, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)