### PR TITLE
fix: ensure not soft logged out in pushhelper

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1932,6 +1932,7 @@ class Client extends MatrixApi {
       ).timeout(timeoutForServerRequests);
     } on MatrixException catch (_) {
       // No access to the MatrixEvent. Search in /notifications
+      await ensureNotSoftLoggedOut();
       final notificationsResponse = await getNotifications();
       matrixEvent ??= notificationsResponse.notifications
           .firstWhereOrNull(


### PR DESCRIPTION
fixes an error report in FluffyChat which therefore also can happen in Famedly. Should reduce the amount of unable to fetch events in notifications a little bit.