### PR TITLE
fix: make login types check optional

### DIFF
--- a/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
+++ b/lib/msc_extensions/msc_2964_oidc_login_flow/msc_2964_oidc_login_flow.dart
@@ -96,8 +96,13 @@ extension Msc2964OidcLoginFlow on Client {
       body: body,
       headers: {'content-type': 'application/x-www-form-urlencoded'},
     );
-    if (response.statusCode != 200) {
+    if (response.statusCode >= 400) {
       unexpectedResponse(response, response.bodyBytes);
+    }
+    if (response.statusCode != 200) {
+      Logs().w(
+        'Expected a status code of 200 but got ${response.statusCode} for OIDC login.',
+      );
     }
     final responseString = utf8.decode(response.bodyBytes);
     final oidcAuthResponse = OidcAuthResponse.fromJson(
@@ -129,8 +134,13 @@ extension Msc2964OidcLoginFlow on Client {
       },
       headers: {'content-type': 'application/x-www-form-urlencoded'},
     );
-    if (response.statusCode != 200) {
+    if (response.statusCode >= 400) {
       unexpectedResponse(response, response.bodyBytes);
+    }
+    if (response.statusCode != 200) {
+      Logs().w(
+        'Expected a status code of 200 but got ${response.statusCode} for OIDC refresh.',
+      );
     }
     final responseString = utf8.decode(response.bodyBytes);
     return OidcAuthResponse.fromJson(jsonDecode(responseString));
@@ -151,8 +161,13 @@ extension Msc2964OidcLoginFlow on Client {
       },
       headers: {'content-type': 'application/x-www-form-urlencoded'},
     );
-    if (response.statusCode != 200) {
+    if (response.statusCode >= 400) {
       unexpectedResponse(response, response.bodyBytes);
+    }
+    if (response.statusCode != 200) {
+      Logs().w(
+        'Expected a status code of 200 but got ${response.statusCode} for revoke OIDC token.',
+      );
     }
   }
 }

--- a/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
+++ b/lib/msc_extensions/msc_2966_oidc_dynamic_client_registration/msc_2966_oidc_dynamic_client_registration.dart
@@ -72,8 +72,13 @@ extension Msc2966OidcDynamicClientRegistration on Client {
       body: jsonEncode(body),
       headers: {'content-type': 'application/json'},
     );
-    if (response.statusCode != 201) {
+    if (response.statusCode >= 400) {
       unexpectedResponse(response, response.bodyBytes);
+    }
+    if (response.statusCode != 201) {
+      Logs().w(
+        'Expected a status code of 201 but got ${response.statusCode} for OIDC client registration.',
+      );
     }
     final responseString = utf8.decode(response.bodyBytes);
     final json = jsonDecode(responseString);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -8,10 +8,11 @@ import 'dart:core';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:async/async.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:http/http.dart' as http;
 import 'package:matrix/encryption.dart';
-import 'package:matrix/matrix.dart';
+import 'package:matrix/matrix.dart' hide Result;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart';
 import 'package:matrix/msc_extensions/msc_unpublished_custom_refresh_token_lifetime/msc_unpublished_custom_refresh_token_lifetime.dart';
 import 'package:matrix/src/models/timeline_chunk.dart';
@@ -576,8 +577,15 @@ class Client extends MatrixApi {
         assert(false);
       }
 
-      final loginTypes = await getLoginFlows() ?? [];
-      if (!loginTypes.any((f) => supportedLoginTypes.contains(f.type))) {
+      final loginTypesResult = await Result.capture(getLoginFlows());
+      final loginTypes = loginTypesResult.asValue?.value ?? [];
+      final loginTypesError = loginTypesResult.asError?.error;
+      if (loginTypesError != null && loginTypesError is! MatrixException) {
+        Logs().w('Unable to fetch legacy login types', loginTypesError);
+      }
+
+      if (loginTypes.isNotEmpty &&
+          !loginTypes.any((f) => supportedLoginTypes.contains(f.type))) {
         throw BadServerLoginTypesException(
           loginTypes.map((f) => f.type).toSet(),
           supportedLoginTypes,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -581,7 +581,7 @@ class Client extends MatrixApi {
       final loginTypes = loginTypesResult.asValue?.value ?? [];
       final loginTypesError = loginTypesResult.asError?.error;
       if (loginTypesError != null && loginTypesError is! MatrixException) {
-        Logs().w('Unable to fetch legacy login types', loginTypesError);
+        throw loginTypesError;
       }
 
       if (loginTypes.isNotEmpty &&


### PR DESCRIPTION
check for login types is soon legacy duo to matrix native oidc. Making this a requirement actually makes login to oidc only homeservers like newest version of conduwuit impossible.

closes https://github.com/krille-chan/fluffychat/issues/3250

closes https://famedly.atlassian.net/browse/FM-757