### PR TITLE
ci: fix publish job failing on Flutter example resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,30 @@ name: Publish to pub.dev
 on:
   workflow_call:
 
-# Publish using the reusable workflow from dart-lang.
 jobs:
+  # Inlined from famedly/frontend-ci-templates publish-pub.yml so we can pass
+  # `--no-example`: pub auto-resolves the Flutter `example/` package, which has
+  # no Flutter SDK on the publish runner and would fail `dart pub get`.
   publish:
+    environment: "pub.dev"
     permissions:
       contents: read
       id-token: write
-    uses: famedly/frontend-ci-templates/.github/workflows/publish-pub.yml@main
-    with:
-      env_file: ".github/workflows/versions.env"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read env file
+        run: cat .github/workflows/versions.env >> $GITHUB_ENV
+      - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: ${{ env.dart_version || 'stable' }}
+      - name: Install dependencies
+        run: dart pub get --no-example
+      - name: Publish - dry run
+        run: dart pub publish --dry-run
+      - name: Publish to pub.dev
+        run: dart pub publish -f
 
   create_gh_release:
     env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `Publish to pub.dev` workflow ([failed run](https://github.com/famedly/matrix-dart-sdk/actions/runs/28084806784/job/83149138760)) errors at `dart pub get`:

```
Resolving dependencies in `./example`...
Because matrix_example_chat requires the Flutter SDK, version solving failed.
```

The shared `famedly/frontend-ci-templates` `publish-pub.yml` runs plain `dart pub get`, which auto-resolves the `example/` package. Since `58c62dbd` rebuilt `example/` as a real Flutter app (adding `example/pubspec.yaml` with a Flutter SDK constraint; previously `example/` had only a `main.dart` and no pubspec), and the publish runner has no Flutter SDK, version solving fails — so `v7.4.0` was never published.

This inlines the publish steps (mirroring the template, keeping the `pub.dev` environment + OIDC) and passes `--no-example`, matching the rest of CI.

## Verification

- `dart pub get` (plain) → exit `1` (reproduces failure)
- `dart pub get --no-example` → exit `0`
- `dart pub publish --dry-run` → `Package has 0 warnings`, exit `0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e25b611c-0717-4652-9b83-b7c59c79cd1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e25b611c-0717-4652-9b83-b7c59c79cd1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

