### PR TITLE
Fixes for OIDC

### DIFF
--- a/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
+++ b/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
@@ -30,6 +30,8 @@ extension Msc2966OidcDynamicClientRegistration on Client {
     if (redirectUris.isEmpty) {
       throw Exception('At least one redirect URI is required!');
     }
+
+    const loopbackHosts = {'localhost', '127.0.0.1', '[::1]'};
     switch (applicationType) {
       case OidcApplicationType.web:
         if (redirectUris.any((uri) => uri.scheme != 'https')) {
@@ -44,19 +46,34 @@ extension Msc2966OidcDynamicClientRegistration on Client {
         }
         break;
       case OidcApplicationType.native:
-        const allowedHosts = {'localhost', '127.0.0.1', '[::1]'};
         if (redirectUris.any(
-          (uri) => uri.scheme == 'http' && !allowedHosts.contains(uri.host),
+          (uri) => uri.scheme == 'http' && !loopbackHosts.contains(uri.host),
         )) {
           throw Exception(
-            'For http loopback interfaces, the host must be one of $allowedHosts',
+            'For http loopback interfaces, the host must be one of $loopbackHosts',
           );
         }
         break;
     }
+
+    // Remove port from address during registration if its a loopback
+    // Some homeservers will reject authentication otherwise.
+    // Setting the port to the default 80 removes it from toString()
+    final registrationRedirectUris = redirectUris
+        .map(
+          (uri) =>
+              applicationType == OidcApplicationType.native &&
+                  uri.scheme == 'http'
+              ? uri.replace(port: 80)
+              : uri,
+        )
+        .toList();
+
     final body = <String, Object?>{
       ...?additionalProperties,
-      'redirect_uris': redirectUris.map((uri) => uri.toString()).toList(),
+      'redirect_uris': registrationRedirectUris
+          .map((uri) => uri.toString())
+          .toList(),
       'token_endpoint_auth_method': tokenEndpointAuthMethod,
       'response_types': responseTypes,
       'grant_types': grantTypes,


### PR DESCRIPTION
These changes allow connection to the newly added OIDC support in [Continuwuity](https://forgejo.ellis.link/continuwuation/continuwuity).
I tested the change by building FluffyChat, which worked (After setting the [oidc flag](https://github.com/krille-chan/fluffychat/blob/650a35b58f1115035a35fbb8629190eb9d260ee2/lib/config/setting_keys.dart#L61)).

Currently, login fails because:
- ~~OIDC-only logins make the sdk throw an exception~~
  - ~~First patch modifies the logic so that the exception only occurs if both legacy and oidc login are unavailable~~
- ~~Continuwuity returns code 200 on successful registration, but 201 is expected by the sdk~~
  - ~~Continuwuity is not standard-conformant here and 201 is correct. I've submitted a [patch](https://forgejo.ellis.link/continuwuation/continuwuity/pulls/1984) there to fix the return code.~~
  - ~~Since this is not *really* an error, for stability I modified the logic to allow 200 as well~~
- Continuwuity will reject oidc registration for loopback addresses if a port is specified. (See [code snippet from continuwuity](https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/52026bb0f1866ebc27dde99ffd69c3ffac2892da/src/service/oauth/client_metadata.rs#L95))
  - I'm not sure which is standard conformant here. The standard only says that "The authorization server MUST allow any port to be specified at the time of the request", i.e. at authorization, but not registration.

The third patch may or may not be correct here, I'm really not sure. Let me know what you think.

NOTE: I've never written dart code, extra scrutiny is appreciated

EDIT: Patch 1 and 2 superseded by #2412 