### PR TITLE
fix: do not assume room member count is 1 if absent

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -1842,6 +1842,18 @@ class FakeMatrixApi extends BaseClient {
               },
             ],
           },
+      '/client/v3/rooms/!1234%3AfakeServer.notExisting/members': (var req) => {
+        'chunk': [
+          {
+            'type': 'm.room.member',
+            'content': {'membership': 'join'},
+            'sender': '@fakeuser:fakeServer.notExisting',
+            'state_key': '@test:fakeServer.notExisting',
+            'event_id': '\$abcd',
+            'origin_server_ts': 1783579093968,
+          },
+        ],
+      },
       '/client/v3/rooms/!696r7674:example.com/members': (var req) => {
         'chunk': [
           {

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -475,13 +475,7 @@ class Room {
     this.lastEvent,
     LatestReceiptState? receiptState,
   }) : roomAccountData = roomAccountData ?? <String, BasicEvent>{},
-       summary =
-           summary ??
-           RoomSummary.fromJson({
-             'm.joined_member_count': 0,
-             'm.invited_member_count': 0,
-             'm.heroes': [],
-           }),
+       summary = summary ?? RoomSummary.fromJson({}),
        receiptState = receiptState ?? LatestReceiptState.empty();
 
   /// The default count of how much events should be requested when requesting the
@@ -1895,6 +1889,11 @@ class Room {
 
   /// Checks if the local participant list of joined and invited users is complete.
   bool get participantListComplete {
+    final joinedMemberCount = summary.mJoinedMemberCount;
+    final invitedMemberCount = summary.mInvitedMemberCount;
+    // We can not know if the participant list is complete!
+    if (joinedMemberCount == null || invitedMemberCount == null) return false;
+
     final knownParticipants = getParticipants();
     final joinedCount = knownParticipants
         .where((u) => u.membership == Membership.join)
@@ -1903,8 +1902,8 @@ class Room {
         .where((u) => u.membership == Membership.invite)
         .length;
 
-    return (summary.mJoinedMemberCount ?? 0) == joinedCount &&
-        (summary.mInvitedMemberCount ?? 0) == invitedCount;
+    return joinedMemberCount == joinedCount &&
+        invitedMemberCount == invitedCount;
   }
 
   @Deprecated(

--- a/test/room_archived_test.dart
+++ b/test/room_archived_test.dart
@@ -127,7 +127,10 @@ void main() async {
       // prep work to be able to set a last event that would trigger the (fixed) bug
       await client.loadArchiveWithTimeline();
       expect(client.getArchiveRoomFromCache(roomid) != null, true);
-      expect(client.getRoomById(roomid)?.membership, Membership.leave);
+      final room = client.getRoomById(roomid)!;
+      room.summary.mJoinedMemberCount = 0;
+      room.summary.mInvitedMemberCount = 0;
+      expect(room.membership, Membership.leave);
 
       final outboundSession = await client.encryption?.keyManager
           .createOutboundGroupSession(roomid);
@@ -169,7 +172,6 @@ void main() async {
       expect(client.getRoomById(roomid)?.membership, Membership.leave);
 
       // set the last event
-      final room = client.getRoomById(roomid)!;
       room.lastEvent = Event(
         type: EventTypes.Encrypted,
         content: encryptedEvent,

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -712,6 +712,10 @@ void main() {
       final newParticipants = room.getParticipants();
       expect(oldParticipants.length < newParticipants.length, true);
       expect(fetchedParticipants.length, newParticipants.length);
+      room.summary.mJoinedMemberCount = 3;
+      expect(room.participantListComplete, true);
+      room.summary.mJoinedMemberCount = null;
+      expect(room.participantListComplete, false);
     });
 
     test('calcEncryptionHealthState', () async {


### PR DESCRIPTION
Assuming this is somehow dirty and we should more transparent return null here instead of guessing. There are actually cases where synapse or another homeserver is not giving us the member count (yet).

This fixes that the sdk sometimes does not fetch keys for a newly created room.

fixes https://famedly.atlassian.net/browse/FM-736