### PR TITLE
chore: release v7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ SPDX-FileCopyrightText: 2019-Present Famedly GmbH
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+## [7.4.0] 23rd June 2026
+- feat: add skipScanner flag to download methods for per-call content scanner bypass (Khalil Amor)
+
 ## [7.3.0] 18th June 2026
 - feat: add isValidMatrixIdStrict for spec-compliant matrix id validation (Cursor Agent)
 - fix: return null when thumbnail was not found and make cast nullable (yurtemre7)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: matrix
 description: Matrix Dart SDK
-version: 7.3.0
+version: 7.4.0
 homepage: https://famedly.com
 repository: https://github.com/famedly/matrix-dart-sdk.git
 issue_tracker: https://github.com/famedly/matrix-dart-sdk/issues


### PR DESCRIPTION
## Release v7.4.0

### Changes
- feat: add `skipScanner` flag to `getDownloadUri`, `getThumbnailUri`, `downloadAndDecryptAttachment`, and `getAttachmentUri` for per-call content scanner bypass

