### PR TITLE
build: Add v7.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SPDX-FileCopyrightText: 2019-Present Famedly GmbH
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+## [7.3.0] 18th June 2026
+- feat: add isValidMatrixIdStrict for spec-compliant matrix id validation (Cursor Agent)
+- fix: return null when thumbnail was not found and make cast nullable (yurtemre7)
+
 ## [7.2.4] 16th June 2026
 - chore: Follow up actually store updated tofu state in db (Christian Kußowski)
 - fix: Allow image resizer to return new mime type (Christian Kußowski)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: matrix
 description: Matrix Dart SDK
-version: 7.2.4
+version: 7.3.0
 homepage: https://famedly.com
 repository: https://github.com/famedly/matrix-dart-sdk.git
 issue_tracker: https://github.com/famedly/matrix-dart-sdk/issues


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts a new release `7.3.0` of the Matrix Dart SDK.

Since `7.2.4` a new public API was added (a `feat`), so this is a minor version bump per semver.

- Bump `version` in `pubspec.yaml`: `7.2.4` → `7.3.0`
- Add `CHANGELOG.md` entry for `7.3.0`:
  - feat: add isValidMatrixIdStrict for spec-compliant matrix id validation
  - fix: return null when thumbnail was not found and make cast nullable

Meta-only commits since `7.2.4` (`chore: add missing 7.1.2 changelog`, `docs: add AGENTS.md`) are intentionally excluded as they don't affect SDK consumers.

## Verification

- `./scripts/extract_changelog.sh 7.3.0` returns the new section (used by the publish workflow to create the GitHub release).
- `dart pub get` succeeds with the bumped version.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67544230-7cbe-45b2-9a8e-1655aedee51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67544230-7cbe-45b2-9a8e-1655aedee51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

