### PR TITLE
fix: avoid concurrent modification when updating group calls

### DIFF
--- a/lib/src/voip/voip.dart
+++ b/lib/src/voip/voip.dart
@@ -127,7 +127,8 @@ class VoIP {
       for (final mem in mems) {
         unawaited(createGroupCallFromRoomStateEvent(mem));
       }
-      for (final map in groupCalls.entries) {
+      final groupCallsEntries = List.of(groupCalls.entries);
+      for (final map in groupCallsEntries) {
         if (map.key.roomId == event.room.id) {
           // because we don't know which call got updated, just update all
           // group calls we have entered for that room

--- a/test/calls_test.dart
+++ b/test/calls_test.dart
@@ -14,6 +14,28 @@ import 'package:webrtc_interface/webrtc_interface.dart';
 import 'fake_client.dart';
 import 'webrtc_stub.dart';
 
+class MockMutatingGroupCallSession extends GroupCallSession {
+  MockMutatingGroupCallSession({
+    required super.client,
+    required super.room,
+    required super.voip,
+    required super.backend,
+    required super.groupCallId,
+    required super.application,
+    required super.scope,
+    this.onMemberStateChangedHook,
+  });
+
+  final FutureOr<void> Function()? onMemberStateChangedHook;
+  int onMemberStateChangedCalls = 0;
+
+  @override
+  Future<void> onMemberStateChanged() async {
+    onMemberStateChangedCalls++;
+    await onMemberStateChangedHook?.call();
+  }
+}
+
 void main() {
   late Client matrix;
   late Room room;
@@ -1276,5 +1298,66 @@ void main() {
       expect(incomingCall, isNotNull);
       expect(incomingCall?.pc, isNotNull);
     });
+
+    test(
+      'updates all room group calls when member-state handling mutates the map',
+      () async {
+        final firstGroupCall = MockMutatingGroupCallSession(
+          client: matrix,
+          room: room,
+          voip: voip,
+          backend: MeshBackend(),
+          groupCallId: 'group-call-a',
+          application: 'm.call',
+          scope: 'm.room',
+          onMemberStateChangedHook: () {
+            voip.setGroupCallById(
+              GroupCallSession(
+                client: matrix,
+                room: room,
+                voip: voip,
+                backend: MeshBackend(),
+                groupCallId: 'group-call-c',
+                application: 'm.call',
+                scope: 'm.room',
+              ),
+            );
+          },
+        );
+        final secondGroupCall = MockMutatingGroupCallSession(
+          client: matrix,
+          room: room,
+          voip: voip,
+          backend: MeshBackend(),
+          groupCallId: 'group-call-b',
+          application: 'm.call',
+          scope: 'm.room',
+        );
+
+        voip.setGroupCallById(firstGroupCall);
+        voip.setGroupCallById(secondGroupCall);
+
+        room.setState(
+          Event(
+            content: {'memberships': []},
+            type: EventTypes.GroupCallMember,
+            eventId: 'member-state-update',
+            senderId: '@alice:example.com',
+            originServerTs: DateTime.now(),
+            room: room,
+            stateKey: '@alice:example.com',
+          ),
+        );
+
+        await pumpEventQueue();
+
+        expect(firstGroupCall.onMemberStateChangedCalls, 1);
+        expect(secondGroupCall.onMemberStateChangedCalls, 1);
+        expect(
+          voip.groupCalls,
+          contains(VoipId(roomId: room.id, callId: 'group-call-c')),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
The VoIP room-state listener iterated directly over `groupCalls.entries` while awaiting `onMemberStateChanged()`, which can mutate the same map during membership processing and trigger `Concurrent modification during iteration`, aborting updates for remaining calls. Iterate over a snapshot instead and add a regression test that reproduces the mutation and verifies the listener continues processing safely.