### PR TITLE
fix: do not rely on joinedMemberCount to determine if local member list is complete

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -1842,6 +1842,18 @@ class FakeMatrixApi extends BaseClient {
               },
             ],
           },
+      '/client/v3/rooms/!1234%3AfakeServer.notExisting/members': (var req) => {
+        'chunk': [
+          {
+            'type': 'm.room.member',
+            'content': {'membership': 'join'},
+            'sender': '@fakeuser:fakeServer.notExisting',
+            'state_key': '@test:fakeServer.notExisting',
+            'event_id': '\$fakeuser',
+            'origin_server_ts': 1783514080052,
+          },
+        ],
+      },
       '/client/v3/rooms/!696r7674:example.com/members': (var req) => {
         'chunk': [
           {

--- a/lib/matrix_api_lite/model/room_summary.dart
+++ b/lib/matrix_api_lite/model/room_summary.dart
@@ -7,6 +7,12 @@ class RoomSummary {
   int? mJoinedMemberCount;
   int? mInvitedMemberCount;
 
+  RoomSummary({
+    this.mHeroes,
+    this.mInvitedMemberCount,
+    this.mJoinedMemberCount,
+  });
+
   RoomSummary.fromJson(Map<String, Object?> json)
     : mHeroes = json['m.heroes'] != null
           ? List<String>.from(json['m.heroes'] as List)

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2719,11 +2719,13 @@ class Client extends MatrixApi {
       final syncRoomUpdate = entry.value;
 
       final room = await _updateRoomsByRoomUpdate(id, syncRoomUpdate);
+      var participantListComplete = room.participantListComplete;
 
       // Is the timeline limited? Then all previous messages should be
       // removed from the database!
       if (syncRoomUpdate is JoinedRoomUpdate &&
           syncRoomUpdate.timeline?.limited == true) {
+        participantListComplete = false;
         await database.deleteTimelineForRoom(id);
         room.lastEvent = null;
       }
@@ -2840,7 +2842,13 @@ class Client extends MatrixApi {
         runInRoot(room.refreshLastEvent);
       }
 
-      await database.storeRoomUpdate(id, syncRoomUpdate, room.lastEvent, this);
+      await database.storeRoomUpdate(
+        id,
+        syncRoomUpdate,
+        room.lastEvent,
+        participantListComplete,
+        this,
+      );
     }
   }
 

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -61,6 +61,7 @@ abstract class DatabaseApi {
     String roomId,
     SyncRoomUpdate roomUpdate,
     Event? lastEvent,
+    bool participantListComplete,
     Client client,
   );
 

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1267,6 +1267,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String roomId,
     SyncRoomUpdate roomUpdate,
     Event? lastEvent,
+    bool participantListComplete,
     Client client,
   ) async {
     // Leave room if membership is leave
@@ -1296,12 +1297,14 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
                 prev_batch: roomUpdate.timeline?.prevBatch,
                 summary: roomUpdate.summary,
                 lastEvent: lastEvent,
+                participantListComplete: participantListComplete,
               ).toJson()
             : Room(
                 client: client,
                 id: roomId,
                 membership: membership,
                 lastEvent: lastEvent,
+                participantListComplete: participantListComplete,
               ).toJson(),
       );
     } else if (roomUpdate is JoinedRoomUpdate) {
@@ -1324,6 +1327,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
               ..addAll(roomUpdate.summary?.toJson() ?? {}),
           ),
           lastEvent: lastEvent,
+          participantListComplete: participantListComplete,
         ).toJson(),
       );
     }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -75,6 +75,7 @@ class Room {
     'prev_batch': prev_batch,
     'summary': summary.toJson(),
     'last_event': lastEvent?.toJson(),
+    'participant_list_complete': participantListComplete,
   };
 
   factory Room.fromJson(Map<String, dynamic> json, Client client) {
@@ -89,6 +90,7 @@ class Room {
       highlightCount: json['highlight_count'],
       prev_batch: json['prev_batch'],
       summary: RoomSummary.fromJson(Map<String, dynamic>.from(json['summary'])),
+      participantListComplete: json['participant_list_complete'] == true,
     );
     if (json['last_event'] != null) {
       room.lastEvent = Event.fromJson(json['last_event'], room);
@@ -474,14 +476,10 @@ class Room {
     RoomSummary? summary,
     this.lastEvent,
     LatestReceiptState? receiptState,
+    bool participantListComplete = false,
   }) : roomAccountData = roomAccountData ?? <String, BasicEvent>{},
-       summary =
-           summary ??
-           RoomSummary.fromJson({
-             'm.joined_member_count': 0,
-             'm.invited_member_count': 0,
-             'm.heroes': [],
-           }),
+       _participantListComplete = participantListComplete,
+       summary = summary ?? RoomSummary(),
        receiptState = receiptState ?? LatestReceiptState.empty();
 
   /// The default count of how much events should be requested when requesting the
@@ -1887,6 +1885,14 @@ class Room {
           client,
         );
       }
+      _participantListComplete = true;
+      await client.database.storeRoomUpdate(
+        id,
+        JoinedRoomUpdate(),
+        lastEvent,
+        _participantListComplete,
+        client,
+      );
     }
 
     users.removeWhere((u) => !membershipFilter.contains(u.membership));
@@ -1894,18 +1900,9 @@ class Room {
   }
 
   /// Checks if the local participant list of joined and invited users is complete.
-  bool get participantListComplete {
-    final knownParticipants = getParticipants();
-    final joinedCount = knownParticipants
-        .where((u) => u.membership == Membership.join)
-        .length;
-    final invitedCount = knownParticipants
-        .where((u) => u.membership == Membership.invite)
-        .length;
+  bool get participantListComplete => _participantListComplete;
 
-    return (summary.mJoinedMemberCount ?? 0) == joinedCount &&
-        (summary.mInvitedMemberCount ?? 0) == invitedCount;
-  }
+  bool _participantListComplete;
 
   @Deprecated(
     'The method was renamed unsafeGetUserFromMemoryOrFallback. Please prefer requestParticipants.',

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -95,7 +95,13 @@ void main() {
           'testclient',
           database: await getMatrixSdkDatabase(),
         );
-        await database.storeRoomUpdate('!testroom', roomUpdate, null, client);
+        await database.storeRoomUpdate(
+          '!testroom',
+          roomUpdate,
+          null,
+          false,
+          client,
+        );
         final rooms = await database.getRoomList(client);
         expect(rooms.single.id, '!testroom');
       });
@@ -270,6 +276,7 @@ void main() {
           roomid,
           JoinedRoomUpdate(),
           null,
+          false,
           client,
         );
 


### PR DESCRIPTION
This might fix a bug where the sdk thinks it has all members cached locally and is not requesting all memers necessary for e2ee, which leads to UTD.

However I'm not yet happy with this approach, storing an additional thing in the DB. I just play around but would like to find a better fix which is stateless