### PR TITLE
fix: prevent overlapping group call force rejoins

### DIFF
--- a/lib/src/voip/group_call_session.dart
+++ b/lib/src/voip/group_call_session.dart
@@ -52,6 +52,7 @@ class GroupCallSession {
       CachedStreamController();
 
   Timer? _resendMemberStateEventTimer;
+  Future<void>? _forceRejoinInProgress;
 
   factory GroupCallSession.withAutoGenId(
     Room room,
@@ -253,6 +254,62 @@ class GroupCallSession {
     );
   }
 
+  Future<void> _forceRejoin() async {
+    if (_forceRejoinInProgress != null) {
+      Logs().v(
+        '[onMemberStateChanged] force rejoin already in progress for room ${room.id} groupCallId: $groupCallId',
+      );
+      return _forceRejoinInProgress!;
+    }
+
+    final cachedLocalParticipant = localParticipant;
+    var shouldRestoreLocalParticipant = false;
+
+    // Optimistically clear the stale local participant so repeated updates do
+    // not keep seeing a local leave while we wait for room state to catch up.
+    if (cachedLocalParticipant != null) {
+      shouldRestoreLocalParticipant = _participants.remove(
+        cachedLocalParticipant,
+      );
+    }
+
+    late final Future<void> rejoinInProgress;
+    rejoinInProgress = Future<void>(() async {
+      try {
+        Logs().w(
+          '[onMemberStateChanged] server says that we left the call but looks like we are still in it, will force join again',
+        );
+
+        // also clear delayed event state so that they can be started again
+        final canceller =
+            voip.delayedEventCancellers['${room.id}|$groupCallId|$scope'];
+        if (canceller != null) {
+          canceller.restartTimer.cancel();
+
+          // because the server said you left, you don't actually have to cancel
+          // the delayed event, the server already thinks it's cancelled
+
+          voip.delayedEventCancellers.remove('${room.id}|$groupCallId|$scope');
+        }
+
+        await sendMemberStateEvent();
+        await backend.preShareKey(this);
+      } catch (error) {
+        if (shouldRestoreLocalParticipant && state == GroupCallState.entered) {
+          _participants.add(cachedLocalParticipant!);
+        }
+        rethrow;
+      } finally {
+        if (identical(_forceRejoinInProgress, rejoinInProgress)) {
+          _forceRejoinInProgress = null;
+        }
+      }
+    });
+
+    _forceRejoinInProgress = rejoinInProgress;
+    return rejoinInProgress;
+  }
+
   /// compltetely rebuilds the local _participants list
   Future<void> onMemberStateChanged() async {
     // The member events may be received for another room, which we will ignore.
@@ -310,28 +367,8 @@ class GroupCallSession {
           // hm we did not leave but got a leave event? probably delayed
           // event did not restart, let's just send our member event again.
           // if we clicked the leave button our state would have been `leaving`
-          Logs().w(
-            '[onMemberStateChanged] server says that we left the call but looks like we are still in it, will force join again',
-          );
-
-          // also clear delayed event state so that they can be started again
-          final canceller =
-              voip.delayedEventCancellers['${room.id}|$groupCallId|$scope'];
-          if (canceller != null) {
-            canceller.restartTimer.cancel();
-
-            // because the server said you left, you don't actually have to cancel
-            // the delayed event, the server already thinks it's cancelled
-
-            voip.delayedEventCancellers.remove(
-              '${room.id}|$groupCallId|$scope',
-            );
-          }
-
-          // rejoin the call and share the key with the existing participants
+          await _forceRejoin();
           anyLeft.remove(localParticipant);
-          await sendMemberStateEvent();
-          await backend.preShareKey(this);
         }
 
         final nonLocalAnyLeft = Set<CallParticipant>.from(anyLeft)

--- a/lib/src/voip/group_call_session.dart
+++ b/lib/src/voip/group_call_session.dart
@@ -254,6 +254,25 @@ class GroupCallSession {
     );
   }
 
+  bool _removeCachedLocalParticipant(CallParticipant? participant) {
+    if (participant == null) {
+      return false;
+    }
+
+    return _participants.remove(participant);
+  }
+
+  void _dropDelayedLeaveState() {
+    final delayedEventKey = '${room.id}|$groupCallId|$scope';
+    final canceller = voip.delayedEventCancellers[delayedEventKey];
+    if (canceller == null) {
+      return;
+    }
+
+    canceller.restartTimer.cancel();
+    voip.delayedEventCancellers.remove(delayedEventKey);
+  }
+
   Future<void> _forceRejoin() async {
     if (_forceRejoinInProgress != null) {
       Logs().v(
@@ -263,15 +282,9 @@ class GroupCallSession {
     }
 
     final cachedLocalParticipant = localParticipant;
-    var shouldRestoreLocalParticipant = false;
-
-    // Optimistically clear the stale local participant so repeated updates do
-    // not keep seeing a local leave while we wait for room state to catch up.
-    if (cachedLocalParticipant != null) {
-      shouldRestoreLocalParticipant = _participants.remove(
-        cachedLocalParticipant,
-      );
-    }
+    final shouldRestoreLocalParticipant = _removeCachedLocalParticipant(
+      cachedLocalParticipant,
+    );
 
     late final Future<void> rejoinInProgress;
     rejoinInProgress = Future<void>(() async {
@@ -280,17 +293,7 @@ class GroupCallSession {
           '[onMemberStateChanged] server says that we left the call but looks like we are still in it, will force join again',
         );
 
-        // also clear delayed event state so that they can be started again
-        final canceller =
-            voip.delayedEventCancellers['${room.id}|$groupCallId|$scope'];
-        if (canceller != null) {
-          canceller.restartTimer.cancel();
-
-          // because the server said you left, you don't actually have to cancel
-          // the delayed event, the server already thinks it's cancelled
-
-          voip.delayedEventCancellers.remove('${room.id}|$groupCallId|$scope');
-        }
+        _dropDelayedLeaveState();
 
         await sendMemberStateEvent();
         await backend.preShareKey(this);

--- a/lib/src/voip/group_call_session.dart
+++ b/lib/src/voip/group_call_session.dart
@@ -285,6 +285,9 @@ class GroupCallSession {
     final shouldRestoreLocalParticipant = _removeCachedLocalParticipant(
       cachedLocalParticipant,
     );
+    if (!shouldRestoreLocalParticipant) {
+      return;
+    }
 
     late final Future<void> rejoinInProgress;
     rejoinInProgress = Future<void>(() async {

--- a/test/group_call_session_test.dart
+++ b/test/group_call_session_test.dart
@@ -1,0 +1,590 @@
+// SPDX-FileCopyrightText: 2019-Present Famedly GmbH
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/voip/models/delayed_event_canceller.dart';
+import 'package:test/test.dart';
+
+import 'fake_client.dart';
+import 'webrtc_stub.dart';
+
+class CountingPreShareKeyBackend extends MeshBackend {
+  int preShareKeyCalls = 0;
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    preShareKeyCalls++;
+  }
+}
+
+class ThrowOncePreShareKeyBackend extends MeshBackend {
+  int preShareKeyCalls = 0;
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    preShareKeyCalls++;
+    if (preShareKeyCalls == 1) {
+      throw Exception('preShareKey failed');
+    }
+  }
+}
+
+class MockConcurrentForceRejoinBackend extends MeshBackend {
+  final firstOnNewParticipantStarted = Completer<void>();
+  final secondOnNewParticipantStarted = Completer<void>();
+  final releaseOnNewParticipant = Completer<void>();
+  final firstPreShareKeyStarted = Completer<void>();
+  final secondPreShareKeyStarted = Completer<void>();
+  final releasePreShareKey = Completer<void>();
+  int onNewParticipantCalls = 0;
+  int preShareKeyCalls = 0;
+
+  @override
+  Future<void> onNewParticipant(
+    GroupCallSession groupCall,
+    List<CallParticipant> participants,
+  ) async {
+    onNewParticipantCalls++;
+    if (onNewParticipantCalls == 1 && !firstOnNewParticipantStarted.isCompleted) {
+      firstOnNewParticipantStarted.complete();
+    }
+    if (onNewParticipantCalls == 2 &&
+        !secondOnNewParticipantStarted.isCompleted) {
+      secondOnNewParticipantStarted.complete();
+    }
+    await releaseOnNewParticipant.future;
+  }
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    preShareKeyCalls++;
+    if (preShareKeyCalls == 1 && !firstPreShareKeyStarted.isCompleted) {
+      firstPreShareKeyStarted.complete();
+    }
+    if (preShareKeyCalls == 2 && !secondPreShareKeyStarted.isCompleted) {
+      secondPreShareKeyStarted.complete();
+    }
+    await releasePreShareKey.future;
+  }
+}
+
+class ThrowingConcurrentForceRejoinBackend extends MeshBackend {
+  final firstOnNewParticipantStarted = Completer<void>();
+  final secondOnNewParticipantStarted = Completer<void>();
+  final releaseOnNewParticipant = Completer<void>();
+  final preShareKeyStarted = Completer<void>();
+  final releasePreShareKey = Completer<void>();
+  int onNewParticipantCalls = 0;
+  int preShareKeyCalls = 0;
+
+  @override
+  Future<void> onNewParticipant(
+    GroupCallSession groupCall,
+    List<CallParticipant> participants,
+  ) async {
+    onNewParticipantCalls++;
+    if (onNewParticipantCalls == 1 && !firstOnNewParticipantStarted.isCompleted) {
+      firstOnNewParticipantStarted.complete();
+    }
+    if (onNewParticipantCalls == 2 &&
+        !secondOnNewParticipantStarted.isCompleted) {
+      secondOnNewParticipantStarted.complete();
+    }
+    await releaseOnNewParticipant.future;
+  }
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    preShareKeyCalls++;
+    if (!preShareKeyStarted.isCompleted) {
+      preShareKeyStarted.complete();
+    }
+    await releasePreShareKey.future;
+    throw Exception('preShareKey failed');
+  }
+}
+
+void main() {
+  late Client matrix;
+  late Room room;
+  late VoIP voip;
+  late CountingPreShareKeyBackend backend;
+  late GroupCallSession groupCall;
+
+  group('GroupCallSession tests', () {
+    Logs().level = Level.info;
+
+    setUp(() async {
+      matrix = await getClient();
+      await matrix.abortSync();
+
+      voip = VoIP(matrix, MockWebRTCDelegate());
+      const id = '!calls:example.com';
+      room = matrix.getRoomById(id)!;
+      backend = CountingPreShareKeyBackend();
+      groupCall = GroupCallSession.withAutoGenId(
+        room,
+        voip,
+        backend,
+        'm.call',
+        'm.room',
+        'test_force_rejoin_clears_stale_local_participant',
+      );
+      groupCall.setState(GroupCallState.entered);
+    });
+
+    tearDown(() async {
+      await groupCall.removeMemberStateEvent();
+    });
+
+    test(
+      'force rejoin clears stale local participant until room state catches up',
+      () async {
+        room.setState(
+          Event(
+            room: room,
+            eventId: 'local_mem_before_repair',
+            originServerTs: DateTime.now(),
+            type: EventTypes.GroupCallMember,
+            content: {
+              'memberships': [
+                CallMembership(
+                  userId: matrix.userID!,
+                  roomId: room.id,
+                  callId: groupCall.groupCallId,
+                  application: groupCall.application,
+                  scope: groupCall.scope,
+                  backend: backend,
+                  deviceId: matrix.deviceID!,
+                  expiresTs: DateTime.now()
+                      .add(Duration(hours: 1))
+                      .millisecondsSinceEpoch,
+                  membershipId: voip.currentSessionId,
+                  feeds: [],
+                  voip: voip,
+                ).toJson(),
+              ],
+            },
+            senderId: matrix.userID!,
+            stateKey: matrix.userID,
+          ),
+        );
+
+        await groupCall.onMemberStateChanged();
+        expect(groupCall.hasLocalParticipant(), isTrue);
+
+        room.setState(
+          Event(
+            room: room,
+            eventId: 'local_mem_removed_during_repair',
+            originServerTs: DateTime.now(),
+            type: EventTypes.GroupCallMember,
+            content: {'memberships': []},
+            senderId: matrix.userID!,
+            stateKey: matrix.userID,
+          ),
+        );
+
+        await groupCall.onMemberStateChanged();
+
+        expect(
+          groupCall.hasLocalParticipant(),
+          isFalse,
+          reason:
+              'The local participant cache must be cleared while waiting for the resent membership event to come back from room state.',
+        );
+        expect(backend.preShareKeyCalls, 1);
+
+        await groupCall.onMemberStateChanged();
+
+        expect(groupCall.hasLocalParticipant(), isFalse);
+        expect(
+          backend.preShareKeyCalls,
+          1,
+          reason:
+              'Once the stale local participant is cleared, repeated member-state updates before room state catches up must not trigger another force rejoin.',
+        );
+      },
+    );
+
+    test('force rejoin clears an existing delayed event canceller', () async {
+      final cancellerKey = '${room.id}|${groupCall.groupCallId}|${groupCall.scope}';
+      final restartTimer = Timer.periodic(Duration(hours: 1), (_) {});
+
+      voip.delayedEventCancellers[cancellerKey] = DelayedEventCanceller(
+        delayedEventId: 'existing-delayed-event',
+        restartTimer: restartTimer,
+      );
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_before_rejoin_with_canceller',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: matrix.userID!,
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: matrix.deviceID!,
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: voip.currentSessionId,
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await groupCall.onMemberStateChanged();
+      expect(groupCall.hasLocalParticipant(), isTrue);
+      expect(voip.delayedEventCancellers.containsKey(cancellerKey), isTrue);
+      expect(restartTimer.isActive, isTrue);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_removed_with_canceller',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {'memberships': []},
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await groupCall.onMemberStateChanged();
+
+      expect(backend.preShareKeyCalls, 1);
+      expect(groupCall.hasLocalParticipant(), isFalse);
+      expect(voip.delayedEventCancellers.containsKey(cancellerKey), isFalse);
+      expect(restartTimer.isActive, isFalse);
+    });
+
+    test('force rejoin failure keeps local participant eligible for retry', () async {
+      final backend = ThrowOncePreShareKeyBackend();
+      final groupCall = GroupCallSession.withAutoGenId(
+        room,
+        voip,
+        backend,
+        'm.call',
+        'm.room',
+        'test_force_rejoin_retry_after_failure',
+      );
+
+      groupCall.setState(GroupCallState.entered);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_before_failed_repair',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: matrix.userID!,
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: matrix.deviceID!,
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: voip.currentSessionId,
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await groupCall.onMemberStateChanged();
+      expect(groupCall.hasLocalParticipant(), isTrue);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_removed_before_failed_repair',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {'memberships': []},
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await expectLater(groupCall.onMemberStateChanged(), throwsException);
+
+      expect(
+        groupCall.hasLocalParticipant(),
+        isTrue,
+        reason:
+            'A failed force rejoin must restore the local participant cache so later diffs still detect that we need to retry.',
+      );
+      expect(backend.preShareKeyCalls, 1);
+
+      await groupCall.onMemberStateChanged();
+
+      expect(backend.preShareKeyCalls, 2);
+      expect(groupCall.hasLocalParticipant(), isFalse);
+    });
+
+    test('does not attempt multiple concurrent force rejoins', () async {
+      final backend = MockConcurrentForceRejoinBackend();
+      final groupCall = GroupCallSession.withAutoGenId(
+        room,
+        voip,
+        backend,
+        'm.call',
+        'm.room',
+        'test_reentrant_preshare',
+      );
+
+      groupCall.setState(GroupCallState.entered);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_before_repair',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: matrix.userID!,
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: matrix.deviceID!,
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: voip.currentSessionId,
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await groupCall.onMemberStateChanged();
+      expect(groupCall.hasLocalParticipant(), isTrue);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_removed_during_remote_join',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {'memberships': []},
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'remote_mem_after_local_disappeared',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: '@alice:testing.com',
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: 'ALICEDEVICE',
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: 'alice-membership',
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: '@alice:testing.com',
+          stateKey: '@alice:testing.com',
+        ),
+      );
+
+      final firstUpdate = groupCall.onMemberStateChanged();
+      await backend.firstOnNewParticipantStarted.future.timeout(
+        Duration(seconds: 1),
+      );
+
+      final secondUpdate = groupCall.onMemberStateChanged();
+      await backend.secondOnNewParticipantStarted.future.timeout(
+        Duration(seconds: 1),
+      );
+
+      if (!backend.releaseOnNewParticipant.isCompleted) {
+        backend.releaseOnNewParticipant.complete();
+      }
+      await backend.firstPreShareKeyStarted.future.timeout(Duration(seconds: 1));
+
+      try {
+        await expectLater(
+          backend.secondPreShareKeyStarted.future.timeout(
+            Duration(milliseconds: 100),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      } finally {
+        if (!backend.releasePreShareKey.isCompleted) {
+          backend.releasePreShareKey.complete();
+        }
+        await Future.wait([firstUpdate, secondUpdate]);
+      }
+
+      expect(backend.preShareKeyCalls, 1);
+    });
+
+    test('concurrent force rejoin waiters observe the same failure', () async {
+      final backend = ThrowingConcurrentForceRejoinBackend();
+      final groupCall = GroupCallSession.withAutoGenId(
+        room,
+        voip,
+        backend,
+        'm.call',
+        'm.room',
+        'test_reentrant_preshare_failure',
+      );
+
+      groupCall.setState(GroupCallState.entered);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_before_failed_rejoin',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: matrix.userID!,
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: matrix.deviceID!,
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: voip.currentSessionId,
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      await groupCall.onMemberStateChanged();
+      expect(groupCall.hasLocalParticipant(), isTrue);
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'local_mem_removed_during_failed_remote_join',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {'memberships': []},
+          senderId: matrix.userID!,
+          stateKey: matrix.userID,
+        ),
+      );
+
+      room.setState(
+        Event(
+          room: room,
+          eventId: 'remote_mem_after_failed_local_disappeared',
+          originServerTs: DateTime.now(),
+          type: EventTypes.GroupCallMember,
+          content: {
+            'memberships': [
+              CallMembership(
+                userId: '@alice:testing.com',
+                roomId: room.id,
+                callId: groupCall.groupCallId,
+                application: groupCall.application,
+                scope: groupCall.scope,
+                backend: backend,
+                deviceId: 'ALICEDEVICE',
+                expiresTs: DateTime.now()
+                    .add(Duration(hours: 1))
+                    .millisecondsSinceEpoch,
+                membershipId: 'alice-membership',
+                feeds: [],
+                voip: voip,
+              ).toJson(),
+            ],
+          },
+          senderId: '@alice:testing.com',
+          stateKey: '@alice:testing.com',
+        ),
+      );
+
+      final firstUpdate = groupCall.onMemberStateChanged();
+      await backend.firstOnNewParticipantStarted.future.timeout(
+        Duration(seconds: 1),
+      );
+
+      final secondUpdate = groupCall.onMemberStateChanged();
+      await backend.secondOnNewParticipantStarted.future.timeout(
+        Duration(seconds: 1),
+      );
+
+      if (!backend.releaseOnNewParticipant.isCompleted) {
+        backend.releaseOnNewParticipant.complete();
+      }
+      await backend.preShareKeyStarted.future.timeout(Duration(seconds: 1));
+
+      if (!backend.releasePreShareKey.isCompleted) {
+        backend.releasePreShareKey.complete();
+      }
+
+      final results = await Future.wait([
+        firstUpdate.then<Object?>((_) => null).catchError((error) => error),
+        secondUpdate.then<Object?>((_) => null).catchError((error) => error),
+      ]);
+
+      expect(results, hasLength(2));
+      expect(results[0], isA<Exception>());
+      expect(results[1], isA<Exception>());
+      expect(backend.preShareKeyCalls, 1);
+      expect(groupCall.hasLocalParticipant(), isTrue);
+    });
+  });
+}

--- a/test/group_call_session_test.dart
+++ b/test/group_call_session_test.dart
@@ -48,7 +48,8 @@ class MockConcurrentForceRejoinBackend extends MeshBackend {
     List<CallParticipant> participants,
   ) async {
     onNewParticipantCalls++;
-    if (onNewParticipantCalls == 1 && !firstOnNewParticipantStarted.isCompleted) {
+    if (onNewParticipantCalls == 1 &&
+        !firstOnNewParticipantStarted.isCompleted) {
       firstOnNewParticipantStarted.complete();
     }
     if (onNewParticipantCalls == 2 &&
@@ -71,6 +72,35 @@ class MockConcurrentForceRejoinBackend extends MeshBackend {
   }
 }
 
+class StaggeredConcurrentForceRejoinBackend extends MeshBackend {
+  final firstOnNewParticipantStarted = Completer<void>();
+  final secondOnNewParticipantStarted = Completer<void>();
+  final releaseFirstOnNewParticipant = Completer<void>();
+  final releaseSecondOnNewParticipant = Completer<void>();
+  int onNewParticipantCalls = 0;
+  int preShareKeyCalls = 0;
+
+  @override
+  Future<void> onNewParticipant(
+    GroupCallSession groupCall,
+    List<CallParticipant> participants,
+  ) async {
+    onNewParticipantCalls++;
+    if (onNewParticipantCalls == 1) {
+      firstOnNewParticipantStarted.complete();
+      await releaseFirstOnNewParticipant.future;
+    } else if (onNewParticipantCalls == 2) {
+      secondOnNewParticipantStarted.complete();
+      await releaseSecondOnNewParticipant.future;
+    }
+  }
+
+  @override
+  Future<void> preShareKey(GroupCallSession groupCall) async {
+    preShareKeyCalls++;
+  }
+}
+
 class ThrowingConcurrentForceRejoinBackend extends MeshBackend {
   final firstOnNewParticipantStarted = Completer<void>();
   final secondOnNewParticipantStarted = Completer<void>();
@@ -86,7 +116,8 @@ class ThrowingConcurrentForceRejoinBackend extends MeshBackend {
     List<CallParticipant> participants,
   ) async {
     onNewParticipantCalls++;
-    if (onNewParticipantCalls == 1 && !firstOnNewParticipantStarted.isCompleted) {
+    if (onNewParticipantCalls == 1 &&
+        !firstOnNewParticipantStarted.isCompleted) {
       firstOnNewParticipantStarted.complete();
     }
     if (onNewParticipantCalls == 2 &&
@@ -150,7 +181,9 @@ void main() {
         originServerTs: DateTime.now(),
         type: EventTypes.GroupCallMember,
         content: {
-          'memberships': memberships.map((membership) => membership.toJson()).toList(),
+          'memberships': memberships
+              .map((membership) => membership.toJson())
+              .toList(),
         },
         senderId: senderId,
         stateKey: stateKey,
@@ -230,7 +263,8 @@ void main() {
     );
 
     test('force rejoin clears an existing delayed event canceller', () async {
-      final cancellerKey = '${room.id}|${groupCall.groupCallId}|${groupCall.scope}';
+      final cancellerKey =
+          '${room.id}|${groupCall.groupCallId}|${groupCall.scope}';
       final restartTimer = Timer.periodic(Duration(hours: 1), (_) {});
 
       voip.delayedEventCancellers[cancellerKey] = DelayedEventCanceller(
@@ -243,9 +277,7 @@ void main() {
         eventId: 'local_mem_before_rejoin_with_canceller',
         senderId: matrix.userID!,
         stateKey: matrix.userID!,
-        memberships: [
-          buildMembership(backend: backend, groupCall: groupCall),
-        ],
+        memberships: [buildMembership(backend: backend, groupCall: groupCall)],
       );
 
       await groupCall.onMemberStateChanged();
@@ -268,54 +300,57 @@ void main() {
       expect(restartTimer.isActive, isFalse);
     });
 
-    test('force rejoin failure keeps local participant eligible for retry', () async {
-      final backend = ThrowOncePreShareKeyBackend();
-      final groupCall = GroupCallSession.withAutoGenId(
-        room,
-        voip,
-        backend,
-        'm.call',
-        'm.room',
-        'test_force_rejoin_retry_after_failure',
-      );
+    test(
+      'force rejoin failure keeps local participant eligible for retry',
+      () async {
+        final backend = ThrowOncePreShareKeyBackend();
+        final groupCall = GroupCallSession.withAutoGenId(
+          room,
+          voip,
+          backend,
+          'm.call',
+          'm.room',
+          'test_force_rejoin_retry_after_failure',
+        );
 
-      groupCall.setState(GroupCallState.entered);
+        groupCall.setState(GroupCallState.entered);
 
-      setGroupCallMemberState(
-        groupCall: groupCall,
-        eventId: 'local_mem_before_failed_repair',
-        senderId: matrix.userID!,
-        stateKey: matrix.userID!,
-        memberships: [
-          buildMembership(backend: backend, groupCall: groupCall),
-        ],
-      );
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_before_failed_repair',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
+          memberships: [
+            buildMembership(backend: backend, groupCall: groupCall),
+          ],
+        );
 
-      await groupCall.onMemberStateChanged();
-      expect(groupCall.hasLocalParticipant(), isTrue);
+        await groupCall.onMemberStateChanged();
+        expect(groupCall.hasLocalParticipant(), isTrue);
 
-      setGroupCallMemberState(
-        groupCall: groupCall,
-        eventId: 'local_mem_removed_before_failed_repair',
-        senderId: matrix.userID!,
-        stateKey: matrix.userID!,
-      );
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_removed_before_failed_repair',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
+        );
 
-      await expectLater(groupCall.onMemberStateChanged(), throwsException);
+        await expectLater(groupCall.onMemberStateChanged(), throwsException);
 
-      expect(
-        groupCall.hasLocalParticipant(),
-        isTrue,
-        reason:
-            'A failed force rejoin must restore the local participant cache so later diffs still detect that we need to retry.',
-      );
-      expect(backend.preShareKeyCalls, 1);
+        expect(
+          groupCall.hasLocalParticipant(),
+          isTrue,
+          reason:
+              'A failed force rejoin must restore the local participant cache so later diffs still detect that we need to retry.',
+        );
+        expect(backend.preShareKeyCalls, 1);
 
-      await groupCall.onMemberStateChanged();
+        await groupCall.onMemberStateChanged();
 
-      expect(backend.preShareKeyCalls, 2);
-      expect(groupCall.hasLocalParticipant(), isFalse);
-    });
+        expect(backend.preShareKeyCalls, 2);
+        expect(groupCall.hasLocalParticipant(), isFalse);
+      },
+    );
 
     test('does not attempt multiple concurrent force rejoins', () async {
       final backend = MockConcurrentForceRejoinBackend();
@@ -335,9 +370,7 @@ void main() {
         eventId: 'local_mem_before_repair',
         senderId: matrix.userID!,
         stateKey: matrix.userID!,
-        memberships: [
-          buildMembership(backend: backend, groupCall: groupCall),
-        ],
+        memberships: [buildMembership(backend: backend, groupCall: groupCall)],
       );
 
       await groupCall.onMemberStateChanged();
@@ -379,7 +412,9 @@ void main() {
       if (!backend.releaseOnNewParticipant.isCompleted) {
         backend.releaseOnNewParticipant.complete();
       }
-      await backend.firstPreShareKeyStarted.future.timeout(Duration(seconds: 1));
+      await backend.firstPreShareKeyStarted.future.timeout(
+        Duration(seconds: 1),
+      );
 
       try {
         await expectLater(
@@ -397,6 +432,91 @@ void main() {
 
       expect(backend.preShareKeyCalls, 1);
     });
+
+    test(
+      'it does not rejoin from a stale snapshot after another rejoin completes',
+      () async {
+        final backend = StaggeredConcurrentForceRejoinBackend();
+        final groupCall = GroupCallSession.withAutoGenId(
+          room,
+          voip,
+          backend,
+          'm.call',
+          'm.room',
+          'test_stale_snapshot_rejoin',
+        );
+
+        groupCall.setState(GroupCallState.entered);
+
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_before_stale_snapshot',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
+          memberships: [
+            buildMembership(backend: backend, groupCall: groupCall),
+          ],
+        );
+
+        await groupCall.onMemberStateChanged();
+        expect(groupCall.hasLocalParticipant(), isTrue);
+
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_removed_before_stale_snapshot',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
+        );
+
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'remote_mem_for_stale_snapshot',
+          senderId: '@alice:testing.com',
+          stateKey: '@alice:testing.com',
+          memberships: [
+            buildMembership(
+              backend: backend,
+              groupCall: groupCall,
+              userId: '@alice:testing.com',
+              deviceId: 'ALICEDEVICE',
+              membershipId: 'alice-membership',
+            ),
+          ],
+        );
+        FakeMatrixApi.calledEndpoints.clear();
+
+        final firstUpdate = groupCall.onMemberStateChanged();
+        await backend.firstOnNewParticipantStarted.future.timeout(
+          Duration(seconds: 1),
+        );
+
+        final secondUpdate = groupCall.onMemberStateChanged();
+        await backend.secondOnNewParticipantStarted.future.timeout(
+          Duration(seconds: 1),
+        );
+
+        backend.releaseFirstOnNewParticipant.complete();
+        await firstUpdate.timeout(Duration(seconds: 1));
+        expect(backend.preShareKeyCalls, 1);
+
+        backend.releaseSecondOnNewParticipant.complete();
+        await secondUpdate.timeout(Duration(seconds: 1));
+
+        final memberStateEventCalls = FakeMatrixApi.calledEndpoints.entries
+            .where(
+              (entry) => entry.key.contains('/state/com.famedly.call.member/'),
+            )
+            .fold<int>(0, (sum, entry) => sum + entry.value.length);
+
+        expect(memberStateEventCalls, 1);
+        expect(
+          backend.preShareKeyCalls,
+          1,
+          reason:
+              'A caller with a stale anyLeft snapshot must not rejoin after the first caller has cleared the local participant cache.',
+        );
+      },
+    );
 
     test('concurrent force rejoin waiters observe the same failure', () async {
       final backend = ThrowingConcurrentForceRejoinBackend();
@@ -416,9 +536,7 @@ void main() {
         eventId: 'local_mem_before_failed_rejoin',
         senderId: matrix.userID!,
         stateKey: matrix.userID!,
-        memberships: [
-          buildMembership(backend: backend, groupCall: groupCall),
-        ],
+        memberships: [buildMembership(backend: backend, groupCall: groupCall)],
       );
 
       await groupCall.onMemberStateChanged();

--- a/test/group_call_session_test.dart
+++ b/test/group_call_session_test.dart
@@ -114,6 +114,50 @@ void main() {
   late CountingPreShareKeyBackend backend;
   late GroupCallSession groupCall;
 
+  CallMembership buildMembership({
+    required CallBackend backend,
+    required GroupCallSession groupCall,
+    String? userId,
+    String? deviceId,
+    String? membershipId,
+  }) {
+    return CallMembership(
+      userId: userId ?? matrix.userID!,
+      roomId: room.id,
+      callId: groupCall.groupCallId,
+      application: groupCall.application,
+      scope: groupCall.scope,
+      backend: backend,
+      deviceId: deviceId ?? matrix.deviceID!,
+      expiresTs: DateTime.now().add(Duration(hours: 1)).millisecondsSinceEpoch,
+      membershipId: membershipId ?? voip.currentSessionId,
+      feeds: [],
+      voip: voip,
+    );
+  }
+
+  void setGroupCallMemberState({
+    required GroupCallSession groupCall,
+    required String eventId,
+    required String senderId,
+    required String stateKey,
+    List<CallMembership> memberships = const [],
+  }) {
+    room.setState(
+      Event(
+        room: room,
+        eventId: eventId,
+        originServerTs: DateTime.now(),
+        type: EventTypes.GroupCallMember,
+        content: {
+          'memberships': memberships.map((membership) => membership.toJson()).toList(),
+        },
+        senderId: senderId,
+        stateKey: stateKey,
+      ),
+    );
+  }
+
   group('GroupCallSession tests', () {
     Logs().level = Level.info;
 
@@ -143,49 +187,24 @@ void main() {
     test(
       'force rejoin clears stale local participant until room state catches up',
       () async {
-        room.setState(
-          Event(
-            room: room,
-            eventId: 'local_mem_before_repair',
-            originServerTs: DateTime.now(),
-            type: EventTypes.GroupCallMember,
-            content: {
-              'memberships': [
-                CallMembership(
-                  userId: matrix.userID!,
-                  roomId: room.id,
-                  callId: groupCall.groupCallId,
-                  application: groupCall.application,
-                  scope: groupCall.scope,
-                  backend: backend,
-                  deviceId: matrix.deviceID!,
-                  expiresTs: DateTime.now()
-                      .add(Duration(hours: 1))
-                      .millisecondsSinceEpoch,
-                  membershipId: voip.currentSessionId,
-                  feeds: [],
-                  voip: voip,
-                ).toJson(),
-              ],
-            },
-            senderId: matrix.userID!,
-            stateKey: matrix.userID,
-          ),
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_before_repair',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
+          memberships: [
+            buildMembership(backend: backend, groupCall: groupCall),
+          ],
         );
 
         await groupCall.onMemberStateChanged();
         expect(groupCall.hasLocalParticipant(), isTrue);
 
-        room.setState(
-          Event(
-            room: room,
-            eventId: 'local_mem_removed_during_repair',
-            originServerTs: DateTime.now(),
-            type: EventTypes.GroupCallMember,
-            content: {'memberships': []},
-            senderId: matrix.userID!,
-            stateKey: matrix.userID,
-          ),
+        setGroupCallMemberState(
+          groupCall: groupCall,
+          eventId: 'local_mem_removed_during_repair',
+          senderId: matrix.userID!,
+          stateKey: matrix.userID!,
         );
 
         await groupCall.onMemberStateChanged();
@@ -219,34 +238,14 @@ void main() {
         restartTimer: restartTimer,
       );
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_before_rejoin_with_canceller',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: matrix.userID!,
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: matrix.deviceID!,
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: voip.currentSessionId,
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_before_rejoin_with_canceller',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
+        memberships: [
+          buildMembership(backend: backend, groupCall: groupCall),
+        ],
       );
 
       await groupCall.onMemberStateChanged();
@@ -254,16 +253,11 @@ void main() {
       expect(voip.delayedEventCancellers.containsKey(cancellerKey), isTrue);
       expect(restartTimer.isActive, isTrue);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_removed_with_canceller',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {'memberships': []},
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_removed_with_canceller',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
       );
 
       await groupCall.onMemberStateChanged();
@@ -287,49 +281,24 @@ void main() {
 
       groupCall.setState(GroupCallState.entered);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_before_failed_repair',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: matrix.userID!,
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: matrix.deviceID!,
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: voip.currentSessionId,
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_before_failed_repair',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
+        memberships: [
+          buildMembership(backend: backend, groupCall: groupCall),
+        ],
       );
 
       await groupCall.onMemberStateChanged();
       expect(groupCall.hasLocalParticipant(), isTrue);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_removed_before_failed_repair',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {'memberships': []},
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_removed_before_failed_repair',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
       );
 
       await expectLater(groupCall.onMemberStateChanged(), throwsException);
@@ -361,79 +330,40 @@ void main() {
 
       groupCall.setState(GroupCallState.entered);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_before_repair',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: matrix.userID!,
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: matrix.deviceID!,
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: voip.currentSessionId,
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_before_repair',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
+        memberships: [
+          buildMembership(backend: backend, groupCall: groupCall),
+        ],
       );
 
       await groupCall.onMemberStateChanged();
       expect(groupCall.hasLocalParticipant(), isTrue);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_removed_during_remote_join',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {'memberships': []},
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_removed_during_remote_join',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
       );
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'remote_mem_after_local_disappeared',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: '@alice:testing.com',
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: 'ALICEDEVICE',
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: 'alice-membership',
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: '@alice:testing.com',
-          stateKey: '@alice:testing.com',
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'remote_mem_after_local_disappeared',
+        senderId: '@alice:testing.com',
+        stateKey: '@alice:testing.com',
+        memberships: [
+          buildMembership(
+            backend: backend,
+            groupCall: groupCall,
+            userId: '@alice:testing.com',
+            deviceId: 'ALICEDEVICE',
+            membershipId: 'alice-membership',
+          ),
+        ],
       );
 
       final firstUpdate = groupCall.onMemberStateChanged();
@@ -481,79 +411,40 @@ void main() {
 
       groupCall.setState(GroupCallState.entered);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_before_failed_rejoin',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: matrix.userID!,
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: matrix.deviceID!,
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: voip.currentSessionId,
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_before_failed_rejoin',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
+        memberships: [
+          buildMembership(backend: backend, groupCall: groupCall),
+        ],
       );
 
       await groupCall.onMemberStateChanged();
       expect(groupCall.hasLocalParticipant(), isTrue);
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'local_mem_removed_during_failed_remote_join',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {'memberships': []},
-          senderId: matrix.userID!,
-          stateKey: matrix.userID,
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'local_mem_removed_during_failed_remote_join',
+        senderId: matrix.userID!,
+        stateKey: matrix.userID!,
       );
 
-      room.setState(
-        Event(
-          room: room,
-          eventId: 'remote_mem_after_failed_local_disappeared',
-          originServerTs: DateTime.now(),
-          type: EventTypes.GroupCallMember,
-          content: {
-            'memberships': [
-              CallMembership(
-                userId: '@alice:testing.com',
-                roomId: room.id,
-                callId: groupCall.groupCallId,
-                application: groupCall.application,
-                scope: groupCall.scope,
-                backend: backend,
-                deviceId: 'ALICEDEVICE',
-                expiresTs: DateTime.now()
-                    .add(Duration(hours: 1))
-                    .millisecondsSinceEpoch,
-                membershipId: 'alice-membership',
-                feeds: [],
-                voip: voip,
-              ).toJson(),
-            ],
-          },
-          senderId: '@alice:testing.com',
-          stateKey: '@alice:testing.com',
-        ),
+      setGroupCallMemberState(
+        groupCall: groupCall,
+        eventId: 'remote_mem_after_failed_local_disappeared',
+        senderId: '@alice:testing.com',
+        stateKey: '@alice:testing.com',
+        memberships: [
+          buildMembership(
+            backend: backend,
+            groupCall: groupCall,
+            userId: '@alice:testing.com',
+            deviceId: 'ALICEDEVICE',
+            membershipId: 'alice-membership',
+          ),
+        ],
       );
 
       final firstUpdate = groupCall.onMemberStateChanged();


### PR DESCRIPTION
When GroupCallSession.onMemberStateChanged() observed the local membership disappear while the call was still in entered, concurrent updates could trigger the force-rejoin path more than once before room state caught up. That led to repeated sendMemberStateEvent() and preShareKey() work, which could cascade into redundant key generation and unstable local participant state. 

This change extracts the recovery flow into _forceRejoin(), shares a single in-flight rejoin across concurrent callers, and clears the stale local participant cache before awaiting the resend path. 

The test coverage was also tightened with focused GroupCallSession regressions that prove both behaviors: stale local state is cleared until room state catches up, and concurrent updates do not start multiple force rejoins.