### PR TITLE
build: update sqlite3 to 3.x and adapt encryption helper to build hooks

### DIFF
--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -6,3 +6,7 @@ exclude:
   - example/**
 ignore:
   - lints
+  # Not imported directly anymore (sqlite3 3.x dropped `package:sqlite3/open.dart`),
+  # but kept as a direct dependency so downstream apps are forced onto the
+  # hooks-based sqlite3 3.x that SQLCipher selection now relies on.
+  - sqlite3

--- a/lib/src/database/sqflite_encryption_helper/io.dart
+++ b/lib/src/database/sqflite_encryption_helper/io.dart
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:ffi';
 import 'dart:io';
-import 'dart:math' show max;
 
 import 'package:matrix/matrix.dart';
 import 'package:sqflite_common/sqlite_api.dart';
-import 'package:sqlite3/open.dart';
 
 // ignore: unused-code
 /// A helper utility for SQfLite related encryption operations
 ///
-/// * helps loading the required dynamic libraries - even on cursed systems
 /// * migrates unencrypted SQLite databases to SQLCipher
 /// * applies the PRAGMA key to a database and ensure it is properly loading
 class SQfLiteEncryptionHelper {
@@ -32,69 +28,23 @@ class SQfLiteEncryptionHelper {
     required this.cipher,
   });
 
-  /// Loads the correct [DynamicLibrary] required for SQLCipher
+  /// No-op, kept for backwards compatibility.
   ///
-  /// To be used with `package:sqlite3/open.dart`:
-  /// ```dart
-  /// void main() {
-  ///   final factory = createDatabaseFactoryFfi(
-  ///     ffiInit: SQfLiteEncryptionHelper.ffiInit,
-  ///   );
-  /// }
+  /// Since `sqlite3` 3.x the SQLite library is bundled via
+  /// [build hooks](https://dart.dev/tools/hooks) and can no longer be
+  /// overridden at runtime. To use SQLCipher, select it in the `hooks`
+  /// section of your application's `pubspec.yaml` instead:
+  /// ```yaml
+  /// hooks:
+  ///   user_defines:
+  ///     sqlite3:
+  ///       source: sqlcipher
   /// ```
-  static void ffiInit() => open.overrideForAll(_loadSQLCipherDynamicLibrary);
-
-  static DynamicLibrary _loadSQLCipherDynamicLibrary() {
-    // Taken from https://github.com/simolus3/sqlite3.dart/blob/e66702c5bec7faec2bf71d374c008d5273ef2b3b/sqlite3/lib/src/load_library.dart#L24
-    if (Platform.isAndroid) {
-      try {
-        return DynamicLibrary.open('libsqlcipher.so');
-      } catch (_) {
-        // On some (especially old) Android devices, we somehow can't dlopen
-        // libraries shipped with the apk. We need to find the full path of the
-        // library (/data/data/<id>/lib/libsqlcipher.so) and open that one.
-        // For details, see https://github.com/simolus3/moor/issues/420
-        final appIdAsBytes = File('/proc/self/cmdline').readAsBytesSync();
-
-        // app id ends with the first \0 character in here.
-        final endOfAppId = max(appIdAsBytes.indexOf(0), 0);
-        final appId = String.fromCharCodes(appIdAsBytes.sublist(0, endOfAppId));
-
-        return DynamicLibrary.open('/data/data/$appId/lib/libsqlcipher.so');
-      }
-    }
-    if (Platform.isLinux) {
-      // *not my fault grumble*
-      //
-      // On many Linux systems, I encountered issues opening the system provided
-      // libsqlcipher.so. I hence decided to ship an own one - statically linked
-      // against a patched version of OpenSSL compiled with the correct options.
-      //
-      // This was the only way I reached to run on particular Fedora and Arch
-      // systems.
-      //
-      // Hours wasted : 12
-      try {
-        return DynamicLibrary.open('libsqlcipher_flutter_libs_plugin.so');
-      } catch (_) {
-        return DynamicLibrary.open('libsqlcipher.so');
-      }
-    }
-    if (Platform.isIOS) {
-      return DynamicLibrary.process();
-    }
-    if (Platform.isMacOS) {
-      return DynamicLibrary.open(
-        'sqlcipher_flutter_libs.framework/Versions/Current/'
-        'sqlcipher_flutter_libs',
-      );
-    }
-    if (Platform.isWindows) {
-      return DynamicLibrary.open('libsqlcipher.dll');
-    }
-
-    throw UnsupportedError('Unsupported platform: ${Platform.operatingSystem}');
-  }
+  @Deprecated(
+    'sqlite3 is now loaded through build hooks. Select SQLCipher via the '
+    'hooks user_defines in your pubspec.yaml instead.',
+  )
+  static void ffiInit() {}
 
   /// checks whether the database exists and is encrypted
   ///

--- a/lib/src/database/sqflite_encryption_helper/io.dart
+++ b/lib/src/database/sqflite_encryption_helper/io.dart
@@ -71,6 +71,16 @@ class SQfLiteEncryptionHelper {
     // hell, it's unencrypted. This should not happen. Time to encrypt it.
     final plainDb = await factory.openDatabase(path);
 
+    // Ensure SQLCipher is actually loaded before running the
+    // SQLCipher-specific migration statements below - they would otherwise
+    // fail with an unclear error.
+    try {
+      await _ensureSQLCipherAvailable(plainDb);
+    } catch (_) {
+      await plainDb.close();
+      rethrow;
+    }
+
     final encryptedPath = '$path.encrypted';
 
     await plainDb.execute(
@@ -107,25 +117,30 @@ class SQfLiteEncryptionHelper {
   /// * applies [cipher] as PRAGMA key
   /// * checks whether this operation was successful
   Future<void> applyPragmaKey(Database database) async {
+    await _ensureSQLCipherAvailable(database);
+
+    final result = await database.rawQuery("PRAGMA KEY='$cipher';");
+    assert(result.single['ok'] == 'ok');
+  }
+
+  /// ensures the given [database] is actually backed by SQLCipher
+  ///
+  /// Throws a [StateError] otherwise, since the encryption PRAGMAs just fail
+  /// silently with regular sqlite3 (meaning that we'd accidentally use
+  /// plaintext databases).
+  Future<void> _ensureSQLCipherAvailable(Database database) async {
     final cipherVersion = await database.rawQuery('PRAGMA cipher_version;');
     if (cipherVersion.isEmpty) {
-      // Make sure that we're actually using SQLCipher, since the pragma
-      // used to encrypt databases just fails silently with regular
-      // sqlite3
-      // (meaning that we'd accidentally use plaintext databases).
       throw StateError(
         'SQLCipher library is not available, '
         'please check your dependencies!',
       );
-    } else {
-      final version = cipherVersion.singleOrNull?['cipher_version'];
-      Logs().d(
-        'PRAGMA supported by bundled SQLite. Encryption supported. SQLCipher version: $version.',
-      );
     }
 
-    final result = await database.rawQuery("PRAGMA KEY='$cipher';");
-    assert(result.single['ok'] == 'ok');
+    final version = cipherVersion.singleOrNull?['cipher_version'];
+    Logs().d(
+      'PRAGMA supported by bundled SQLite. Encryption supported. SQLCipher version: $version.',
+    );
   }
 
   /// checks whether a File has a plain text SQLite header

--- a/lib/src/database/sqflite_encryption_helper/stub.dart
+++ b/lib/src/database/sqflite_encryption_helper/stub.dart
@@ -6,7 +6,6 @@ import 'package:sqflite_common/sqlite_api.dart';
 
 /// A helper utility for SQfLite related encryption operations
 ///
-/// * helps loading the required dynamic libraries - even on cursed systems
 /// * migrates unencrypted SQLite databases to SQLCipher
 /// * applies the PRAGMA key to a database and ensure it is properly loading
 class SQfLiteEncryptionHelper {
@@ -25,17 +24,23 @@ class SQfLiteEncryptionHelper {
     required this.cipher,
   });
 
-  /// Loads the correct [DynamicLibrary] required for SQLCipher
+  /// No-op, kept for backwards compatibility.
   ///
-  /// To be used with `package:sqlite3/open.dart`:
-  /// ```dart
-  /// void main() {
-  ///   final factory = createDatabaseFactoryFfi(
-  ///     ffiInit: SQfLiteEncryptionHelper.ffiInit,
-  ///   );
-  /// }
+  /// Since `sqlite3` 3.x the SQLite library is bundled via
+  /// [build hooks](https://dart.dev/tools/hooks) and can no longer be
+  /// overridden at runtime. To use SQLCipher, select it in the `hooks`
+  /// section of your application's `pubspec.yaml` instead:
+  /// ```yaml
+  /// hooks:
+  ///   user_defines:
+  ///     sqlite3:
+  ///       source: sqlcipher
   /// ```
-  static void ffiInit() => throw UnimplementedError();
+  @Deprecated(
+    'sqlite3 is now loaded through build hooks. Select SQLCipher via the '
+    'hooks user_defines in your pubspec.yaml instead.',
+  )
+  static void ffiInit() {}
 
   /// checks whether the database exists and is encrypted
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   sdp_transform: ^0.3.2
   slugify: ^2.0.0
   sqflite_common: ^2.4.5
-  sqlite3: ^2.1.0
+  sqlite3: ^3.3.4
   typed_data: ^1.3.2
   vodozemac: ^0.5.0
   web: ^1.1.1
@@ -45,5 +45,5 @@ dev_dependencies:
       url: https://github.com/famedly/frontend-ci-templates.git
       path: lints/dart
   lints: any
-  sqflite_common_ffi: ^2.3.4+4 # sqflite_common_ffi aggressively requires newer dart versions
+  sqflite_common_ffi: ^2.4.0+3 # sqflite_common_ffi aggressively requires newer dart versions
   test: ^1.27.0

--- a/test/sqflite_encryption_helper_test.dart
+++ b/test/sqflite_encryption_helper_test.dart
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2019-Present Famedly GmbH
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:matrix/matrix.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SQfLiteEncryptionHelper', () {
+    late Directory tempDir;
+    late String dbPath;
+    late SQfLiteEncryptionHelper helper;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('encryption_helper');
+      dbPath = '${tempDir.path}/test.sqlite';
+      helper = SQfLiteEncryptionHelper(
+        factory: databaseFactoryFfi,
+        path: dbPath,
+        cipher: 'secret',
+      );
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('ffiInit is a no-op', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(SQfLiteEncryptionHelper.ffiInit, returnsNormally);
+    });
+
+    test(
+      'ensureDatabaseFileEncrypted does nothing without a database file',
+      () async {
+        await helper.ensureDatabaseFileEncrypted();
+        expect(await File(dbPath).exists(), false);
+      },
+    );
+
+    test(
+      'ensureDatabaseFileEncrypted skips already encrypted databases',
+      () async {
+        // an encrypted database does not start with the plain text SQLite header
+        final bytes = List<int>.generate(32, (i) => 255 - i);
+        await File(dbPath).writeAsBytes(bytes);
+
+        await helper.ensureDatabaseFileEncrypted();
+
+        expect(await File(dbPath).readAsBytes(), bytes);
+      },
+    );
+
+    test(
+      'ensureDatabaseFileEncrypted fails loudly when SQLCipher is not available',
+      () async {
+        // create a plain text SQLite database
+        final db = await databaseFactoryFfi.openDatabase(dbPath);
+        await db.execute('CREATE TABLE cats (name TEXT)');
+        await db.close();
+
+        // the bundled sqlite3 is not SQLCipher, so the migration must not
+        // silently do the wrong thing
+        await expectLater(
+          helper.ensureDatabaseFileEncrypted(),
+          throwsStateError,
+        );
+
+        // the plain database file is left untouched
+        expect(await File(dbPath).exists(), true);
+      },
+    );
+
+    test(
+      'applyPragmaKey fails loudly when SQLCipher is not available',
+      () async {
+        final db = await databaseFactoryFfi.openDatabase(dbPath);
+
+        await expectLater(helper.applyPragmaKey(db), throwsStateError);
+
+        await db.close();
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the last outdated dependencies in `pubspec.yaml` (everything else already resolves to the latest version compatible with Dart 3.11):

- `sqlite3` `^2.1.0` → `^3.3.4` — the major bump dependabot could not land (#2190…#2393) because sqlite3 3.x dropped `package:sqlite3/open.dart` in favour of [build hooks](https://dart.dev/tools/hooks).
- `sqflite_common_ffi` `^2.3.4+4` → `^2.4.0+3` (2.4.1+ needs Dart 3.12).
- `sqflite_common` stays at 2.5.8 (2.5.9+ needs Dart 3.12).

To make the SDK compile against sqlite3 3.x, `SQfLiteEncryptionHelper.ffiInit` no longer performs the runtime `DynamicLibrary` override (that API is gone). It is now a deprecated no-op pointing apps to the hooks `user_defines` (`source: sqlcipher`) migration path. Both `applyPragmaKey` and `ensureDatabaseFileEncrypted` now check `PRAGMA cipher_version` and throw an explicit `StateError` when SQLCipher is not actually loaded, and the helper is covered by new tests in `test/sqflite_encryption_helper_test.dart`.

## Verification

- `dart analyze`, `dart format`, `dependency_validator`, `dart pub publish --dry-run` all clean
- Full test suite: 52/52 files passed (build hooks download the prebuilt sqlite3 automatically), plus new encryption helper tests
- E2EE integration test against synapse: all tests passed
- `web_test` compiles via `dart run webdev build`; `test/box_test.dart --platform chrome` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e581809-c654-42ac-bf68-ef5b1f1b0428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e581809-c654-42ac-bf68-ef5b1f1b0428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

