### PR TITLE
feat(event): respect scanBeforePreview for inline attachment downloads

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -806,10 +806,21 @@ class Event extends MatrixEvent {
   /// With `Client.contentScannerConfig`, network downloads use the scanner.
   /// Scanner errors throw [ContentScannerException]. For encrypted scanner
   /// downloads, [downloadCallback] is ignored.
+  ///
+  /// Set [isInline] to true when the attachment is rendered inline (e.g. an
+  /// image preview in the timeline) rather than explicitly downloaded by the
+  /// user. The scanner is then only used when the scanner advertises
+  /// `scanBeforePreview`. Concretely, when a scanner is configured:
+  /// - `scanBeforePreview == true`: always scan, regardless of [isInline].
+  /// - `scanBeforePreview == false` and `isInline == true`: bypass the scanner
+  ///   and download directly from the homeserver.
+  /// - `scanBeforePreview == false` and `isInline == false`: scan, since the
+  ///   user is actually downloading the file.
   Future<MatrixFile> downloadAndDecryptAttachment({
     bool getThumbnail = false,
     Future<Uint8List> Function(Uri)? downloadCallback,
     bool fromLocalStoreOnly = false,
+    bool isInline = false,
 
     /// Callback which gets triggered on progress containing the amount of
     /// downloaded bytes.
@@ -846,7 +857,11 @@ class Event extends MatrixEvent {
 
     // Download the file
     final scanner = room.client.contentScannerConfig;
-    final useScannerForEncrypted = scanner != null && isEncrypted;
+    // Inline previews bypass the scanner unless it requires scanning before
+    // preview. Explicit downloads (and non-inline previews) always scan.
+    final useScanner =
+        scanner != null && (scanner.scanBeforePreview || !isInline);
+    final useScannerForEncrypted = useScanner && isEncrypted;
     final canDownloadFileFromServer = uint8list == null && !fromLocalStoreOnly;
     if (canDownloadFileFromServer) {
       if (useScannerForEncrypted) {
@@ -860,13 +875,14 @@ class Event extends MatrixEvent {
           fileMap: fileMap,
         );
       } else {
-        final downloadUri = await mxcUrl.getDownloadUri(room.client);
+        final downloadUri =
+            await mxcUrl.getDownloadUri(room.client, useScanner: useScanner);
         if (downloadCallback != null) {
           uint8list = await downloadCallback(downloadUri);
         } else {
           uint8list = await _downloadAttachmentBytes(
             downloadUri,
-            scanner: scanner,
+            scanner: useScanner ? scanner : null,
             onDownloadProgress: onDownloadProgress,
           );
         }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -809,11 +809,14 @@ class Event extends MatrixEvent {
   ///
   /// Set [isInline] to true when the attachment is rendered inline (e.g. an
   /// image preview in the timeline) rather than explicitly downloaded by the
-  /// user. The scanner is then only used when the scanner advertises
-  /// `scanBeforePreview`. Concretely, when a scanner is configured:
+  /// user. Inline previews only ever fetch the thumbnail, never the full file:
+  /// [getThumbnail] is forced to true and a [String] is thrown when the event
+  /// has no thumbnail to preview. The scanner is also only used for inline
+  /// previews when it advertises `scanBeforePreview`. Concretely, when a
+  /// scanner is configured:
   /// - `scanBeforePreview == true`: always scan, regardless of [isInline].
   /// - `scanBeforePreview == false` and `isInline == true`: bypass the scanner
-  ///   and download directly from the homeserver.
+  ///   and download the thumbnail directly from the homeserver.
   /// - `scanBeforePreview == false` and `isInline == false`: scan, since the
   ///   user is actually downloading the file.
   Future<MatrixFile> downloadAndDecryptAttachment({
@@ -829,12 +832,23 @@ class Event extends MatrixEvent {
     if (![EventTypes.Message, EventTypes.Sticker].contains(type)) {
       throw ("This event has the type '$type' and so it can't contain an attachment.");
     }
+    // Inline previews must only ever fetch the thumbnail, never the full file.
+    if (isInline) {
+      if (!hasThumbnail) {
+        throw "This event hasn't any thumbnail to preview inline.";
+      }
+      getThumbnail = true;
+    }
     if (!status.isSent) {
       final localFile = await _getCachedFile(getThumbnail: getThumbnail);
       if (localFile != null) return localFile;
     }
     final database = room.client.database;
-    final mxcUrl = attachmentOrThumbnailMxcUrl(getThumbnail: getThumbnail);
+    // For inline previews always use the thumbnail mxc directly, skipping the
+    // size-based fallback to the full attachment in [attachmentOrThumbnailMxcUrl].
+    final mxcUrl = isInline
+        ? thumbnailMxcUrl
+        : attachmentOrThumbnailMxcUrl(getThumbnail: getThumbnail);
     if (mxcUrl == null) {
       throw "This event hasn't any attachment or thumbnail.";
     }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -809,14 +809,16 @@ class Event extends MatrixEvent {
   ///
   /// Set [isInline] to true when the attachment is rendered inline (e.g. an
   /// image preview in the timeline) rather than explicitly downloaded by the
-  /// user. Inline previews only ever fetch the thumbnail, never the full file:
-  /// [getThumbnail] is forced to true and a [String] is thrown when the event
-  /// has no thumbnail to preview. The scanner is also only used for inline
-  /// previews when it advertises `scanBeforePreview`. Concretely, when a
-  /// scanner is configured:
+  /// user. Inline previews prefer the thumbnail ([getThumbnail] is forced) and
+  /// fall back to the full file only when the event has no thumbnail. The
+  /// scanner is only used for inline previews when it advertises
+  /// `scanBeforePreview`. Concretely, when a scanner is configured:
   /// - `scanBeforePreview == true`: always scan, regardless of [isInline].
   /// - `scanBeforePreview == false` and `isInline == true`: bypass the scanner
-  ///   and download the thumbnail directly from the homeserver.
+  ///   and download directly from the homeserver. When this ends up fetching
+  ///   the full file (no thumbnail) the bytes are **not** cached, so a later
+  ///   explicit download (`isInline == false`) still runs through the scanner
+  ///   instead of being served an unscanned cached copy.
   /// - `scanBeforePreview == false` and `isInline == false`: scan, since the
   ///   user is actually downloading the file.
   Future<MatrixFile> downloadAndDecryptAttachment({
@@ -832,11 +834,9 @@ class Event extends MatrixEvent {
     if (![EventTypes.Message, EventTypes.Sticker].contains(type)) {
       throw ("This event has the type '$type' and so it can't contain an attachment.");
     }
-    // Inline previews must only ever fetch the thumbnail, never the full file.
+    // Inline previews prefer the thumbnail; they only fall back to the full
+    // file when the event has no thumbnail.
     if (isInline) {
-      if (!hasThumbnail) {
-        throw "This event hasn't any thumbnail to preview inline.";
-      }
       getThumbnail = true;
     }
     if (!status.isSent) {
@@ -844,11 +844,7 @@ class Event extends MatrixEvent {
       if (localFile != null) return localFile;
     }
     final database = room.client.database;
-    // For inline previews always use the thumbnail mxc directly, skipping the
-    // size-based fallback to the full attachment in [attachmentOrThumbnailMxcUrl].
-    final mxcUrl = isInline
-        ? thumbnailMxcUrl
-        : attachmentOrThumbnailMxcUrl(getThumbnail: getThumbnail);
+    final mxcUrl = attachmentOrThumbnailMxcUrl(getThumbnail: getThumbnail);
     if (mxcUrl == null) {
       throw "This event hasn't any attachment or thumbnail.";
     }
@@ -901,7 +897,15 @@ class Event extends MatrixEvent {
           );
         }
       }
-      storeable = storeable && uint8list.lengthInBytes < database.maxFileSize;
+      // When a scanner is configured but bypassed for an inline preview that
+      // ended up fetching the full file (no thumbnail), don't cache it: a later
+      // explicit download must still go through the scanner rather than hit an
+      // unscanned cached copy.
+      final bypassedScannerForFullFile =
+          scanner != null && !useScanner && !getThumbnail;
+      storeable = storeable &&
+          uint8list.lengthInBytes < database.maxFileSize &&
+          !bypassedScannerForFullFile;
       if (storeable) {
         await database.storeFile(
           mxcUrl,

--- a/lib/src/utils/uri_extension.dart
+++ b/lib/src/utils/uri_extension.dart
@@ -15,11 +15,15 @@ extension MxcUriExtension on Uri {
   ///
   /// Scanner and authenticated media URLs may need an authorization header:
   /// `headers: {"authorization": "Bearer ${client.accessToken}"}`
-  Future<Uri> getDownloadUri(Client client) async {
+  ///
+  /// Set [useScanner] to `false` to download directly from the homeserver even
+  /// when a `Client.contentScannerConfig` is configured (e.g. for inline
+  /// previews that should bypass the scanner).
+  Future<Uri> getDownloadUri(Client client, {bool useScanner = true}) async {
     if (!isScheme('mxc')) return Uri();
 
     final scanner = client.contentScannerConfig;
-    if (scanner != null) {
+    if (useScanner && scanner != null) {
       return _appendMxcTo(scanner.downloadUri);
     }
 

--- a/test/content_scanner_test.dart
+++ b/test/content_scanner_test.dart
@@ -549,4 +549,179 @@ void main() {
       await client.dispose(closeDatabase: true);
     });
   });
+
+  group('downloadAndDecryptAttachment + isInline / scanBeforePreview', () {
+    Event buildUnencryptedEvent(Room room) => Event.fromJson(
+          {
+            'type': EventTypes.Message,
+            'event_id': '\$inline-evt',
+            'sender': '@alice:example.org',
+            'origin_server_ts': 0,
+            'content': {
+              'msgtype': 'm.image',
+              'body': 'pic.png',
+              'filename': 'pic.png',
+              'info': {'mimetype': 'image/png', 'size': 3},
+              'url': _mxc,
+            },
+          },
+          room,
+        );
+
+    Event buildEncryptedEvent(Room room) => Event.fromJson(
+          {
+            'type': EventTypes.Message,
+            'event_id': '\$inline-enc-evt',
+            'sender': '@alice:example.org',
+            'origin_server_ts': 0,
+            'content': {
+              'msgtype': 'm.image',
+              'body': 'secret.png',
+              'filename': 'secret.png',
+              'info': {'mimetype': 'image/png', 'size': 5},
+              'file': {
+                'v': 'v2',
+                'url': _encryptedMxc,
+                'key': {
+                  'alg': 'A256CTR',
+                  'ext': true,
+                  'key_ops': ['encrypt', 'decrypt'],
+                  'kty': 'oct',
+                  'k': _encryptedFileKey,
+                },
+                'iv': _encryptedFileIv,
+                'hashes': {'sha256': _encryptedFileSha256},
+              },
+            },
+          },
+          room,
+        );
+
+    // Routes /_matrix/client/versions to a legacy (non-authenticated-media)
+    // response and serves [payload] for any other (download) request, while
+    // recording the last non-versions request that was seen.
+    MockClient homeserverMock(
+      Uint8List payload,
+      void Function(http.Request) onDownload,
+    ) =>
+        MockClient((req) async {
+          if (req.url.path.endsWith('/_matrix/client/versions')) {
+            return http.Response(jsonEncode({'versions': <String>[]}), 200);
+          }
+          onDownload(req);
+          return http.Response.bytes(payload, 200);
+        });
+
+    test('inline preview bypasses scanner when scanBeforePreview is false',
+        () async {
+      http.Request? downloadRequest;
+      final payload = Uint8List.fromList([1, 2, 3]);
+      final client = await _freshClient(
+        httpClient: homeserverMock(payload, (req) => downloadRequest = req),
+        scanner: _config(scanBeforePreview: false),
+      );
+      client.homeserver = Uri.parse('https://home.example');
+      final room = Room(id: '!room:example.org', client: client);
+      final event = buildUnencryptedEvent(room);
+
+      final file = await event.downloadAndDecryptAttachment(isInline: true);
+
+      expect(file.bytes, payload);
+      expect(downloadRequest, isNotNull);
+      expect(
+        downloadRequest!.url.toString(),
+        'https://home.example/_matrix/media/v3/download/example.org/abcd1234',
+      );
+
+      await client.dispose(closeDatabase: true);
+    });
+
+    test('inline preview uses scanner when scanBeforePreview is true',
+        () async {
+      http.BaseRequest? seenRequest;
+      final payload = Uint8List.fromList([4, 5, 6]);
+      final mockHttp = MockClient((req) async {
+        seenRequest = req;
+        return http.Response.bytes(payload, 200);
+      });
+      final client = await _freshClient(
+        httpClient: mockHttp,
+        scanner: _config(scanBeforePreview: true),
+      );
+      final room = Room(id: '!room:example.org', client: client);
+      final event = buildUnencryptedEvent(room);
+
+      final file = await event.downloadAndDecryptAttachment(isInline: true);
+
+      expect(file.bytes, payload);
+      expect(
+        seenRequest!.url.toString(),
+        'https://scanner.example/_matrix/media_proxy/unstable/download/example.org/abcd1234',
+      );
+
+      await client.dispose(closeDatabase: true);
+    });
+
+    test('explicit download uses scanner when scanBeforePreview is false',
+        () async {
+      http.BaseRequest? seenRequest;
+      final payload = Uint8List.fromList([7, 8, 9]);
+      final mockHttp = MockClient((req) async {
+        seenRequest = req;
+        return http.Response.bytes(payload, 200);
+      });
+      final client = await _freshClient(
+        httpClient: mockHttp,
+        scanner: _config(scanBeforePreview: false),
+      );
+      final room = Room(id: '!room:example.org', client: client);
+      final event = buildUnencryptedEvent(room);
+
+      final file = await event.downloadAndDecryptAttachment(isInline: false);
+
+      expect(file.bytes, payload);
+      expect(
+        seenRequest!.url.toString(),
+        'https://scanner.example/_matrix/media_proxy/unstable/download/example.org/abcd1234',
+      );
+
+      await client.dispose(closeDatabase: true);
+    });
+
+    test(
+        'inline encrypted preview bypasses scanner and decrypts homeserver bytes',
+        () async {
+      http.Request? downloadRequest;
+      final encryptedBytes = Uint8List.fromList([0x3B, 0x6B, 0xB2, 0x8C, 0xAF]);
+      final decryptedBytes = Uint8List.fromList([0x74, 0x65, 0x73, 0x74, 0x0A]);
+      final nativeImplementations = _DecryptingNativeImplementations(
+        expectedEncryptedBytes: encryptedBytes,
+        decryptedBytes: decryptedBytes,
+      );
+      final client = await _freshClient(
+        httpClient:
+            homeserverMock(encryptedBytes, (req) => downloadRequest = req),
+        scanner: _config(scanBeforePreview: false),
+        nativeImplementations: nativeImplementations,
+        encryptionEnabled: true,
+      );
+      client.homeserver = Uri.parse('https://home.example');
+      final room = Room(id: '!room:example.org', client: client);
+      final event = buildEncryptedEvent(room);
+
+      final file = await event.downloadAndDecryptAttachment(isInline: true);
+
+      expect(file.bytes, decryptedBytes);
+      expect(downloadRequest, isNotNull);
+      expect(downloadRequest!.method, 'GET');
+      expect(
+        downloadRequest!.url.toString(),
+        'https://home.example/_matrix/media/v3/download/example.com/file',
+      );
+      expect(nativeImplementations.seenFile, isNotNull);
+      expect(nativeImplementations.seenFile!.data, encryptedBytes);
+
+      await client.dispose(closeDatabase: true);
+    });
+  });
 }

--- a/test/content_scanner_test.dart
+++ b/test/content_scanner_test.dart
@@ -551,7 +551,11 @@ void main() {
   });
 
   group('downloadAndDecryptAttachment + isInline / scanBeforePreview', () {
-    Event buildUnencryptedEvent(Room room) => Event.fromJson(
+    const thumbMxc = 'mxc://example.org/thumb5678';
+    const encryptedThumbMxc = 'mxc://example.com/thumbfile';
+
+    Event buildUnencryptedEvent(Room room, {bool withThumbnail = true}) =>
+        Event.fromJson(
           {
             'type': EventTypes.Message,
             'event_id': '\$inline-evt',
@@ -561,7 +565,14 @@ void main() {
               'msgtype': 'm.image',
               'body': 'pic.png',
               'filename': 'pic.png',
-              'info': {'mimetype': 'image/png', 'size': 3},
+              'info': {
+                'mimetype': 'image/png',
+                'size': 3,
+                if (withThumbnail) ...{
+                  'thumbnail_url': thumbMxc,
+                  'thumbnail_info': {'mimetype': 'image/png', 'size': 2},
+                },
+              },
               'url': _mxc,
             },
           },
@@ -578,7 +589,23 @@ void main() {
               'msgtype': 'm.image',
               'body': 'secret.png',
               'filename': 'secret.png',
-              'info': {'mimetype': 'image/png', 'size': 5},
+              'info': {
+                'mimetype': 'image/png',
+                'size': 5,
+                'thumbnail_file': {
+                  'v': 'v2',
+                  'url': encryptedThumbMxc,
+                  'key': {
+                    'alg': 'A256CTR',
+                    'ext': true,
+                    'key_ops': ['encrypt', 'decrypt'],
+                    'kty': 'oct',
+                    'k': _encryptedFileKey,
+                  },
+                  'iv': _encryptedFileIv,
+                  'hashes': {'sha256': _encryptedFileSha256},
+                },
+              },
               'file': {
                 'v': 'v2',
                 'url': _encryptedMxc,
@@ -612,7 +639,7 @@ void main() {
           return http.Response.bytes(payload, 200);
         });
 
-    test('inline preview bypasses scanner when scanBeforePreview is false',
+    test('inline preview only downloads the thumbnail, never the full file',
         () async {
       http.Request? downloadRequest;
       final payload = Uint8List.fromList([1, 2, 3]);
@@ -628,15 +655,40 @@ void main() {
 
       expect(file.bytes, payload);
       expect(downloadRequest, isNotNull);
+      // Thumbnail mxc, not the full attachment, and bypassing the scanner.
       expect(
         downloadRequest!.url.toString(),
-        'https://home.example/_matrix/media/v3/download/example.org/abcd1234',
+        'https://home.example/_matrix/media/v3/download/example.org/thumb5678',
       );
 
       await client.dispose(closeDatabase: true);
     });
 
-    test('inline preview uses scanner when scanBeforePreview is true',
+    test('inline preview without a thumbnail throws and never downloads',
+        () async {
+      var downloaded = false;
+      final mockHttp = MockClient((req) async {
+        downloaded = true;
+        return http.Response.bytes(Uint8List.fromList([1]), 200);
+      });
+      final client = await _freshClient(
+        httpClient: mockHttp,
+        scanner: _config(scanBeforePreview: false),
+      );
+      client.homeserver = Uri.parse('https://home.example');
+      final room = Room(id: '!room:example.org', client: client);
+      final event = buildUnencryptedEvent(room, withThumbnail: false);
+
+      await expectLater(
+        event.downloadAndDecryptAttachment(isInline: true),
+        throwsA(isA<String>()),
+      );
+      expect(downloaded, false);
+
+      await client.dispose(closeDatabase: true);
+    });
+
+    test('inline preview uses scanner for the thumbnail when scanBeforePreview',
         () async {
       http.BaseRequest? seenRequest;
       final payload = Uint8List.fromList([4, 5, 6]);
@@ -656,14 +708,13 @@ void main() {
       expect(file.bytes, payload);
       expect(
         seenRequest!.url.toString(),
-        'https://scanner.example/_matrix/media_proxy/unstable/download/example.org/abcd1234',
+        'https://scanner.example/_matrix/media_proxy/unstable/download/example.org/thumb5678',
       );
 
       await client.dispose(closeDatabase: true);
     });
 
-    test('explicit download uses scanner when scanBeforePreview is false',
-        () async {
+    test('explicit download fetches the full file via the scanner', () async {
       http.BaseRequest? seenRequest;
       final payload = Uint8List.fromList([7, 8, 9]);
       final mockHttp = MockClient((req) async {
@@ -688,8 +739,7 @@ void main() {
       await client.dispose(closeDatabase: true);
     });
 
-    test(
-        'inline encrypted preview bypasses scanner and decrypts homeserver bytes',
+    test('inline encrypted preview downloads and decrypts only the thumbnail',
         () async {
       http.Request? downloadRequest;
       final encryptedBytes = Uint8List.fromList([0x3B, 0x6B, 0xB2, 0x8C, 0xAF]);
@@ -714,9 +764,10 @@ void main() {
       expect(file.bytes, decryptedBytes);
       expect(downloadRequest, isNotNull);
       expect(downloadRequest!.method, 'GET');
+      // Encrypted thumbnail mxc, not the full encrypted attachment.
       expect(
         downloadRequest!.url.toString(),
-        'https://home.example/_matrix/media/v3/download/example.com/file',
+        'https://home.example/_matrix/media/v3/download/example.com/thumbfile',
       );
       expect(nativeImplementations.seenFile, isNotNull);
       expect(nativeImplementations.seenFile!.data, encryptedBytes);

--- a/test/content_scanner_test.dart
+++ b/test/content_scanner_test.dart
@@ -639,8 +639,9 @@ void main() {
           return http.Response.bytes(payload, 200);
         });
 
-    test('inline preview only downloads the thumbnail, never the full file',
-        () async {
+    test(
+        'inline preview with a thumbnail downloads the thumbnail, bypassing '
+        'the scanner', () async {
       http.Request? downloadRequest;
       final payload = Uint8List.fromList([1, 2, 3]);
       final client = await _freshClient(
@@ -664,12 +665,17 @@ void main() {
       await client.dispose(closeDatabase: true);
     });
 
-    test('inline preview without a thumbnail throws and never downloads',
-        () async {
-      var downloaded = false;
+    test(
+        'inline preview without a thumbnail shows the full file uncached so an '
+        'explicit download still scans', () async {
+      final requests = <String>[];
+      final payload = Uint8List.fromList([1, 2, 3]);
       final mockHttp = MockClient((req) async {
-        downloaded = true;
-        return http.Response.bytes(Uint8List.fromList([1]), 200);
+        if (req.url.path.endsWith('/_matrix/client/versions')) {
+          return http.Response(jsonEncode({'versions': <String>[]}), 200);
+        }
+        requests.add(req.url.toString());
+        return http.Response.bytes(payload, 200);
       });
       final client = await _freshClient(
         httpClient: mockHttp,
@@ -679,11 +685,21 @@ void main() {
       final room = Room(id: '!room:example.org', client: client);
       final event = buildUnencryptedEvent(room, withThumbnail: false);
 
-      await expectLater(
-        event.downloadAndDecryptAttachment(isInline: true),
-        throwsA(isA<String>()),
-      );
-      expect(downloaded, false);
+      // Inline preview falls back to the full file, fetched from the homeserver
+      // while bypassing the scanner.
+      final preview = await event.downloadAndDecryptAttachment(isInline: true);
+      expect(preview.bytes, payload);
+
+      // Explicit download must NOT be served the unscanned cached copy; it has
+      // to go through the scanner again.
+      final download =
+          await event.downloadAndDecryptAttachment(isInline: false);
+      expect(download.bytes, payload);
+
+      expect(requests, [
+        'https://home.example/_matrix/media/v3/download/example.org/abcd1234',
+        'https://scanner.example/_matrix/media_proxy/unstable/download/example.org/abcd1234',
+      ]);
 
       await client.dispose(closeDatabase: true);
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `isInline` flag to `Event.downloadAndDecryptAttachment` for chat-preview (inline) rendering, so inline previews stay cheap while explicit downloads always run through the content scanner.

Behaviour with a `MatrixContentScannerConfig` configured:
- `scanBeforePreview == true`: always scan, regardless of `isInline`.
- `isInline == true`, `scanBeforePreview == false`: bypass the scanner and download directly from the homeserver.
  - With a thumbnail: fetch the thumbnail (cached as usual).
  - Without a thumbnail: fall back to the full file, but **do not cache it**, so a later explicit download isn't served an unscanned cached copy.
- `isInline == false`: scan via the scanner, since the user is actually downloading the file.

`getDownloadUri` gained an optional `useScanner` flag to allow direct homeserver downloads while a scanner is configured.

## Verification
- `dart analyze lib` (clean except a pre-existing deprecation hint)
- `dart format --set-exit-if-changed`
- `dart test test/content_scanner_test.dart` (22 tests pass), incl. a test proving an inline no-thumbnail preview (homeserver, unscanned, uncached) is followed by an explicit download that goes through the scanner.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81813c0e-71a7-451e-9aec-e5042efdb42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81813c0e-71a7-451e-9aec-e5042efdb42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

