### PR TITLE
fix: allow redact-power users to end polls (MSC3381)

### DIFF
--- a/lib/msc_extensions/msc_3381_polls/poll_event_extension.dart
+++ b/lib/msc_extensions/msc_3381_polls/poll_event_extension.dart
@@ -120,11 +120,23 @@ extension PollEventExtension on Event {
     );
   }
 
+  /// Ends this poll by sending an `m.poll.end` reference event into the
+  /// room.
+  ///
+  /// Per MSC3381, a poll may be ended by its creator or by a user with
+  /// permission to redact other users' messages in the room (the redaction
+  /// power level). This matches the receiving-side validation in
+  /// [_getEndPollEvent], which ignores `m.poll.end` events from any other
+  /// sender.
+  ///
+  /// Throws an [Exception] if this event is not a poll start event or if the
+  /// current user is neither the poll creator nor allowed to redact in the
+  /// room.
   Future<String?> endPoll({String? txid}) {
     if (type != PollEventContent.startType) {
       throw Exception('Event is not a poll.');
     }
-    if (senderId != room.client.userID) {
+    if (senderId != room.client.userID && !room.canRedact) {
       throw Exception('You can not end a poll created by someone else.');
     }
     return room.sendEvent(

--- a/test/msc_extensions/msc_3881_polls_test.dart
+++ b/test/msc_extensions/msc_3881_polls_test.dart
@@ -370,6 +370,60 @@ void main() {
       expect(await getRoomEventsFuture.timeout(const Duration(seconds: 1)), 1);
       await aggregationFinished.future.timeout(const Duration(seconds: 1));
     });
+
+    test('endPoll: only the creator or a user with redact power may end (MSC3381)', () async {
+      final room = client.getRoomById(roomId)!;
+      room.membership = Membership.join;
+      final content = PollEventContent(
+        mText: 'EndPoll',
+        pollStartContent: PollStartContent(
+          maxSelections: 1,
+          question: PollQuestion(mText: 'Who?'),
+          answers: [PollAnswer(id: 'a', mText: 'A')],
+        ),
+      ).toJson();
+
+      Event poll(String sender) => Event(
+            content: content,
+            type: PollEventContent.startType,
+            eventId: 'poll_$sender',
+            senderId: sender,
+            originServerTs: DateTime.now(),
+            room: room,
+          );
+
+      void stubEnd(String txid) =>
+          (FakeMatrixApi.currentApi!.api['PUT'] ??= {})['/client/v3/rooms/!696r7674%3Aexample.com/send/org.matrix.msc3381.poll.end/$txid'] =
+              (var req) => {'event_id': txid};
+
+      const other = '@someone:example.com';
+
+      // A non-creator without redact power may not end the poll.
+      expectLater(
+        () => poll(other).endPoll(),
+        throwsA(predicate(
+          (Object? e) => e
+              .toString()
+              .contains('You can not end a poll created by someone else.'),
+        )),
+      );
+
+      // Grant redact power; the same non-creator may now end it.
+      (room.states[EventTypes.RoomPowerLevels] ??= {})[''] = Event.fromJson({
+        'type': EventTypes.RoomPowerLevels,
+        'sender': other,
+        'state_key': '',
+        'content': {'redact': 0, 'users': {client.userID!: 0}, 'users_default': 0},
+        'room_id': room.id,
+        'origin_server_ts': 1,
+      }, room);
+      stubEnd('end_mod');
+      expect(await poll(other).endPoll(txid: 'end_mod'), 'end_mod');
+
+      // The creator may always end their own poll.
+      stubEnd('end_creator');
+      expect(await poll(client.userID!).endPoll(txid: 'end_creator'), 'end_creator');
+    });
   });
 }
 

--- a/test/msc_extensions/msc_3881_polls_test.dart
+++ b/test/msc_extensions/msc_3881_polls_test.dart
@@ -399,7 +399,7 @@ void main() {
       const other = '@someone:example.com';
 
       // A non-creator without redact power may not end the poll.
-      expectLater(
+      await expectLater(
         () => poll(other).endPoll(),
         throwsA(predicate(
           (Object? e) => e


### PR DESCRIPTION
## Summary

I am working on a Matrix client called [Kohera](https://github.com/Quantumheart/Kohera). I am currently, working through the [polling spec 3381](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3381-polls.md) and found that the power level redaction is not respected for moderators.

## Changes
* add !room.canRedact
* add test "endPoll: creator may end, non-creator without redact power may not, redact power may end"