### PR TITLE
docs: correct Dart SDK version in cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@ root fails (the example needs the Flutter SDK). Use `dart pub get --no-example` 
 `flutter pub get`, which the shared `dart` CI template uses). All plain-dart CI jobs
 in `.github/workflows/integrate.yml` pass `--no-example`.
 
-Toolchain already provided by the VM snapshot (do not reinstall): Dart SDK 3.9.2 (on
-`PATH` as `dart`), the Rust toolchain (`cargo`), Docker, mikefarah `yq` (at
+Toolchain already provided by the VM snapshot (do not reinstall): Dart SDK 3.11.1 (on
+`PATH` as `dart`, pinned to `.github/workflows/versions.env`; the repo requires SDK
+`>=3.11.0`), the Rust toolchain (`cargo`), Docker, mikefarah `yq` (at
 `/usr/local/bin/yq` — required by `scripts/prepare_vodozemac.sh`; note the distro's
 `/usr/bin/yq` is the incompatible python `yq`), and `libsqlite3-dev`/`lcov`. The update
 script fetches dependencies with `dart pub get --no-example` (plain `dart pub get`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The repo bumped its SDK constraint to Dart `>=3.11.0` (commit `351a5843`), but the Cloud VM snapshot still shipped Dart `3.9.2`, so `dart pub get` failed version solving. I updated the VM toolchain to Dart `3.11.1` (matching `.github/workflows/versions.env`) and corrected the now-inaccurate version reference in `AGENTS.md`.

## Verification

- `dart pub get --no-example` — resolves
- `dart analyze` — no issues
- `dart format --output=none --set-exit-if-changed lib` — clean
- Core tests pass: `client_test.dart`, `room_test.dart`, `matrix_database_test.dart`
- E2EE test passes (vodozemac native lib built): `encryption/encrypt_decrypt_room_message_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f23592-b17f-42ef-9af8-220daa8237e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f23592-b17f-42ef-9af8-220daa8237e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

