### PR TITLE
Krille/refactor user device keys

### DIFF
--- a/doc/trust-on-first-use.md
+++ b/doc/trust-on-first-use.md
@@ -42,7 +42,7 @@ Future<List<User>> getUntrustedUsers(Room room) async {
 
         if (keys == null ||
             masterKey == null ||
-            await masterKey.verified ||
+            masterKey.verified ||
             masterKey.trustOnFirstUseSince != null) {
             continue;
         }

--- a/doc/trust-on-first-use.md
+++ b/doc/trust-on-first-use.md
@@ -14,14 +14,14 @@ You can store that a user confirmed to this by this:
 
 ```dart
 // Assuming that this user has cross signing enabled and we know the master key:
-final masterKey = client.userDeviceKeys['@userid:domain.abc']?.masterKey;
-masterKey?.trustOnFirstUse();
+final keys = await client.fetchUserDeviceKeysList('@userid:domain.abc');
+final masterKey = keys?.masterKey?.trustOnFirstUse();
 ```
 
 You can check the datetime when you have done this like this:
 
 ```dart
-final tofuSince = masterKey?.trustOnFirstUseSince; // returns a DateTime?
+final tofuSince = keys?.masterKey?.trustOnFirstUseSince; // returns a DateTime?
 ```
 
 You can loop over all users in a room like this:
@@ -31,20 +31,24 @@ Future<List<User>> getUntrustedUsers(Room room) async {
     if (!room.encrypted) return [];
 
     final users = await room.requestParticipants();
+    final userIds = users.map((u) => u.id).toSet();
+    final allKeys = await room.client.fetchUserDeviceKeysLists(userIds);
 
-    return users.where((user) {
-        if (user.id == room.client.userID) return false;
-        final keys = room.client.userDeviceKeys[user.id];
+    final untrusted = <User>[];
+    for (final user in users) {
+        if (user.id == room.client.userID) continue;
+        final keys = allKeys[user.id];
         final masterKey = keys?.masterKey;
 
         if (keys == null ||
             masterKey == null ||
-            masterKey.verified ||
+            await masterKey.verified ||
             masterKey.trustOnFirstUseSince != null) {
-            return false;
+            continue;
         }
-        return true;
-    }).toList();
+        untrusted.add(user);
+    }
+    return untrusted;
 }
 ```
 

--- a/lib/encryption/cross_signing.dart
+++ b/lib/encryption/cross_signing.dart
@@ -21,8 +21,9 @@ class CrossSigning {
     ) async {
       try {
         final keyObj = vod.PkSigning.fromSecretKey(secret);
+        final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
         return keyObj.publicKey.toBase64() ==
-            client.userDeviceKeys[client.userID]!.selfSigningKey!.ed25519Key;
+            ownKeys!.selfSigningKey!.ed25519Key;
       } catch (_) {
         return false;
       }
@@ -32,8 +33,9 @@ class CrossSigning {
     ) async {
       try {
         final keyObj = vod.PkSigning.fromSecretKey(secret);
+        final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
         return keyObj.publicKey.toBase64() ==
-            client.userDeviceKeys[client.userID]!.userSigningKey!.ed25519Key;
+            ownKeys!.userSigningKey!.ed25519Key;
       } catch (_) {
         return false;
       }
@@ -86,12 +88,12 @@ class CrossSigning {
     } catch (e) {
       masterPubkey = null;
     }
-    final userDeviceKeys =
-        client.userDeviceKeys[client.userID]?.deviceKeys[client.deviceID];
+    final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+    final userDeviceKeys = ownKeys?.deviceKeys[client.deviceID];
     if (masterPubkey == null || userDeviceKeys == null) {
       throw Exception('Master or user keys not found');
     }
-    final masterKey = client.userDeviceKeys[client.userID]?.masterKey;
+    final masterKey = ownKeys?.masterKey;
     if (masterKey == null || masterKey.ed25519Key != masterPubkey) {
       throw Exception('Master pubkey key doesn\'t match');
     }
@@ -113,7 +115,7 @@ class CrossSigning {
     final signedKeys = <MatrixSignableKey>[];
     Uint8List? selfSigningKey;
     Uint8List? userSigningKey;
-    final userKeys = client.userDeviceKeys[client.userID];
+    final userKeys = await client.fetchUserDeviceKeysList(client.userID!);
     if (userKeys == null) {
       throw Exception('[sign] keys are not in cache but sign was called');
     }

--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -389,12 +389,12 @@ class Encryption {
 
   Future<void> autovalidateMasterOwnKey() async {
     // check if we can set our own master key as verified, if it isn't yet
-    final userId = client.userID;
-    final masterKey = client.userDeviceKeys[userId]?.masterKey;
+    final userId = client.userID!;
+    final ownKeys = await client.fetchUserDeviceKeysList(userId);
+    final masterKey = ownKeys?.masterKey;
     if (masterKey != null &&
-        userId != null &&
         !masterKey.directVerified &&
-        masterKey.hasValidSignatureChain(onlyValidateUserIds: {userId})) {
+        await masterKey.hasValidSignatureChain(onlyValidateUserIds: {userId})) {
       await masterKey.setVerified(true);
     }
   }

--- a/lib/encryption/encryption.dart
+++ b/lib/encryption/encryption.dart
@@ -394,7 +394,7 @@ class Encryption {
     final masterKey = ownKeys?.masterKey;
     if (masterKey != null &&
         !masterKey.directVerified &&
-        await masterKey.hasValidSignatureChain(onlyValidateUserIds: {userId})) {
+        masterKey.hasValidSignatureChain(onlyValidateUserIds: {userId})) {
       await masterKey.setVerified(true);
     }
   }

--- a/lib/encryption/key_manager.dart
+++ b/lib/encryption/key_manager.dart
@@ -89,7 +89,7 @@ class KeyManager {
     if (userId == null) return Future.value();
 
     if (!senderClaimedKeys_.containsKey('ed25519')) {
-      final device = client.getUserDeviceKeysByCurve25519Key(senderKey);
+      final device = await client.getUserDeviceKeysByCurve25519Key(senderKey);
       if (device != null && device.ed25519Key != null) {
         senderClaimedKeys_['ed25519'] = device.ed25519Key!;
       }
@@ -229,7 +229,7 @@ class KeyManager {
   }) async {
     final room = client.getRoomById(roomId);
     final requestIdent = '$roomId|$sessionId';
-    if (room != null && !client.isUnknownSession) {
+    if (room != null && !await client.isUnknownSession) {
       final existingReqCompleter = _requestedSessionIdCompleters[requestIdent];
       if (existingReqCompleter != null) {
         if (awaitRequest) {
@@ -290,9 +290,9 @@ class KeyManager {
     return roomInboundGroupSessions[sessionId] = dbSess;
   }
 
-  Map<String, Map<String, bool>> _getDeviceKeyIdMap(
+  Future<Map<String, Map<String, bool>>> _getDeviceKeyIdMap(
     List<DeviceKeys> deviceKeys,
-  ) {
+  ) async {
     final deviceKeyIds = <String, Map<String, bool>>{};
     for (final device in deviceKeys) {
       final deviceId = device.deviceId;
@@ -301,7 +301,7 @@ class KeyManager {
         continue;
       }
       final userDeviceKeyIds = deviceKeyIds[device.userId] ??= <String, bool>{};
-      userDeviceKeyIds[deviceId] = !device.encryptToDevice;
+      userDeviceKeyIds[deviceId] = !(await device.encryptToDevice);
     }
     return deviceKeyIds;
   }
@@ -356,7 +356,7 @@ class KeyManager {
       // next check if the devices in the room changed
       final devicesToReceive = <DeviceKeys>[];
       final newDeviceKeys = await room.getUserDeviceKeys();
-      final newDeviceKeyIds = _getDeviceKeyIdMap(newDeviceKeys);
+      final newDeviceKeyIds = await _getDeviceKeyIdMap(newDeviceKeys);
       // first check for user differences
       final oldUserIds = sess.devices.keys.toSet();
       final newUserIds = newDeviceKeyIds.keys.toSet();
@@ -439,10 +439,15 @@ class KeyManager {
           'session_key': sess.outboundGroupSession!.sessionKey,
         };
         try {
-          devicesToReceive.removeWhere((k) => !k.encryptToDevice);
-          if (devicesToReceive.isNotEmpty) {
+          final encryptableDevices = <DeviceKeys>[];
+          for (final device in devicesToReceive) {
+            if (await device.encryptToDevice) {
+              encryptableDevices.add(device);
+            }
+          }
+          if (encryptableDevices.isNotEmpty) {
             // update allowedAtIndex
-            for (final device in devicesToReceive) {
+            for (final device in encryptableDevices) {
               inboundSess!.allowedAtIndex[device.userId] ??= <String, int>{};
               if (!inboundSess.allowedAtIndex[device.userId]!.containsKey(
                     device.curve25519Key,
@@ -462,7 +467,7 @@ class KeyManager {
             );
             // send out the key
             await client.sendToDeviceEncryptedChunked(
-              devicesToReceive,
+              encryptableDevices,
               EventTypes.RoomKey,
               rawSession,
             );
@@ -550,9 +555,14 @@ class KeyManager {
       );
     }
 
-    final deviceKeys = await room.getUserDeviceKeys();
-    final deviceKeyIds = _getDeviceKeyIdMap(deviceKeys);
-    deviceKeys.removeWhere((k) => !k.encryptToDevice);
+    final allDeviceKeys = await room.getUserDeviceKeys();
+    final deviceKeyIds = await _getDeviceKeyIdMap(allDeviceKeys);
+    final deviceKeys = <DeviceKeys>[];
+    for (final device in allDeviceKeys) {
+      if (await device.encryptToDevice) {
+        deviceKeys.add(device);
+      }
+    }
     final outboundGroupSession = vod.GroupSession();
 
     final rawSession = <String, dynamic>{
@@ -901,13 +911,13 @@ class KeyManager {
         // so that the event loop can progress
         var i = 0;
         for (final dbSession in dbSessions) {
-          final device = client.getUserDeviceKeysByCurve25519Key(
+          final device = await client.getUserDeviceKeysByCurve25519Key(
             dbSession.senderKey,
           );
           args.dbSessions.add(
             DbInboundGroupSessionBundle(
               dbSession: dbSession,
-              verified: device?.verified ?? false,
+              verified: (await device?.verified) ?? false,
             ),
           );
           i++;
@@ -970,9 +980,11 @@ class KeyManager {
           );
           return; // wrong type for roomId or no roomId found
         }
-        final device = client
-            .userDeviceKeys[event.sender]
-            ?.deviceKeys[event.content['requesting_device_id']];
+        final senderDeviceKeys = await client.fetchUserDeviceKeysList(
+          event.sender,
+        );
+        final device =
+            senderDeviceKeys?.deviceKeys[event.content['requesting_device_id']];
         if (device == null) {
           Logs().w('[KeyManager] Device not found, doing nothing');
           return; // device not found
@@ -1023,12 +1035,12 @@ class KeyManager {
           request,
         );
         if (device.userId == client.userID &&
-            device.verified &&
+            await device.verified &&
             !device.blocked) {
           Logs().i('[KeyManager] All checks out, forwarding key...');
           // alright, we can forward the key
           await roomKeyRequest.forwardKey();
-        } else if (device.encryptToDevice &&
+        } else if (await device.encryptToDevice &&
             session.allowedAtIndex
                     .tryGet<Map<String, Object?>>(device.userId)
                     ?.tryGet(device.curve25519Key!) !=
@@ -1150,8 +1162,10 @@ class KeyManager {
         );
         return;
       }
-      final sender_ed25519 = client
-          .userDeviceKeys[event.sender]
+      final senderDeviceKeys = await client.fetchUserDeviceKeysList(
+        event.sender,
+      );
+      final sender_ed25519 = senderDeviceKeys
           ?.deviceKeys[event.content['requesting_device_id']]
           ?.ed25519Key;
       if (sender_ed25519 != null) {

--- a/lib/encryption/key_manager.dart
+++ b/lib/encryption/key_manager.dart
@@ -630,7 +630,6 @@ class KeyManager {
     if (!enabled) {
       return false;
     }
-    await client.userDeviceKeysLoading;
     return (await encryption.ssss.getCached(megolmKey)) != null;
   }
 
@@ -867,8 +866,6 @@ class KeyManager {
 
     Future<void> uploadInternal() async {
       try {
-        await client.userDeviceKeysLoading;
-
         if (!(await isCached())) {
           return; // we can't backup anyways
         }

--- a/lib/encryption/key_manager.dart
+++ b/lib/encryption/key_manager.dart
@@ -301,7 +301,7 @@ class KeyManager {
         continue;
       }
       final userDeviceKeyIds = deviceKeyIds[device.userId] ??= <String, bool>{};
-      userDeviceKeyIds[deviceId] = !(await device.encryptToDevice);
+      userDeviceKeyIds[deviceId] = !(device.encryptToDevice);
     }
     return deviceKeyIds;
   }
@@ -441,7 +441,7 @@ class KeyManager {
         try {
           final encryptableDevices = <DeviceKeys>[];
           for (final device in devicesToReceive) {
-            if (await device.encryptToDevice) {
+            if (device.encryptToDevice) {
               encryptableDevices.add(device);
             }
           }
@@ -559,7 +559,7 @@ class KeyManager {
     final deviceKeyIds = await _getDeviceKeyIdMap(allDeviceKeys);
     final deviceKeys = <DeviceKeys>[];
     for (final device in allDeviceKeys) {
-      if (await device.encryptToDevice) {
+      if (device.encryptToDevice) {
         deviceKeys.add(device);
       }
     }
@@ -917,7 +917,7 @@ class KeyManager {
           args.dbSessions.add(
             DbInboundGroupSessionBundle(
               dbSession: dbSession,
-              verified: (await device?.verified) ?? false,
+              verified: (device?.verified) ?? false,
             ),
           );
           i++;
@@ -1035,12 +1035,12 @@ class KeyManager {
           request,
         );
         if (device.userId == client.userID &&
-            await device.verified &&
+            device.verified &&
             !device.blocked) {
           Logs().i('[KeyManager] All checks out, forwarding key...');
           // alright, we can forward the key
           await roomKeyRequest.forwardKey();
-        } else if (await device.encryptToDevice &&
+        } else if (device.encryptToDevice &&
             session.allowedAtIndex
                     .tryGet<Map<String, Object?>>(device.userId)
                     ?.tryGet(device.curve25519Key!) !=

--- a/lib/encryption/olm_manager.dart
+++ b/lib/encryption/olm_manager.dart
@@ -384,8 +384,10 @@ class OlmManager {
     if (type != 0 && type != 1) {
       throw DecryptException(DecryptException.unknownMessageType);
     }
-    final device = client.userDeviceKeys[event.sender]?.deviceKeys.values
-        .firstWhereOrNull((d) => d.curve25519Key == senderKey);
+    final senderKeys = await client.fetchUserDeviceKeysList(event.sender);
+    final device = senderKeys?.deviceKeys.values.firstWhereOrNull(
+      (d) => d.curve25519Key == senderKey,
+    );
     final existingSessions = olmSessions[senderKey];
     Future<void> updateSessionUsage([OlmSession? session]) async {
       try {
@@ -528,11 +530,13 @@ class OlmManager {
   final Map<String, DateTime> _restoredOlmSessionsTime = {};
 
   Future<void> restoreOlmSession(String userId, String senderKey) async {
-    if (!client.userDeviceKeys.containsKey(userId)) {
+    final userKeys = await client.fetchUserDeviceKeysList(userId);
+    if (userKeys == null) {
       return;
     }
-    final device = client.userDeviceKeys[userId]!.deviceKeys.values
-        .firstWhereOrNull((d) => d.curve25519Key == senderKey);
+    final device = userKeys.deviceKeys.values.firstWhereOrNull(
+      (d) => d.curve25519Key == senderKey,
+    );
     if (device == null) {
       return;
     }
@@ -599,10 +603,9 @@ class OlmManager {
       final userId = userKeysEntry.key;
       for (final deviceKeysEntry in userKeysEntry.value.entries) {
         final deviceId = deviceKeysEntry.key;
-        final fingerprintKey =
-            client.userDeviceKeys[userId]!.deviceKeys[deviceId]!.ed25519Key;
-        final identityKey =
-            client.userDeviceKeys[userId]!.deviceKeys[deviceId]!.curve25519Key;
+        final fetchedKeys = await client.fetchUserDeviceKeysList(userId);
+        final fingerprintKey = fetchedKeys!.deviceKeys[deviceId]!.ed25519Key;
+        final identityKey = fetchedKeys.deviceKeys[deviceId]!.curve25519Key;
         for (final deviceKey in deviceKeysEntry.value.values) {
           if (fingerprintKey == null ||
               identityKey == null ||
@@ -745,7 +748,7 @@ class OlmManager {
       if (encryptedContent == null || encryption.olmDatabase == null) {
         return;
       }
-      final device = client.getUserDeviceKeysByCurve25519Key(
+      final device = await client.getUserDeviceKeysByCurve25519Key(
         encryptedContent.tryGet<String>('sender_key') ?? '',
       );
       if (device == null) {

--- a/lib/encryption/ssss.dart
+++ b/lib/encryption/ssss.dart
@@ -516,20 +516,23 @@ class SSSS {
     // only send to own, verified devices
     Logs().i('[SSSS] Requesting type $type...');
     if (devices == null || devices.isEmpty) {
-      if (!client.userDeviceKeys.containsKey(client.userID)) {
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      if (ownKeys == null) {
         Logs().w('[SSSS] User does not have any devices');
         return;
       }
-      devices = client.userDeviceKeys[client.userID]!.deviceKeys.values
-          .toList();
+      devices = ownKeys.deviceKeys.values.toList();
     }
-    devices.removeWhere(
-      (DeviceKeys d) =>
-          d.userId != client.userID ||
-          !d.verified ||
-          d.blocked ||
-          d.deviceId == client.deviceID,
-    );
+    final verifiedDevices = <DeviceKeys>[];
+    for (final d in devices) {
+      if (d.userId == client.userID &&
+          await d.verified &&
+          !d.blocked &&
+          d.deviceId != client.deviceID) {
+        verifiedDevices.add(d);
+      }
+    }
+    devices = verifiedDevices;
     if (devices.isEmpty) {
       Logs().w('[SSSS] No devices');
       return;
@@ -558,7 +561,7 @@ class SSSS {
             DateTime.now()
                 .subtract(Duration(minutes: 15))
                 .isBefore(_lastCacheRequest!)) ||
-        client.isUnknownSession) {
+        await client.isUnknownSession) {
       // we are already requesting right now or we attempted to within the last 15 min
       return;
     }
@@ -575,8 +578,12 @@ class SSSS {
     if (event.type == EventTypes.SecretRequest) {
       // got a request to share a secret
       Logs().i('[SSSS] Received sharing request...');
-      if (event.sender != client.userID ||
-          !client.userDeviceKeys.containsKey(client.userID)) {
+      if (event.sender != client.userID) {
+        Logs().i('[SSSS] Not sent by us');
+        return; // we aren't asking for it ourselves, so ignore
+      }
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      if (ownKeys == null) {
         Logs().i('[SSSS] Not sent by us');
         return; // we aren't asking for it ourselves, so ignore
       }
@@ -584,10 +591,8 @@ class SSSS {
         Logs().i('[SSSS] it is actually a cancelation');
         return; // not actually requesting, so ignore
       }
-      final device = client
-          .userDeviceKeys[client.userID]!
-          .deviceKeys[event.content['requesting_device_id']];
-      if (device == null || !device.verified || device.blocked) {
+      final device = ownKeys.deviceKeys[event.content['requesting_device_id']];
+      if (device == null || !(await device.verified) || device.blocked) {
         Logs().i('[SSSS] Unknown / unverified devices, ignoring');
         return; // nope....unknown or untrusted device
       }
@@ -1148,19 +1153,17 @@ class OpenSSSS {
     // first try to cache all secrets that aren't cached yet
     await maybeCacheAll();
     // now try to self-sign
+    final ownKeys = await ssss.client.fetchUserDeviceKeysList(
+      ssss.client.userID!,
+    );
     if (ssss.encryption.crossSigning.enabled &&
-        ssss.client.userDeviceKeys[ssss.client.userID]?.masterKey != null &&
+        ownKeys?.masterKey != null &&
         (ssss
                 .keyIdsFromType(EventTypes.CrossSigningMasterKey)
                 ?.contains(keyId) ??
             false) &&
-        (ssss.client.isUnknownSession ||
-            ssss
-                    .client
-                    .userDeviceKeys[ssss.client.userID]!
-                    .masterKey
-                    ?.directVerified !=
-                true)) {
+        (await ssss.client.isUnknownSession ||
+            ownKeys?.masterKey?.directVerified != true)) {
       try {
         await ssss.encryption.crossSigning.selfSign(openSsss: this);
       } catch (e, s) {

--- a/lib/encryption/ssss.dart
+++ b/lib/encryption/ssss.dart
@@ -526,7 +526,7 @@ class SSSS {
     final verifiedDevices = <DeviceKeys>[];
     for (final d in devices) {
       if (d.userId == client.userID &&
-          await d.verified &&
+          d.verified &&
           !d.blocked &&
           d.deviceId != client.deviceID) {
         verifiedDevices.add(d);
@@ -592,7 +592,7 @@ class SSSS {
         return; // not actually requesting, so ignore
       }
       final device = ownKeys.deviceKeys[event.content['requesting_device_id']];
-      if (device == null || !(await device.verified) || device.blocked) {
+      if (device == null || !(device.verified) || device.blocked) {
         Logs().i('[SSSS] Unknown / unverified devices, ignoring');
         return; // nope....unknown or untrusted device
       }

--- a/lib/encryption/utils/bootstrap.dart
+++ b/lib/encryption/utils/bootstrap.dart
@@ -422,7 +422,9 @@ class Bootstrap {
       // aaaand set the SSSS secrets
       if (masterKey != null) {
         while (!(masterKey.publicKey != null &&
-            client.userDeviceKeys[client.userID]?.masterKey?.ed25519Key ==
+            (await client.fetchUserDeviceKeysList(
+                  client.userID!,
+                ))?.masterKey?.ed25519Key ==
                 masterKey.publicKey)) {
           Logs().v('Waiting for master to be created');
           await client.oneShotSync();
@@ -438,24 +440,19 @@ class Bootstrap {
       }
 
       final keysToSign = <SignableKey>[];
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
       if (masterKey != null) {
-        if (client.userDeviceKeys[client.userID]?.masterKey?.ed25519Key !=
-            masterKey.publicKey) {
+        if (ownKeys?.masterKey?.ed25519Key != masterKey.publicKey) {
           throw BootstrapBadStateException(
             'ERROR: New master key does not match up!',
           );
         }
         Logs().v('Set own master key to verified...');
-        await client.userDeviceKeys[client.userID]!.masterKey!.setVerified(
-          true,
-          false,
-        );
-        keysToSign.add(client.userDeviceKeys[client.userID]!.masterKey!);
+        await ownKeys!.masterKey!.setVerified(true, false);
+        keysToSign.add(ownKeys.masterKey!);
       }
       if (selfSigningKey != null && selfSign) {
-        keysToSign.add(
-          client.userDeviceKeys[client.userID]!.deviceKeys[client.deviceID]!,
-        );
+        keysToSign.add(ownKeys!.deviceKeys[client.deviceID]!);
       }
       Logs().v('Sign ourself...');
       await encryption.crossSigning.sign(keysToSign);

--- a/lib/encryption/utils/key_verification.dart
+++ b/lib/encryption/utils/key_verification.dart
@@ -385,7 +385,6 @@ class KeyVerification {
 
           // ensure we have the other sides keys
           if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            await client.updateUserDeviceKeys(additionalUsers: {userId});
             if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;
@@ -433,7 +432,6 @@ class KeyVerification {
 
           // ensure we have the other sides keys
           if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            await client.updateUserDeviceKeys(additionalUsers: {userId});
             if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;
@@ -520,7 +518,6 @@ class KeyVerification {
 
           // ensure we have the other sides keys
           if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            await client.updateUserDeviceKeys(additionalUsers: {userId});
             if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;

--- a/lib/encryption/utils/key_verification.dart
+++ b/lib/encryption/utils/key_verification.dart
@@ -261,7 +261,7 @@ class KeyVerification {
     final ownKeys = client.userID != null
         ? await client.fetchUserDeviceKeysList(client.userID!)
         : null;
-    final ownMasterVerified = await ownKeys?.masterKey?.verified ?? false;
+    final ownMasterVerified = ownKeys?.masterKey?.verified ?? false;
     final qrCanWork = (userId == client.userID) || ownMasterVerified;
 
     if (client.verificationMethods.contains(KeyVerificationMethod.qrShow) &&
@@ -642,11 +642,11 @@ class KeyVerification {
         final ownUserKeys = await client.fetchUserDeviceKeysList(
           client.userID!,
         );
-        if (!(await ownUserKeys?.deviceKeys[deviceId]?.hasValidSignatureChain(
+        if (!(ownUserKeys?.deviceKeys[deviceId]?.hasValidSignatureChain(
                   verifiedByTheirMasterKey: true,
                 ) ??
                 false) &&
-            !(await ownUserKeys?.masterKey?.verified ?? false)) {
+            !(ownUserKeys?.masterKey?.verified ?? false)) {
           copyKnownVerificationMethods.removeWhere(
             (element) => element.startsWith('m.qr_code'),
           );
@@ -956,7 +956,7 @@ class KeyVerification {
           final deviceKeysToSend = <DeviceKeys>[];
           if (userDeviceKeys != null) {
             for (final deviceKey in userDeviceKeys.deviceKeys.values) {
-              if (await deviceKey.hasValidSignatureChain(
+              if (deviceKey.hasValidSignatureChain(
                 verifiedByTheirMasterKey: true,
               )) {
                 deviceKeysToSend.add(deviceKey);
@@ -1035,7 +1035,7 @@ class KeyVerification {
       QRMode.verifyOtherUser,
       QRMode.verifySelfUntrusted,
     }.contains(remoteQrMode)) {
-      if (!(await ownMasterKey?.verified ?? false)) {
+      if (!(ownMasterKey?.verified ?? false)) {
         Logs().e(
           '[KeyVerification] verifyQrData because you were in mode 0/2 and had untrusted msk',
         );
@@ -1090,13 +1090,13 @@ class KeyVerification {
         otherMasterKey != null) {
       // we already have this check when sending `knownVerificationMethods`, but
       // just to be safe anyway
-      if (await ownMasterKey.verified) {
+      if (ownMasterKey.verified) {
         return (ownMasterKey.ed25519Key!, otherMasterKey.ed25519Key!);
       }
     } else if (mode == QRMode.verifySelfTrusted &&
         ownMasterKey != null &&
         otherDeviceKey != null) {
-      if (await ownMasterKey.verified) {
+      if (ownMasterKey.verified) {
         return (ownMasterKey.ed25519Key!, otherDeviceKey.ed25519Key!);
       }
     } else if (mode == QRMode.verifySelfUntrusted &&
@@ -1531,7 +1531,7 @@ class _KeyVerificationMethodSas extends _KeyVerificationMethod {
                 ? await client.fetchUserDeviceKeysList(client.userID!)
                 : null)
             ?.masterKey;
-    if (masterKey != null && await masterKey.verified) {
+    if (masterKey != null && masterKey.verified) {
       // we have our own master key verified, let's send it!
       final masterKeyId = 'ed25519:${masterKey.publicKey}';
       mac[masterKeyId] = _calculateMac(

--- a/lib/encryption/utils/key_verification.dart
+++ b/lib/encryption/utils/key_verification.dart
@@ -250,7 +250,7 @@ class KeyVerification {
             : null);
   }
 
-  List<String> get knownVerificationMethods {
+  Future<List<String>> get knownVerificationMethods async {
     final methods = <String>{};
     if (client.verificationMethods.contains(KeyVerificationMethod.numbers) ||
         client.verificationMethods.contains(KeyVerificationMethod.emoji)) {
@@ -258,9 +258,11 @@ class KeyVerification {
     }
 
     /// `qrCanWork` -  qr cannot work if we are verifying another master key but our own is unverified
-    final qrCanWork =
-        (userId == client.userID) ||
-        ((client.userDeviceKeys[client.userID]?.masterKey?.verified ?? false));
+    final ownKeys = client.userID != null
+        ? await client.fetchUserDeviceKeysList(client.userID!)
+        : null;
+    final ownMasterVerified = await ownKeys?.masterKey?.verified ?? false;
+    final qrCanWork = (userId == client.userID) || ownMasterVerified;
 
     if (client.verificationMethods.contains(KeyVerificationMethod.qrShow) &&
         qrCanWork) {
@@ -309,7 +311,7 @@ class KeyVerification {
 
   Future<void> sendRequest() async {
     await send(EventTypes.KeyVerificationRequest, {
-      'methods': knownVerificationMethods,
+      'methods': await knownVerificationMethods,
       if (room == null) 'timestamp': DateTime.now().millisecondsSinceEpoch,
     });
     startedVerification = true;
@@ -323,7 +325,7 @@ class KeyVerification {
     }
     if (encryption.crossSigning.enabled &&
         !(await encryption.crossSigning.isCached()) &&
-        !client.isUnknownSession) {
+        !await client.isUnknownSession) {
       setState(KeyVerificationState.askSSSS);
       _nextAction = 'request';
     } else {
@@ -333,13 +335,13 @@ class KeyVerification {
 
   bool _handlePayloadLock = false;
 
-  QRMode getOurQRMode() {
+  Future<QRMode> getOurQRMode() async {
     var mode = QRMode.verifyOtherUser;
     if (client.userID == userId) {
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
       if (client.encryption != null &&
           client.encryption!.enabled &&
-          (client.userDeviceKeys[client.userID]?.masterKey?.directVerified ??
-              false)) {
+          (ownKeys?.masterKey?.directVerified ?? false)) {
         mode = QRMode.verifySelfTrusted;
       } else {
         mode = QRMode.verifySelfUntrusted;
@@ -361,6 +363,9 @@ class KeyVerification {
     }
     _handlePayloadLock = true;
     Logs().i('[Key Verification] Received type $type: $payload');
+    // Fetch once upfront to avoid multiple DB round-trips within the switch.
+    final knownMethods = await knownVerificationMethods;
+    var userKeys = await client.fetchUserDeviceKeysList(userId);
     try {
       var thisLastStep = lastStep;
       switch (type) {
@@ -384,8 +389,10 @@ class KeyVerification {
           }
 
           // ensure we have the other sides keys
-          if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
+          if (userKeys?.deviceKeys[deviceId!] == null) {
+            await client.database.storeUserDeviceKeysInfo(userId, true);
+            userKeys = await client.fetchUserDeviceKeysList(userId);
+            if (userKeys?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;
             }
@@ -394,7 +401,7 @@ class KeyVerification {
           oppositePossibleMethods = List<String>.from(payload['methods']);
           // verify it has a method we can use
           possibleMethods = _calculatePossibleMethods(
-            knownVerificationMethods,
+            knownMethods,
             payload['methods'],
           );
           if (possibleMethods.isEmpty) {
@@ -411,8 +418,7 @@ class KeyVerification {
             transactionId ??= eventId ?? payload['transaction_id'];
             // and broadcast the cancel to the other devices
             final devices = List<DeviceKeys>.from(
-              client.userDeviceKeys[userId]?.deviceKeys.values ??
-                  Iterable.empty(),
+              userKeys?.deviceKeys.values ?? Iterable.empty(),
             );
             devices.removeWhere(
               (d) => {deviceId, client.deviceID}.contains(d.deviceId),
@@ -431,8 +437,10 @@ class KeyVerification {
           _deviceId ??= payload['from_device'];
 
           // ensure we have the other sides keys
-          if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
+          if (userKeys?.deviceKeys[deviceId!] == null) {
+            await client.database.storeUserDeviceKeysInfo(userId, true);
+            userKeys = await client.fetchUserDeviceKeysList(userId);
+            if (userKeys?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;
             }
@@ -440,7 +448,7 @@ class KeyVerification {
 
           oppositePossibleMethods = List<String>.from(payload['methods']);
           possibleMethods = _calculatePossibleMethods(
-            knownVerificationMethods,
+            knownMethods,
             payload['methods'],
           );
           if (possibleMethods.isEmpty) {
@@ -457,8 +465,8 @@ class KeyVerification {
 
           // play nice with sdks < 0.20.5
           // https://matrix.to/#/!KBwfdofYJUmnsVoqwn:famedly.de/$wlHXlLQJdfrqKAF5KkuQrXydwOhY_uyqfH4ReasZqnA?via=neko.dev&via=famedly.de&via=lihotzki.de
-          if (!isQrSupported(knownVerificationMethods, payload['methods'])) {
-            if (knownVerificationMethods.contains(EventTypes.Sas)) {
+          if (!isQrSupported(knownMethods, payload['methods'])) {
+            if (knownMethods.contains(EventTypes.Sas)) {
               final method = _method = _makeVerificationMethod(
                 possibleMethods.first,
                 this,
@@ -504,7 +512,7 @@ class KeyVerification {
           ]))) {
             return; // abort
           }
-          if (!knownVerificationMethods.contains(payload['method'])) {
+          if (!knownMethods.contains(payload['method'])) {
             await cancel('m.unknown_method');
             return;
           }
@@ -517,8 +525,10 @@ class KeyVerification {
           }
 
           // ensure we have the other sides keys
-          if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
-            if (client.userDeviceKeys[userId]?.deviceKeys[deviceId!] == null) {
+          if (userKeys?.deviceKeys[deviceId!] == null) {
+            await client.database.storeUserDeviceKeysInfo(userId, true);
+            userKeys = await client.fetchUserDeviceKeysList(userId);
+            if (userKeys?.deviceKeys[deviceId!] == null) {
               await cancel('im.fluffychat.unknown_device');
               return;
             }
@@ -625,16 +635,18 @@ class KeyVerification {
     }
     setState(KeyVerificationState.waitingAccept);
     if (lastStep == EventTypes.KeyVerificationRequest) {
-      final copyKnownVerificationMethods = List<String>.from(
-        knownVerificationMethods,
-      );
+      final knownMethods = await knownVerificationMethods;
+      final copyKnownVerificationMethods = List<String>.from(knownMethods);
       // qr code only works when atleast one side has verified master key
       if (userId == client.userID) {
-        if (!(client.userDeviceKeys[client.userID]?.deviceKeys[deviceId]
-                    ?.hasValidSignatureChain(verifiedByTheirMasterKey: true) ??
+        final ownUserKeys = await client.fetchUserDeviceKeysList(
+          client.userID!,
+        );
+        if (!(await ownUserKeys?.deviceKeys[deviceId]?.hasValidSignatureChain(
+                  verifiedByTheirMasterKey: true,
+                ) ??
                 false) &&
-            !(client.userDeviceKeys[client.userID]?.masterKey?.verified ??
-                false)) {
+            !(await ownUserKeys?.masterKey?.verified ?? false)) {
           copyKnownVerificationMethods.removeWhere(
             (element) => element.startsWith('m.qr_code'),
           );
@@ -759,7 +771,7 @@ class KeyVerification {
   ) async {
     _verifiedDevices = <SignableKey>[];
 
-    final userDeviceKey = client.userDeviceKeys[userId];
+    final userDeviceKey = await client.fetchUserDeviceKeysList(userId);
     if (userDeviceKey == null) {
       await cancel('m.key_mismatch');
       return;
@@ -779,7 +791,7 @@ class KeyVerification {
     }
     // okay, we reached this far, so all the devices are verified!
     var verifiedMasterKey = false;
-    final wasUnknownSession = client.isUnknownSession;
+    final wasUnknownSession = await client.isUnknownSession;
     for (final key in _verifiedDevices) {
       await key.setVerified(
         true,
@@ -820,9 +832,9 @@ class KeyVerification {
   /// shower is true only for reciprocated verifications (shower side)
   Future<void> verifyKeysQR(SignableKey key, {bool shower = true}) async {
     var verifiedMasterKey = false;
-    final wasUnknownSession = client.isUnknownSession;
+    final wasUnknownSession = await client.isUnknownSession;
 
-    key.setDirectVerified(true);
+    await key.setVerified(true, false);
     if (key is CrossSigningKey && key.usage.contains('master')) {
       verifiedMasterKey = true;
     }
@@ -940,19 +952,20 @@ class KeyVerification {
           EventTypes.KeyVerificationRequest,
           EventTypes.KeyVerificationCancel,
         }.contains(type)) {
-          final deviceKeys = client.userDeviceKeys[userId]?.deviceKeys.values
-              .where(
-                (deviceKey) => deviceKey.hasValidSignatureChain(
-                  verifiedByTheirMasterKey: true,
-                ),
-              );
+          final userDeviceKeys = await client.fetchUserDeviceKeysList(userId);
+          final deviceKeysToSend = <DeviceKeys>[];
+          if (userDeviceKeys != null) {
+            for (final deviceKey in userDeviceKeys.deviceKeys.values) {
+              if (await deviceKey.hasValidSignatureChain(
+                verifiedByTheirMasterKey: true,
+              )) {
+                deviceKeysToSend.add(deviceKey);
+              }
+            }
+          }
 
-          if (deviceKeys != null) {
-            await client.sendToDeviceEncrypted(
-              deviceKeys.toList(),
-              type,
-              payload,
-            );
+          if (deviceKeysToSend.isNotEmpty) {
+            await client.sendToDeviceEncrypted(deviceKeysToSend, type, payload);
           }
         } else {
           Logs().e(
@@ -960,9 +973,10 @@ class KeyVerification {
           );
         }
       } else {
-        if (client.userDeviceKeys[userId]?.deviceKeys[deviceId] != null) {
+        final userDeviceKeys = await client.fetchUserDeviceKeysList(userId);
+        if (userDeviceKeys?.deviceKeys[deviceId] != null) {
           await client.sendToDeviceEncrypted(
-            [client.userDeviceKeys[userId]!.deviceKeys[deviceId]!],
+            [userDeviceKeys!.deviceKeys[deviceId]!],
             type,
             payload,
           );
@@ -1001,10 +1015,9 @@ class KeyVerification {
     if (utf8.decode(data.sublist(10, 10 + encodedTxnLen)) != transactionId) {
       return false;
     }
-    final keys = client.userDeviceKeys;
 
-    final ownKeys = keys[client.userID];
-    final otherUserKeys = keys[userId];
+    final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+    final otherUserKeys = await client.fetchUserDeviceKeysList(userId);
     final ownMasterKey = ownKeys?.getCrossSigningKey('master');
     final ownDeviceKey = ownKeys?.getKey(client.deviceID!);
     final ownOtherDeviceKey = ownKeys?.getKey(deviceId!);
@@ -1022,7 +1035,7 @@ class KeyVerification {
       QRMode.verifyOtherUser,
       QRMode.verifySelfUntrusted,
     }.contains(remoteQrMode)) {
-      if (!(ownMasterKey?.verified ?? false)) {
+      if (!(await ownMasterKey?.verified ?? false)) {
         Logs().e(
           '[KeyVerification] verifyQrData because you were in mode 0/2 and had untrusted msk',
         );
@@ -1060,10 +1073,13 @@ class KeyVerification {
   }
 
   Future<(String, String)?> getKeys(QRMode mode) async {
-    final keys = client.userDeviceKeys;
+    final allKeys = await client.fetchUserDeviceKeysLists({
+      userId,
+      if (client.userID != null) client.userID!,
+    });
 
-    final ownKeys = keys[client.userID];
-    final otherUserKeys = keys[userId];
+    final ownKeys = allKeys[client.userID];
+    final otherUserKeys = allKeys[userId];
     final ownDeviceKey = ownKeys?.getKey(client.deviceID!);
     final ownMasterKey = ownKeys?.getCrossSigningKey('master');
     final otherDeviceKey = otherUserKeys?.getKey(deviceId!);
@@ -1074,13 +1090,13 @@ class KeyVerification {
         otherMasterKey != null) {
       // we already have this check when sending `knownVerificationMethods`, but
       // just to be safe anyway
-      if (ownMasterKey.verified) {
+      if (await ownMasterKey.verified) {
         return (ownMasterKey.ed25519Key!, otherMasterKey.ed25519Key!);
       }
     } else if (mode == QRMode.verifySelfTrusted &&
         ownMasterKey != null &&
         otherDeviceKey != null) {
-      if (ownMasterKey.verified) {
+      if (await ownMasterKey.verified) {
         return (ownMasterKey.ed25519Key!, otherDeviceKey.ed25519Key!);
       }
     } else if (mode == QRMode.verifySelfUntrusted &&
@@ -1098,7 +1114,7 @@ class KeyVerification {
       uc.secureRandomBytes(11),
     );
 
-    final mode = getOurQRMode();
+    final mode = await getOurQRMode();
     data.addAll(ascii.encode(prefix));
     data.add(version);
     data.add(mode.code);
@@ -1182,16 +1198,19 @@ class _KeyVerificationMethodQRReciprocate extends _KeyVerificationMethod {
   Future<void> acceptQRScanConfirmation() async {
     // secret validation already done in validateStart
 
-    final ourQRMode = request.getOurQRMode();
+    final ourQRMode = await request.getOurQRMode();
     SignableKey? keyToVerify;
+    final allKeys = await client.fetchUserDeviceKeysLists({
+      request.userId,
+      if (client.userID != null) client.userID!,
+    });
 
     if (ourQRMode == QRMode.verifyOtherUser) {
-      keyToVerify = client.userDeviceKeys[request.userId]?.masterKey;
+      keyToVerify = allKeys[request.userId]?.masterKey;
     } else if (ourQRMode == QRMode.verifySelfTrusted) {
-      keyToVerify =
-          client.userDeviceKeys[client.userID]?.deviceKeys[request.deviceId];
+      keyToVerify = allKeys[client.userID]?.deviceKeys[request.deviceId];
     } else if (ourQRMode == QRMode.verifySelfUntrusted) {
-      keyToVerify = client.userDeviceKeys[client.userID]?.masterKey;
+      keyToVerify = allKeys[client.userID]?.masterKey;
     }
     if (keyToVerify != null) {
       await request.verifyKeysQR(keyToVerify, shower: true);
@@ -1507,8 +1526,12 @@ class _KeyVerificationMethodSas extends _KeyVerificationMethod {
     );
     keyList.add(deviceKeyId);
 
-    final masterKey = client.userDeviceKeys[client.userID]?.masterKey;
-    if (masterKey != null && masterKey.verified) {
+    final masterKey =
+        (client.userID != null
+                ? await client.fetchUserDeviceKeysList(client.userID!)
+                : null)
+            ?.masterKey;
+    if (masterKey != null && await masterKey.verified) {
       // we have our own master key verified, let's send it!
       final masterKeyId = 'ed25519:${masterKey.publicKey}';
       mac[masterKeyId] = _calculateMac(
@@ -1536,7 +1559,8 @@ class _KeyVerificationMethodSas extends _KeyVerificationMethod {
       return;
     }
 
-    if (!client.userDeviceKeys.containsKey(request.userId)) {
+    final userKeys = await client.fetchUserDeviceKeysList(request.userId);
+    if (userKeys == null) {
       await request.cancel('m.key_mismatch');
       return;
     }

--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -349,14 +349,20 @@ class FakeMatrixApi extends BaseClient {
             'user_signing_key',
           }) {
             if (jsonBody[keyType] == null) continue;
-            final key = sdk.CrossSigningKey.fromJson(jsonBody[keyType], client);
-            final publicKey = key.publicKey;
-            if (publicKey == null || !key.isValid) continue;
-
             final existing = await database.getUserDeviceKeysList(
               userId,
               client,
             );
+            final list = existing ?? sdk.DeviceKeysList(userId, client);
+            final key = sdk.CrossSigningKey.fromJson(
+              jsonBody[keyType],
+              list,
+              list,
+              client,
+            );
+            final publicKey = key.publicKey;
+            if (publicKey == null || !key.isValid) continue;
+
             CrossSigningKey? oldKey;
             if (existing != null) {
               for (final entry in existing.crossSigningKeys.entries) {

--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -338,26 +338,60 @@ class FakeMatrixApi extends BaseClient {
     api['POST']?['/client/v3/keys/device_signing/upload'] = (var reqI) {
       if (_client != null) {
         final jsonBody = decodeJson(reqI);
-        for (final keyType in {
-          'master_key',
-          'self_signing_key',
-          'user_signing_key',
-        }) {
-          if (jsonBody[keyType] != null) {
-            final key = sdk.CrossSigningKey.fromJson(
-              jsonBody[keyType],
-              _client!,
-            );
-            _client!.userDeviceKeys[_client!.userID!]?.crossSigningKeys
-                .removeWhere((k, v) => v.usage.contains(key.usage.first));
-            _client!.userDeviceKeys[_client!.userID!]?.crossSigningKeys[key
-                    .publicKey!] =
-                key;
-          }
-        }
-        // and generate a fake sync
+        final client = _client!;
+        final userId = client.userID!;
         // ignore: discarded_futures
-        _client!.handleSync(sdk.SyncUpdate(nextBatch: ''));
+        (() async {
+          final database = client.database;
+          for (final keyType in {
+            'master_key',
+            'self_signing_key',
+            'user_signing_key',
+          }) {
+            if (jsonBody[keyType] == null) continue;
+            final key = sdk.CrossSigningKey.fromJson(jsonBody[keyType], client);
+            final publicKey = key.publicKey;
+            if (publicKey == null || !key.isValid) continue;
+
+            final existing = await database.getUserDeviceKeysList(
+              userId,
+              client,
+            );
+            CrossSigningKey? oldKey;
+            if (existing != null) {
+              for (final entry in existing.crossSigningKeys.entries) {
+                if (entry.value.usage.contains(key.usage.first)) {
+                  if (entry.key == publicKey) {
+                    oldKey = entry.value;
+                  }
+                  await database.removeUserCrossSigningKey(userId, entry.key);
+                }
+              }
+            }
+            if (oldKey != null) {
+              key.setDirectVerified(oldKey.directVerified);
+              if (oldKey.trustOnFirstUseSince != null) {
+                key.trustOnFirstUse(
+                  since: oldKey.trustOnFirstUseSince,
+                  updateInDatabase: false,
+                );
+              }
+              key.blocked = oldKey.blocked;
+              key.validSignatures = oldKey.validSignatures;
+            }
+
+            await database.storeUserCrossSigningKey(
+              userId,
+              publicKey,
+              jsonEncode(key.toJson()),
+              key.directVerified,
+              key.blocked,
+              trustOnFirstUseSince: key.trustOnFirstUseSince,
+            );
+          }
+          await database.storeUserDeviceKeysInfo(userId, false);
+          await client.handleSync(sdk.SyncUpdate(nextBatch: ''));
+        })();
       }
       return {};
     };

--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -64,10 +64,10 @@ extension DehydratedDeviceHandler on Client {
       }
 
       // Verify that the device is cross-signed
-      final dehydratedDeviceIdentity =
-          userDeviceKeys[userID]!.deviceKeys[device.deviceId];
+      final ownKeys = await fetchUserDeviceKeysList(userID!);
+      final dehydratedDeviceIdentity = ownKeys?.deviceKeys[device.deviceId];
       if (dehydratedDeviceIdentity == null ||
-          !dehydratedDeviceIdentity.hasValidSignatureChain()) {
+          !await dehydratedDeviceIdentity.hasValidSignatureChain()) {
         Logs().w(
           'Dehydrated device ${device.deviceId} is unknown or unverified, replacing it',
         );
@@ -193,9 +193,8 @@ extension DehydratedDeviceHandler on Client {
       encryption.olmManager.ourDeviceId = device;
 
       // cross sign the device from our currently signed in device
-      final keysToSign = <SignableKey>[
-        userDeviceKeys[userID]!.deviceKeys[device]!,
-      ];
+      final ownKeys = await fetchUserDeviceKeysList(userID!);
+      final keysToSign = <SignableKey>[ownKeys!.deviceKeys[device]!];
       await this.encryption?.crossSigning.sign(keysToSign);
     } finally {
       await encryption.dispose();

--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -67,7 +67,7 @@ extension DehydratedDeviceHandler on Client {
       final ownKeys = await fetchUserDeviceKeysList(userID!);
       final dehydratedDeviceIdentity = ownKeys?.deviceKeys[device.deviceId];
       if (dehydratedDeviceIdentity == null ||
-          !await dehydratedDeviceIdentity.hasValidSignatureChain()) {
+          !dehydratedDeviceIdentity.hasValidSignatureChain()) {
         Logs().w(
           'Dehydrated device ${device.deviceId} is unknown or unverified, replacing it',
         );

--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -193,7 +193,6 @@ extension DehydratedDeviceHandler on Client {
       encryption.olmManager.ourDeviceId = device;
 
       // cross sign the device from our currently signed in device
-      await updateUserDeviceKeys(additionalUsers: {userID!});
       final keysToSign = <SignableKey>[
         userDeviceKeys[userID]!.deviceKeys[device]!,
       ];

--- a/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
+++ b/lib/msc_extensions/msc_3814_dehydrated_devices/msc_3814_dehydrated_devices.dart
@@ -193,7 +193,10 @@ extension DehydratedDeviceHandler on Client {
       encryption.olmManager.ourDeviceId = device;
 
       // cross sign the device from our currently signed in device
-      final ownKeys = await fetchUserDeviceKeysList(userID!);
+      final ownKeys = await fetchUserDeviceKeysList(
+        userID!,
+        alwaysFetchFromServer: true,
+      );
       final keysToSign = <SignableKey>[ownKeys!.deviceKeys[device]!];
       await this.encryption?.crossSigning.sign(keysToSign);
     } finally {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -406,7 +406,7 @@ class Client extends MatrixApi {
     final keys = await fetchUserDeviceKeysList(userId);
     final deviceKey = keys?.deviceKeys[deviceId];
     if (deviceKey == null) return true;
-    return !(await deviceKey.signed);
+    return !deviceKey.signed;
   }
 
   /// Warning! This endpoint is for testing only!
@@ -3288,6 +3288,11 @@ class Client extends MatrixApi {
 
   /// Fetches the user device keys first from the database. If those are
   /// missing or marked as outdated will then get fetched from the server.
+  ///
+  /// Returns a **snapshot**. [SignableKey.setVerified] / [SignableKey.setBlocked]
+  /// on this list update the DB, but other previously fetched lists stay stale.
+  /// Fetch again after trust changes (or before acting on trust flags) if you
+  /// might be holding an older instance.
   Future<DeviceKeysList?> fetchUserDeviceKeysList(
     String userId, {
     Duration? queryKeysTimeout,
@@ -3300,6 +3305,8 @@ class Client extends MatrixApi {
 
   /// Fetches the user device keys first from the database. Those which are
   /// missing or marked as outdated will then get fetched from the server.
+  ///
+  /// Returns snapshots — see [fetchUserDeviceKeysList].
   Future<Map<String, DeviceKeysList>> fetchUserDeviceKeysLists(
     Set<String> userIds, {
     Duration? queryKeysTimeout,
@@ -3339,14 +3346,26 @@ class Client extends MatrixApi {
       }
     }
 
+    // Single list instance for our own keys — always passed into SignableKey
+    // constructors for cross-user signature chains. Must be resolved after the
+    // trust reload above, and reused as userKeys when updating our own user.
+    final ownUserId = userID!;
+    final ownKeys =
+        oldDeviceKeys[ownUserId] ??
+        userDeviceKeys[ownUserId] ??
+        await database.getUserDeviceKeysList(ownUserId, this) ??
+        DeviceKeysList(ownUserId, this);
+
     final dbActions = <Future<dynamic> Function()>[];
 
     final deviceKeys = response.deviceKeys;
     if (deviceKeys != null) {
       for (final rawDeviceKeyListEntry in deviceKeys.entries) {
         final userId = rawDeviceKeyListEntry.key;
-        final userKeys = userDeviceKeys[userId] ??=
-            oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this);
+        final userKeys = userDeviceKeys[userId] ??= userId == ownUserId
+            ? ownKeys
+            : (oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this));
+        if (userId == ownUserId) oldDeviceKeys.remove(userId);
         final oldKeys = Map<String, DeviceKeys>.from(userKeys.deviceKeys);
         userKeys.deviceKeys.clear();
         for (final rawDeviceKeyEntry in rawDeviceKeyListEntry.value.entries) {
@@ -3355,6 +3374,8 @@ class Client extends MatrixApi {
           // Set the new device key for this device
           final entry = DeviceKeys.fromMatrixDeviceKeys(
             rawDeviceKeyEntry.value,
+            userKeys,
+            ownKeys,
             this,
             oldKeys[deviceId]?.lastActive,
           );
@@ -3465,8 +3486,10 @@ class Client extends MatrixApi {
       }
       for (final crossSigningKeyListEntry in keys.entries) {
         final userId = crossSigningKeyListEntry.key;
-        final userKeys = userDeviceKeys[userId] ??=
-            oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this);
+        final userKeys = userDeviceKeys[userId] ??= userId == ownUserId
+            ? ownKeys
+            : (oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this));
+        if (userId == ownUserId) oldDeviceKeys.remove(userId);
         final oldKeys = Map<String, CrossSigningKey>.from(
           userKeys.crossSigningKeys,
         );
@@ -3485,6 +3508,8 @@ class Client extends MatrixApi {
         }
         final entry = CrossSigningKey.fromMatrixCrossSigningKey(
           crossSigningKeyListEntry.value,
+          userKeys,
+          ownKeys,
           this,
         );
         final publicKey = entry.publicKey;
@@ -3567,7 +3592,7 @@ class Client extends MatrixApi {
     if (deviceKeys == null) return [];
     final unverified = <DeviceKeys>[];
     for (final deviceKey in deviceKeys) {
-      if (!await deviceKey.verified && !deviceKey.blocked) {
+      if (!deviceKey.verified && !deviceKey.blocked) {
         unverified.add(deviceKey);
       }
     }
@@ -3699,7 +3724,7 @@ class Client extends MatrixApi {
       for (final dk in deviceKeys) {
         if (dk.blocked) continue;
         if (dk.userId == userID && dk.deviceId == deviceID) continue;
-        if (onlyVerified && !(await dk.verified)) continue;
+        if (onlyVerified && !(dk.verified)) continue;
         keysToSend.add(dk);
       }
       if (keysToSend.isEmpty) return;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3296,28 +3296,34 @@ class Client extends MatrixApi {
   Future<DeviceKeysList?> fetchUserDeviceKeysList(
     String userId, {
     Duration? queryKeysTimeout,
+    bool alwaysFetchFromServer = false,
   }) async {
-    final keys = await fetchUserDeviceKeysLists({
-      userId,
-    }, queryKeysTimeout: queryKeysTimeout);
+    final keys = await fetchUserDeviceKeysLists(
+      {userId},
+      queryKeysTimeout: queryKeysTimeout,
+      alwaysFetchFromServer: alwaysFetchFromServer,
+    );
     return keys[userId];
   }
 
   /// Fetches the user device keys first from the database. Those which are
   /// missing or marked as outdated will then get fetched from the server.
+  /// Always contains the own keys as well!
   ///
   /// Returns snapshots — see [fetchUserDeviceKeysList].
   Future<Map<String, DeviceKeysList>> fetchUserDeviceKeysLists(
     Set<String> userIds, {
     Duration? queryKeysTimeout,
+    bool alwaysFetchFromServer = false,
   }) async {
+    userIds.add(userID!); // Ensure own keys are always up2date
     final userDeviceKeys = <String, DeviceKeysList>{};
     final oldDeviceKeys = <String, DeviceKeysList>{};
     // Get from database:
     for (final userId in userIds) {
       final cachedList = await database.getUserDeviceKeysList(userId, this);
       if (cachedList != null) {
-        if (cachedList.outdated) {
+        if (cachedList.outdated || alwaysFetchFromServer) {
           oldDeviceKeys[userId] = cachedList;
         } else {
           userDeviceKeys[userId] = cachedList;
@@ -3337,18 +3343,9 @@ class Client extends MatrixApi {
 
     if (!isLogged()) return userDeviceKeys;
 
-    // Trust may have been updated (setVerified/setBlocked) while /keys/query
-    // was in flight. Reload so we merge against the latest trust flags.
-    for (final userId in userIds) {
-      final latest = await database.getUserDeviceKeysList(userId, this);
-      if (latest != null) {
-        oldDeviceKeys[userId] = latest;
-      }
-    }
-
     // Single list instance for our own keys — always passed into SignableKey
-    // constructors for cross-user signature chains. Must be resolved after the
-    // trust reload above, and reused as userKeys when updating our own user.
+    // constructors for cross-user signature chains. Reused as userKeys when
+    // updating our own user.
     final ownUserId = userID!;
     final ownKeys =
         oldDeviceKeys[ownUserId] ??
@@ -3445,8 +3442,11 @@ class Client extends MatrixApi {
                   userId,
                   deviceId,
                   json.encode(entry.toJson()),
-                  entry.directVerified,
-                  entry.blocked,
+                  // Own device is always trusted.
+                  deviceId == deviceID && entry.ed25519Key == fingerprintKey
+                      ? true
+                      : null,
+                  null,
                   entry.lastActive.millisecondsSinceEpoch,
                 ),
               );
@@ -3559,16 +3559,11 @@ class Client extends MatrixApi {
 
     // now process all the failures
     if (response.failures != null) {
-      for (final failureDomain in response.failures?.keys ?? <String>[]) {
-        _keyQueryFailures[failureDomain] = DateTime.now();
-      }
+      Logs().w('Failed to fetch device keys from:', response.failures?.keys);
     }
 
     if (dbActions.isNotEmpty) {
       if (!isLogged()) return userDeviceKeys;
-      Logs().i(
-        'Updating user device keys in database... (${dbActions.length} operations)',
-      );
       await runBenchmarked(
         'Updating user device keys in database...',
         () => database.transaction(() async {
@@ -3600,18 +3595,8 @@ class Client extends MatrixApi {
   }
 
   /// Gets user device keys by its curve25519 key. Returns null if it isn't found
-  Future<DeviceKeys?> getUserDeviceKeysByCurve25519Key(String senderKey) async {
-    final allKeys = await database.getUserDeviceKeys(this);
-    for (final user in allKeys.values) {
-      final device = user.deviceKeys.values.firstWhereOrNull(
-        (e) => e.curve25519Key == senderKey,
-      );
-      if (device != null) return device;
-    }
-    return null;
-  }
-
-  final Map<String, DateTime> _keyQueryFailures = {};
+  Future<DeviceKeys?> getUserDeviceKeysByCurve25519Key(String senderKey) =>
+      database.getUserDeviceKeysByCurve25519Key(senderKey, this);
 
   bool _toDeviceQueueNeedsProcessing = true;
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3316,6 +3316,254 @@ class Client extends MatrixApi {
   Map<String, DeviceKeysList> get userDeviceKeys => _userDeviceKeys;
   Map<String, DeviceKeysList> _userDeviceKeys = {};
 
+  Future<Map<String, DeviceKeysList>> fetchUserDeviceKeysLists(
+    Set<String> userIds, {
+    Duration? queryKeysTimeout,
+  }) async {
+    final userDeviceKeys = <String, DeviceKeysList>{};
+    final oldDeviceKeys = <String, DeviceKeysList>{};
+    // Get from database:
+    for (final userId in userIds) {
+      final cachedList = await database.getUserDeviceKeysList(userId, this);
+      if (cachedList != null) {
+        if (cachedList.outdated) {
+          oldDeviceKeys[userId] = cachedList;
+        } else {
+          userDeviceKeys[userId] = cachedList;
+        }
+      }
+    }
+
+    userIds.removeWhere(userDeviceKeys.containsKey);
+    if (userIds.isEmpty) return userDeviceKeys;
+
+    // Fetch the rest from the server:
+    final missingUserIds = {for (final userId in userIds) userId: <String>[]};
+    final response = await queryKeys(
+      missingUserIds,
+      timeout: queryKeysTimeout?.inMilliseconds,
+    );
+
+    if (!isLogged()) return userDeviceKeys;
+
+    final dbActions = <Future<dynamic> Function()>[];
+
+    final deviceKeys = response.deviceKeys;
+    if (deviceKeys != null) {
+      for (final rawDeviceKeyListEntry in deviceKeys.entries) {
+        final userId = rawDeviceKeyListEntry.key;
+        final userKeys = userDeviceKeys[userId] ??= DeviceKeysList(
+          userId,
+          this,
+        );
+        final oldKeys = Map<String, DeviceKeys>.from(userKeys.deviceKeys);
+        userKeys.deviceKeys = {};
+        for (final rawDeviceKeyEntry in rawDeviceKeyListEntry.value.entries) {
+          final deviceId = rawDeviceKeyEntry.key;
+
+          // Set the new device key for this device
+          final entry = DeviceKeys.fromMatrixDeviceKeys(
+            rawDeviceKeyEntry.value,
+            this,
+            oldKeys[deviceId]?.lastActive,
+          );
+          final ed25519Key = entry.ed25519Key;
+          final curve25519Key = entry.curve25519Key;
+          if (entry.isValid &&
+              deviceId == entry.deviceId &&
+              ed25519Key != null &&
+              curve25519Key != null) {
+            // Check if deviceId or deviceKeys are known
+            if (!oldKeys.containsKey(deviceId)) {
+              final oldPublicKeys = await database.deviceIdSeen(
+                userId,
+                deviceId,
+              );
+              if (oldPublicKeys != null &&
+                  oldPublicKeys != curve25519Key + ed25519Key) {
+                Logs().w(
+                  'Already seen Device ID has been added again. This might be an attack!',
+                );
+                continue;
+              }
+              final oldDeviceId = await database.publicKeySeen(ed25519Key);
+              if (oldDeviceId != null && oldDeviceId != deviceId) {
+                Logs().w(
+                  'Already seen ED25519 has been added again. This might be an attack!',
+                );
+                continue;
+              }
+              final oldDeviceId2 = await database.publicKeySeen(curve25519Key);
+              if (oldDeviceId2 != null && oldDeviceId2 != deviceId) {
+                Logs().w(
+                  'Already seen Curve25519 has been added again. This might be an attack!',
+                );
+                continue;
+              }
+              dbActions.add(() async {
+                await database.addSeenDeviceId(
+                  userId,
+                  deviceId,
+                  curve25519Key + ed25519Key,
+                );
+                await database.addSeenPublicKey(ed25519Key, deviceId);
+                await database.addSeenPublicKey(curve25519Key, deviceId);
+              });
+            }
+
+            // is this a new key or the same one as an old one?
+            // better store an update - the signatures might have changed!
+            final oldKey = oldKeys[deviceId];
+            if (oldKey == null ||
+                (oldKey.ed25519Key == entry.ed25519Key &&
+                    oldKey.curve25519Key == entry.curve25519Key)) {
+              if (oldKey != null) {
+                // be sure to save the verified status
+                entry.setDirectVerified(oldKey.directVerified);
+                entry.blocked = oldKey.blocked;
+                entry.validSignatures = oldKey.validSignatures;
+              }
+              userKeys.deviceKeys[deviceId] = entry;
+              if (deviceId == deviceID && entry.ed25519Key == fingerprintKey) {
+                // Always trust the own device
+                entry.setDirectVerified(true);
+              }
+              dbActions.add(
+                () => database.storeUserDeviceKey(
+                  userId,
+                  deviceId,
+                  json.encode(entry.toJson()),
+                  entry.directVerified,
+                  entry.blocked,
+                  entry.lastActive.millisecondsSinceEpoch,
+                ),
+              );
+            } else if (oldKeys.containsKey(deviceId)) {
+              // This shouldn't ever happen. The same device ID has gotten
+              // a new public key. So we ignore the update. TODO: ask krille
+              // if we should instead use the new key with unknown verified / blocked status
+              userKeys.deviceKeys[deviceId] = oldKeys[deviceId]!;
+            }
+          } else {
+            Logs().w('Invalid device ${entry.userId}:${entry.deviceId}');
+          }
+        }
+        // delete old/unused entries
+        for (final oldDeviceKeyEntry in oldKeys.entries) {
+          final deviceId = oldDeviceKeyEntry.key;
+          if (!userKeys.deviceKeys.containsKey(deviceId)) {
+            // we need to remove an old key
+            dbActions.add(() => database.removeUserDeviceKey(userId, deviceId));
+          }
+        }
+        userKeys.outdated = false;
+        dbActions.add(() => database.storeUserDeviceKeysInfo(userId, false));
+      }
+    }
+    // next we parse and persist the cross signing keys
+    final crossSigningTypes = {
+      'master': response.masterKeys,
+      'self_signing': response.selfSigningKeys,
+      'user_signing': response.userSigningKeys,
+    };
+    for (final crossSigningKeysEntry in crossSigningTypes.entries) {
+      final keyType = crossSigningKeysEntry.key;
+      final keys = crossSigningKeysEntry.value;
+      if (keys == null) {
+        continue;
+      }
+      for (final crossSigningKeyListEntry in keys.entries) {
+        final userId = crossSigningKeyListEntry.key;
+        final userKeys = userDeviceKeys[userId] ??= DeviceKeysList(
+          userId,
+          this,
+        );
+        final oldKeys = Map<String, CrossSigningKey>.from(
+          userKeys.crossSigningKeys,
+        );
+        userKeys.crossSigningKeys = {};
+        // add the types we aren't handling atm back
+        for (final oldEntry in oldKeys.entries) {
+          if (!oldEntry.value.usage.contains(keyType)) {
+            userKeys.crossSigningKeys[oldEntry.key] = oldEntry.value;
+          } else {
+            // There is a previous cross-signing key with  this usage, that we no
+            // longer need/use. Clear it from the database.
+            dbActions.add(
+              () => database.removeUserCrossSigningKey(userId, oldEntry.key),
+            );
+          }
+        }
+        final entry = CrossSigningKey.fromMatrixCrossSigningKey(
+          crossSigningKeyListEntry.value,
+          this,
+        );
+        final publicKey = entry.publicKey;
+        if (entry.isValid && publicKey != null) {
+          final oldKey = oldKeys[publicKey];
+          if (oldKey == null || oldKey.ed25519Key == entry.ed25519Key) {
+            if (oldKey != null) {
+              // be sure to save the verification status
+              entry.setDirectVerified(oldKey.directVerified);
+              if (oldKey.trustOnFirstUseSince != null) {
+                entry.trustOnFirstUse(
+                  since: oldKey.trustOnFirstUseSince,
+                  updateInDatabase: false,
+                );
+              }
+              entry.blocked = oldKey.blocked;
+              entry.validSignatures = oldKey.validSignatures;
+            }
+            userKeys.crossSigningKeys[publicKey] = entry;
+          } else {
+            // This shouldn't ever happen. The same device ID has gotten
+            // a new public key. So we ignore the update. TODO: ask krille
+            // if we should instead use the new key with unknown verified / blocked status
+            userKeys.crossSigningKeys[publicKey] = oldKey;
+          }
+          dbActions.add(
+            () => database.storeUserCrossSigningKey(
+              userId,
+              publicKey,
+              json.encode(entry.toJson()),
+              entry.directVerified,
+              entry.blocked,
+              trustOnFirstUseSince: entry.trustOnFirstUseSince,
+            ),
+          );
+        }
+        userDeviceKeys[userId]?.outdated = false;
+        dbActions.add(() => database.storeUserDeviceKeysInfo(userId, false));
+      }
+    }
+
+    // now process all the failures
+    if (response.failures != null) {
+      for (final failureDomain in response.failures?.keys ?? <String>[]) {
+        _keyQueryFailures[failureDomain] = DateTime.now();
+      }
+    }
+
+    if (dbActions.isNotEmpty) {
+      if (!isLogged()) return userDeviceKeys;
+      Logs().i(
+        'Updating user device keys in database... (${dbActions.length} operations)',
+      );
+      await runBenchmarked(
+        'Updating user device keys in database...',
+        () => database.transaction(() async {
+          for (final f in dbActions) {
+            await f();
+          }
+        }),
+      );
+    }
+
+    // For migration also add to the legacy cache:
+    this.userDeviceKeys.addAll(userDeviceKeys);
+    return userDeviceKeys;
+  }
+
   /// A list of all not verified and not blocked device keys. Clients should
   /// display a warning if this list is not empty and suggest the user to
   /// verify or block those devices.

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -399,8 +399,15 @@ class Client extends MatrixApi {
   String get fingerprintKey => encryption?.fingerprintKey ?? '';
 
   /// Whether this session is unknown to others
-  bool get isUnknownSession =>
-      userDeviceKeys[userID]?.deviceKeys[deviceID]?.signed != true;
+  Future<bool> get isUnknownSession async {
+    final userId = userID;
+    final deviceId = deviceID;
+    if (userId == null || deviceId == null) return true;
+    final keys = await fetchUserDeviceKeysList(userId);
+    final deviceKey = keys?.deviceKeys[deviceId];
+    if (deviceKey == null) return true;
+    return !(await deviceKey.signed);
+  }
 
   /// Warning! This endpoint is for testing only!
   set rooms(List<Room> newList) {
@@ -1029,7 +1036,8 @@ class Client extends MatrixApi {
   /// server to answer this.
   Future<bool> userOwnsEncryptionKeys(String userId) async {
     if (userId == userID) return encryptionEnabled;
-    if (_userDeviceKeys[userId]?.deviceKeys.isNotEmpty ?? false) {
+    if ((await fetchUserDeviceKeysList(userId))?.deviceKeys.isNotEmpty ??
+        false) {
       return true;
     }
     final keys = await queryKeys({userId: []});
@@ -2307,7 +2315,7 @@ class Client extends MatrixApi {
     }
 
     _id = accessToken = _syncFilterId = homeserver = _userID = _deviceID =
-        _deviceName = _prevBatch = _trackedUserIds = null;
+        _deviceName = _prevBatch = null;
     _rooms = [];
     _eventsPendingDecryption.clear();
     await encryption?.dispose();
@@ -2620,24 +2628,15 @@ class Client extends MatrixApi {
   Future<void> _handleDeviceListsEvents(DeviceListsUpdate deviceLists) async {
     if (deviceLists.changed is List) {
       for (final userId in deviceLists.changed ?? []) {
-        final userKeys = _userDeviceKeys[userId];
-        if (userKeys != null) {
-          userKeys.outdated = true;
-          await database.storeUserDeviceKeysInfo(userId, true);
-        } else {
-          // Per spec `changed` also includes users who *now* share an
-          // encrypted room with us. We might not know about them yet, for
-          // example when their membership event was truncated out of a
-          // limited (gappy) sync timeline. Track them so that the next
-          // `updateUserDeviceKeys()` fetches their device keys.
-          _trackedUserIds?.add(userId);
-        }
+        // Mark as outdated in DB so the next fetchUserDeviceKeysList call
+        // will re-fetch from the server.
+        await database.storeUserDeviceKeysInfo(userId, true);
       }
       for (final userId in deviceLists.left ?? []) {
-        if (_userDeviceKeys.containsKey(userId)) {
-          _userDeviceKeys.remove(userId);
-          _trackedUserIds?.remove(userId);
-        }
+        // We do not do that yet but we keep the key to later compare it to
+        // avoid MITM attacks. However, we mark it as outdated so if we
+        // want to access the key again, we need to update it.
+        await database.storeUserDeviceKeysInfo(userId, true);
       }
     }
   }
@@ -2912,11 +2911,6 @@ class Client extends MatrixApi {
             jsonEncode(event.toJson()),
           );
           continue;
-        } else {
-          // Encryption has been enabled in a room -> Reset tracked user IDs so
-          // sync they can be calculated again.
-          Logs().i('End to end encryption enabled in', room.id);
-          _trackedUserIds = null;
         }
       }
 
@@ -3152,19 +3146,6 @@ class Client extends MatrixApi {
           if (!room.partial || importantStateEvents.contains(event.type)) {
             room.setState(event);
           }
-
-          // New members must be added to the tracked user IDs for encryption
-          // even if the room is only partially loaded, as otherwise their
-          // device keys are never fetched and they never receive room keys:
-          if (room.encrypted &&
-              room.membership == Membership.join &&
-              event.type == EventTypes.RoomMember &&
-              {
-                'join',
-                'invite',
-              }.contains(event.content.tryGet<String>('membership'))) {
-            _trackedUserIds?.add(stateKey);
-          }
         }
 
         if (type != EventUpdateType.timeline) break;
@@ -3305,6 +3286,20 @@ class Client extends MatrixApi {
 
   Future? get accountDataLoading => _accountDataLoading;
 
+  /// Fetches the user device keys first from the database. If those are
+  /// missing or marked as outdated will then get fetched from the server.
+  Future<DeviceKeysList?> fetchUserDeviceKeysList(
+    String userId, {
+    Duration? queryKeysTimeout,
+  }) async {
+    final keys = await fetchUserDeviceKeysLists({
+      userId,
+    }, queryKeysTimeout: queryKeysTimeout);
+    return keys[userId];
+  }
+
+  /// Fetches the user device keys first from the database. Those which are
+  /// missing or marked as outdated will then get fetched from the server.
   Future<Map<String, DeviceKeysList>> fetchUserDeviceKeysLists(
     Set<String> userIds, {
     Duration? queryKeysTimeout,
@@ -3335,18 +3330,25 @@ class Client extends MatrixApi {
 
     if (!isLogged()) return userDeviceKeys;
 
+    // Trust may have been updated (setVerified/setBlocked) while /keys/query
+    // was in flight. Reload so we merge against the latest trust flags.
+    for (final userId in userIds) {
+      final latest = await database.getUserDeviceKeysList(userId, this);
+      if (latest != null) {
+        oldDeviceKeys[userId] = latest;
+      }
+    }
+
     final dbActions = <Future<dynamic> Function()>[];
 
     final deviceKeys = response.deviceKeys;
     if (deviceKeys != null) {
       for (final rawDeviceKeyListEntry in deviceKeys.entries) {
         final userId = rawDeviceKeyListEntry.key;
-        final userKeys = userDeviceKeys[userId] ??= DeviceKeysList(
-          userId,
-          this,
-        );
+        final userKeys = userDeviceKeys[userId] ??=
+            oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this);
         final oldKeys = Map<String, DeviceKeys>.from(userKeys.deviceKeys);
-        userKeys.deviceKeys = {};
+        userKeys.deviceKeys.clear();
         for (final rawDeviceKeyEntry in rawDeviceKeyListEntry.value.entries) {
           final deviceId = rawDeviceKeyEntry.key;
 
@@ -3463,14 +3465,12 @@ class Client extends MatrixApi {
       }
       for (final crossSigningKeyListEntry in keys.entries) {
         final userId = crossSigningKeyListEntry.key;
-        final userKeys = userDeviceKeys[userId] ??= DeviceKeysList(
-          userId,
-          this,
-        );
+        final userKeys = userDeviceKeys[userId] ??=
+            oldDeviceKeys.remove(userId) ?? DeviceKeysList(userId, this);
         final oldKeys = Map<String, CrossSigningKey>.from(
           userKeys.crossSigningKeys,
         );
-        userKeys.crossSigningKeys = {};
+        userKeys.crossSigningKeys.clear();
         // add the types we aren't handling atm back
         for (final oldEntry in oldKeys.entries) {
           if (!oldEntry.value.usage.contains(keyType)) {
@@ -3526,6 +3526,12 @@ class Client extends MatrixApi {
       }
     }
 
+    // Keep the previously cached (still outdated) lists for any user the
+    // server failed to return, so we don't lose their trust state.
+    for (final oldEntry in oldDeviceKeys.entries) {
+      userDeviceKeys.putIfAbsent(oldEntry.key, () => oldEntry.value);
+    }
+
     // now process all the failures
     if (response.failures != null) {
       for (final failureDomain in response.failures?.keys ?? <String>[]) {
@@ -3553,35 +3559,34 @@ class Client extends MatrixApi {
   /// A list of all not verified and not blocked device keys. Clients should
   /// display a warning if this list is not empty and suggest the user to
   /// verify or block those devices.
-  List<DeviceKeys> get unverifiedDevices {
+  Future<List<DeviceKeys>> fetchUnverifiedDevices() async {
     final userId = userID;
     if (userId == null) return [];
-    return userDeviceKeys[userId]?.deviceKeys.values
-            .where((deviceKey) => !deviceKey.verified && !deviceKey.blocked)
-            .toList() ??
-        [];
+    final keys = await fetchUserDeviceKeysList(userId);
+    final deviceKeys = keys?.deviceKeys.values;
+    if (deviceKeys == null) return [];
+    final unverified = <DeviceKeys>[];
+    for (final deviceKey in deviceKeys) {
+      if (!await deviceKey.verified && !deviceKey.blocked) {
+        unverified.add(deviceKey);
+      }
+    }
+    return unverified;
   }
 
   /// Gets user device keys by its curve25519 key. Returns null if it isn't found
-  DeviceKeys? getUserDeviceKeysByCurve25519Key(String senderKey) {
-    for (final user in userDeviceKeys.values) {
+  Future<DeviceKeys?> getUserDeviceKeysByCurve25519Key(String senderKey) async {
+    final allKeys = await database.getUserDeviceKeys(this);
+    for (final user in allKeys.values) {
       final device = user.deviceKeys.values.firstWhereOrNull(
         (e) => e.curve25519Key == senderKey,
       );
-      if (device != null) {
-        return device;
-      }
+      if (device != null) return device;
     }
     return null;
   }
 
   final Map<String, DateTime> _keyQueryFailures = {};
-
-  /// These are the user IDs we share an encrypted room with and need to track
-  /// the devices from, cached here for performance reasons.
-  /// It gets initialized after the first sync of every
-  /// instance and then updated on member changes or sync device changes.
-  Set<String>? _trackedUserIds;
 
   bool _toDeviceQueueNeedsProcessing = true;
 
@@ -3690,13 +3695,15 @@ class Client extends MatrixApi {
     // Don't send this message to blocked devices, and if specified onlyVerified
     // then only send it to verified devices
     if (deviceKeys.isNotEmpty) {
-      deviceKeys.removeWhere(
-        (DeviceKeys deviceKeys) =>
-            deviceKeys.blocked ||
-            (deviceKeys.userId == userID && deviceKeys.deviceId == deviceID) ||
-            (onlyVerified && !deviceKeys.verified),
-      );
-      if (deviceKeys.isEmpty) return;
+      final keysToSend = <DeviceKeys>[];
+      for (final dk in deviceKeys) {
+        if (dk.blocked) continue;
+        if (dk.userId == userID && dk.deviceId == deviceID) continue;
+        if (onlyVerified && !(await dk.verified)) continue;
+        keysToSend.add(dk);
+      }
+      if (keysToSend.isEmpty) return;
+      deviceKeys = keysToSend;
     }
 
     // So that we can guarantee order of encrypted to_device messages to be preserved we
@@ -3863,7 +3870,6 @@ class Client extends MatrixApi {
   Future<void> clearCache() async {
     await abortSync();
     _prevBatch = null;
-    _trackedUserIds = null;
     rooms.clear();
     await database.clearCache();
     encryption?.keyManager.clearOutboundGroupSessions();

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2044,8 +2044,8 @@ class Client extends MatrixApi {
   /// and rethrows if this request fails.
   ///
   /// Set [waitForFirstSync] and [waitUntilLoadCompletedLoaded] to false to speed this
-  /// up. You can then wait for `roomsLoading`, `_accountDataLoading` and
-  /// `userDeviceKeysLoading` where it is necessary.
+  /// up. You can then wait for `roomsLoading` and `_accountDataLoading` where it
+  /// is necessary.
   Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
@@ -2225,9 +2225,6 @@ class Client extends MatrixApi {
           newOidcClientId,
         );
       }
-      userDeviceKeysLoading = database
-          .getUserDeviceKeys(this)
-          .then((keys) => _userDeviceKeys = keys);
       roomsLoading = database.getRoomList(this).then((rooms) {
         _rooms = rooms;
         _sortRooms();
@@ -2241,7 +2238,6 @@ class Client extends MatrixApi {
       presences.clear();
       if (waitUntilLoadCompletedLoaded) {
         onInitStateChanged?.call(InitState.loadingData);
-        await userDeviceKeysLoading;
         await roomsLoading;
         await _accountDataLoading;
       }
@@ -2476,7 +2472,6 @@ class Client extends MatrixApi {
       }
 
       final database = this.database;
-      await userDeviceKeysLoading;
       await roomsLoading;
       await _accountDataLoading;
       _currentTransaction = database.transaction(() async {
@@ -2497,7 +2492,6 @@ class Client extends MatrixApi {
       database.deleteOldFiles(
         DateTime.now().subtract(Duration(days: 30)).millisecondsSinceEpoch,
       );
-      await updateUserDeviceKeys();
       if (encryptionEnabled) {
         encryption?.onSync();
       }
@@ -3305,16 +3299,11 @@ class Client extends MatrixApi {
     _sortLock = false;
   }
 
-  Future? userDeviceKeysLoading;
   Future? roomsLoading;
   Future? _accountDataLoading;
   Future? firstSyncReceived;
 
   Future? get accountDataLoading => _accountDataLoading;
-
-  /// A map of known device keys per user.
-  Map<String, DeviceKeysList> get userDeviceKeys => _userDeviceKeys;
-  Map<String, DeviceKeysList> _userDeviceKeys = {};
 
   Future<Map<String, DeviceKeysList>> fetchUserDeviceKeysLists(
     Set<String> userIds, {
@@ -3558,9 +3547,6 @@ class Client extends MatrixApi {
         }),
       );
     }
-
-    // For migration also add to the legacy cache:
-    this.userDeviceKeys.addAll(userDeviceKeys);
     return userDeviceKeys;
   }
 
@@ -3589,24 +3575,6 @@ class Client extends MatrixApi {
     return null;
   }
 
-  Future<Set<String>> _getUserIdsInEncryptedRooms() async {
-    final userIds = <String>{};
-    for (final room in rooms) {
-      if (room.encrypted && room.membership == Membership.join) {
-        try {
-          final userList = await room.requestParticipants([
-            Membership.join,
-            Membership.invite,
-          ], true);
-          userIds.addAll(userList.map((user) => user.id));
-        } catch (e, s) {
-          Logs().e('[E2EE] Failed to fetch participants', e, s);
-        }
-      }
-    }
-    return userIds;
-  }
-
   final Map<String, DateTime> _keyQueryFailures = {};
 
   /// These are the user IDs we share an encrypted room with and need to track
@@ -3614,286 +3582,6 @@ class Client extends MatrixApi {
   /// It gets initialized after the first sync of every
   /// instance and then updated on member changes or sync device changes.
   Set<String>? _trackedUserIds;
-
-  Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) async {
-    try {
-      final database = this.database;
-      if (!isLogged()) return;
-      final dbActions = <Future<dynamic> Function()>[];
-      final trackedUserIds = _trackedUserIds ??=
-          await _getUserIdsInEncryptedRooms();
-      if (!isLogged()) {
-        // For the case we get logged out while `_getUserIdsInEncryptedRooms()`
-        // was already started.
-        _trackedUserIds = null;
-        return;
-      }
-      trackedUserIds.add(userID!);
-      if (additionalUsers != null) trackedUserIds.addAll(additionalUsers);
-
-      // Remove all userIds we no longer need to track the devices of.
-      _userDeviceKeys.removeWhere(
-        (String userId, v) => !trackedUserIds.contains(userId),
-      );
-
-      // Check if there are outdated device key lists. Add it to the set.
-      final outdatedLists = <String, List<String>>{};
-      for (final userId in (additionalUsers ?? <String>[])) {
-        outdatedLists[userId] = [];
-      }
-      for (final userId in trackedUserIds) {
-        final deviceKeysList = _userDeviceKeys[userId] ??= DeviceKeysList(
-          userId,
-          this,
-        );
-        final failure = _keyQueryFailures[userId.domain];
-
-        // deviceKeysList.outdated is not nullable but we have seen this error
-        // in production: `Failed assertion: boolean expression must not be null`
-        // So this could either be a null safety bug in Dart or a result of
-        // using unsound null safety. The extra equal check `!= false` should
-        // save us here.
-        if (deviceKeysList.outdated != false &&
-            (failure == null ||
-                DateTime.now()
-                    .subtract(Duration(minutes: 5))
-                    .isAfter(failure))) {
-          outdatedLists[userId] = [];
-        }
-      }
-
-      if (outdatedLists.isNotEmpty) {
-        if (!isLogged()) return;
-        // Request the missing device key lists from the server.
-        final response = await queryKeys(outdatedLists, timeout: 10000);
-        if (!isLogged()) return;
-
-        final deviceKeys = response.deviceKeys;
-        if (deviceKeys != null) {
-          for (final rawDeviceKeyListEntry in deviceKeys.entries) {
-            final userId = rawDeviceKeyListEntry.key;
-            final userKeys = _userDeviceKeys[userId] ??= DeviceKeysList(
-              userId,
-              this,
-            );
-            final oldKeys = Map<String, DeviceKeys>.from(userKeys.deviceKeys);
-            userKeys.deviceKeys = {};
-            for (final rawDeviceKeyEntry
-                in rawDeviceKeyListEntry.value.entries) {
-              final deviceId = rawDeviceKeyEntry.key;
-
-              // Set the new device key for this device
-              final entry = DeviceKeys.fromMatrixDeviceKeys(
-                rawDeviceKeyEntry.value,
-                this,
-                oldKeys[deviceId]?.lastActive,
-              );
-              final ed25519Key = entry.ed25519Key;
-              final curve25519Key = entry.curve25519Key;
-              if (entry.isValid &&
-                  deviceId == entry.deviceId &&
-                  ed25519Key != null &&
-                  curve25519Key != null) {
-                // Check if deviceId or deviceKeys are known
-                if (!oldKeys.containsKey(deviceId)) {
-                  final oldPublicKeys = await database.deviceIdSeen(
-                    userId,
-                    deviceId,
-                  );
-                  if (oldPublicKeys != null &&
-                      oldPublicKeys != curve25519Key + ed25519Key) {
-                    Logs().w(
-                      'Already seen Device ID has been added again. This might be an attack!',
-                    );
-                    continue;
-                  }
-                  final oldDeviceId = await database.publicKeySeen(ed25519Key);
-                  if (oldDeviceId != null && oldDeviceId != deviceId) {
-                    Logs().w(
-                      'Already seen ED25519 has been added again. This might be an attack!',
-                    );
-                    continue;
-                  }
-                  final oldDeviceId2 = await database.publicKeySeen(
-                    curve25519Key,
-                  );
-                  if (oldDeviceId2 != null && oldDeviceId2 != deviceId) {
-                    Logs().w(
-                      'Already seen Curve25519 has been added again. This might be an attack!',
-                    );
-                    continue;
-                  }
-                  dbActions.add(() async {
-                    await database.addSeenDeviceId(
-                      userId,
-                      deviceId,
-                      curve25519Key + ed25519Key,
-                    );
-                    await database.addSeenPublicKey(ed25519Key, deviceId);
-                    await database.addSeenPublicKey(curve25519Key, deviceId);
-                  });
-                }
-
-                // is this a new key or the same one as an old one?
-                // better store an update - the signatures might have changed!
-                final oldKey = oldKeys[deviceId];
-                if (oldKey == null ||
-                    (oldKey.ed25519Key == entry.ed25519Key &&
-                        oldKey.curve25519Key == entry.curve25519Key)) {
-                  if (oldKey != null) {
-                    // be sure to save the verified status
-                    entry.setDirectVerified(oldKey.directVerified);
-                    entry.blocked = oldKey.blocked;
-                    entry.validSignatures = oldKey.validSignatures;
-                  }
-                  userKeys.deviceKeys[deviceId] = entry;
-                  if (deviceId == deviceID &&
-                      entry.ed25519Key == fingerprintKey) {
-                    // Always trust the own device
-                    entry.setDirectVerified(true);
-                  }
-                  dbActions.add(
-                    () => database.storeUserDeviceKey(
-                      userId,
-                      deviceId,
-                      json.encode(entry.toJson()),
-                      entry.directVerified,
-                      entry.blocked,
-                      entry.lastActive.millisecondsSinceEpoch,
-                    ),
-                  );
-                } else if (oldKeys.containsKey(deviceId)) {
-                  // This shouldn't ever happen. The same device ID has gotten
-                  // a new public key. So we ignore the update. TODO: ask krille
-                  // if we should instead use the new key with unknown verified / blocked status
-                  userKeys.deviceKeys[deviceId] = oldKeys[deviceId]!;
-                }
-              } else {
-                Logs().w('Invalid device ${entry.userId}:${entry.deviceId}');
-              }
-            }
-            // delete old/unused entries
-            for (final oldDeviceKeyEntry in oldKeys.entries) {
-              final deviceId = oldDeviceKeyEntry.key;
-              if (!userKeys.deviceKeys.containsKey(deviceId)) {
-                // we need to remove an old key
-                dbActions.add(
-                  () => database.removeUserDeviceKey(userId, deviceId),
-                );
-              }
-            }
-            userKeys.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
-          }
-        }
-        // next we parse and persist the cross signing keys
-        final crossSigningTypes = {
-          'master': response.masterKeys,
-          'self_signing': response.selfSigningKeys,
-          'user_signing': response.userSigningKeys,
-        };
-        for (final crossSigningKeysEntry in crossSigningTypes.entries) {
-          final keyType = crossSigningKeysEntry.key;
-          final keys = crossSigningKeysEntry.value;
-          if (keys == null) {
-            continue;
-          }
-          for (final crossSigningKeyListEntry in keys.entries) {
-            final userId = crossSigningKeyListEntry.key;
-            final userKeys = _userDeviceKeys[userId] ??= DeviceKeysList(
-              userId,
-              this,
-            );
-            final oldKeys = Map<String, CrossSigningKey>.from(
-              userKeys.crossSigningKeys,
-            );
-            userKeys.crossSigningKeys = {};
-            // add the types we aren't handling atm back
-            for (final oldEntry in oldKeys.entries) {
-              if (!oldEntry.value.usage.contains(keyType)) {
-                userKeys.crossSigningKeys[oldEntry.key] = oldEntry.value;
-              } else {
-                // There is a previous cross-signing key with  this usage, that we no
-                // longer need/use. Clear it from the database.
-                dbActions.add(
-                  () =>
-                      database.removeUserCrossSigningKey(userId, oldEntry.key),
-                );
-              }
-            }
-            final entry = CrossSigningKey.fromMatrixCrossSigningKey(
-              crossSigningKeyListEntry.value,
-              this,
-            );
-            final publicKey = entry.publicKey;
-            if (entry.isValid && publicKey != null) {
-              final oldKey = oldKeys[publicKey];
-              if (oldKey == null || oldKey.ed25519Key == entry.ed25519Key) {
-                if (oldKey != null) {
-                  // be sure to save the verification status
-                  entry.setDirectVerified(oldKey.directVerified);
-                  if (oldKey.trustOnFirstUseSince != null) {
-                    entry.trustOnFirstUse(
-                      since: oldKey.trustOnFirstUseSince,
-                      updateInDatabase: false,
-                    );
-                  }
-                  entry.blocked = oldKey.blocked;
-                  entry.validSignatures = oldKey.validSignatures;
-                }
-                userKeys.crossSigningKeys[publicKey] = entry;
-              } else {
-                // This shouldn't ever happen. The same device ID has gotten
-                // a new public key. So we ignore the update. TODO: ask krille
-                // if we should instead use the new key with unknown verified / blocked status
-                userKeys.crossSigningKeys[publicKey] = oldKey;
-              }
-              dbActions.add(
-                () => database.storeUserCrossSigningKey(
-                  userId,
-                  publicKey,
-                  json.encode(entry.toJson()),
-                  entry.directVerified,
-                  entry.blocked,
-                  trustOnFirstUseSince: entry.trustOnFirstUseSince,
-                ),
-              );
-            }
-            _userDeviceKeys[userId]?.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
-          }
-        }
-
-        // now process all the failures
-        if (response.failures != null) {
-          for (final failureDomain in response.failures?.keys ?? <String>[]) {
-            _keyQueryFailures[failureDomain] = DateTime.now();
-          }
-        }
-      }
-
-      if (dbActions.isNotEmpty) {
-        if (!isLogged()) return;
-        Logs().i(
-          'Updating user device keys in database... (${dbActions.length} operations)',
-        );
-        await runBenchmarked(
-          'Updating user device keys in database...',
-          () => database.transaction(() async {
-            for (final f in dbActions) {
-              await f();
-            }
-          }),
-        );
-      }
-    } catch (e, s) {
-      Logs().e('[Vodozemac] Unable to update user device keys', e, s);
-    }
-  }
 
   bool _toDeviceQueueNeedsProcessing = true;
 

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -126,6 +126,8 @@ abstract class DatabaseApi {
 
   Future storeRoomAccountData(String roomId, BasicEvent event);
 
+  Future<DeviceKeysList?> getUserDeviceKeysList(String userId, Client client);
+
   Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client);
 
   Future<SSSSCache?> getSSSSCache(String type);

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -216,12 +216,17 @@ abstract class DatabaseApi {
 
   Future storeUserDeviceKeysInfo(String userId, bool outdated);
 
+  /// Stores a device key.
+  ///
+  /// When [verified] or [blocked] is `null`, keeps the existing DB value if any,
+  /// otherwise falls back to `false`. Pass explicit booleans only when trust
+  /// should be overwritten (e.g. migration or intentional trust writes).
   Future storeUserDeviceKey(
     String userId,
     String deviceId,
     String content,
-    bool verified,
-    bool blocked,
+    bool? verified,
+    bool? blocked,
     int lastActive,
   );
 
@@ -229,12 +234,17 @@ abstract class DatabaseApi {
 
   Future removeUserCrossSigningKey(String userId, String publicKey);
 
+  /// Stores a cross-signing key.
+  ///
+  /// When [verified] or [blocked] is `null`, keeps the existing DB value if any,
+  /// otherwise falls back to `false`. Pass explicit booleans only when trust
+  /// should be overwritten (e.g. migration or intentional trust writes).
   Future storeUserCrossSigningKey(
     String userId,
     String publicKey,
     String content,
-    bool verified,
-    bool blocked, {
+    bool? verified,
+    bool? blocked, {
     DateTime? trustOnFirstUseSince,
   });
 
@@ -296,6 +306,11 @@ abstract class DatabaseApi {
     String userId,
     String deviceId,
     String publicKeys,
+  );
+
+  Future<DeviceKeys?> getUserDeviceKeysByCurve25519Key(
+    String senderKey,
+    Client client,
   );
 
   Future<void> addSeenPublicKey(String publicKey, String deviceId);

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1369,18 +1369,23 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String publicKey,
     String content,
-    bool verified,
-    bool blocked, {
+    bool? verified,
+    bool? blocked, {
     DateTime? trustOnFirstUseSince,
   }) async {
-    await _userCrossSigningKeysBox.put(TupleKey(userId, publicKey).toString(), {
+    final boxKey = TupleKey(userId, publicKey).toString();
+    final existing = await _userCrossSigningKeysBox.get(boxKey);
+    final existingMap = existing != null ? copyMap(existing) : null;
+    await _userCrossSigningKeysBox.put(boxKey, {
       'user_id': userId,
       'public_key': publicKey,
       'content': content,
-      'verified': verified,
-      'blocked': blocked,
+      'verified': verified ?? existingMap?['verified'] ?? false,
+      'blocked': blocked ?? existingMap?['blocked'] ?? false,
       if (trustOnFirstUseSince != null)
-        'tofu': trustOnFirstUseSince.millisecondsSinceEpoch,
+        'tofu': trustOnFirstUseSince.millisecondsSinceEpoch
+      else if (existingMap?['tofu'] != null)
+        'tofu': existingMap!['tofu'],
     });
   }
 
@@ -1389,16 +1394,19 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
     String content,
-    bool verified,
-    bool blocked,
+    bool? verified,
+    bool? blocked,
     int lastActive,
   ) async {
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), {
+    final boxKey = TupleKey(userId, deviceId).toString();
+    final existing = await _userDeviceKeysBox.get(boxKey);
+    final existingMap = existing != null ? copyMap(existing) : null;
+    await _userDeviceKeysBox.put(boxKey, {
       'user_id': userId,
       'device_id': deviceId,
       'content': content,
-      'verified': verified,
-      'blocked': blocked,
+      'verified': verified ?? existingMap?['verified'] ?? false,
+      'blocked': blocked ?? existingMap?['blocked'] ?? false,
       'last_active': lastActive,
       'last_sent_message': '',
     });
@@ -1864,6 +1872,30 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       client,
       ownKeys: ownKeys,
     );
+  }
+
+  @override
+  Future<DeviceKeys?> getUserDeviceKeysByCurve25519Key(
+    String senderKey,
+    Client client,
+  ) async {
+    final deviceId = await _seenDeviceKeysBox.get(senderKey);
+    if (deviceId == null) return null;
+
+    final seenDevicesKeys = await _seenDeviceIdsBox.getAllKeys();
+
+    for (final key in seenDevicesKeys) {
+      final tuple = TupleKey.fromString(key);
+      if (tuple.parts.last != deviceId) continue;
+      final publicKeys = await _seenDeviceIdsBox.get(key);
+      if (publicKeys == null || !publicKeys.startsWith(senderKey)) continue;
+      final deviceKeysList = await getUserDeviceKeysList(
+        tuple.parts.first,
+        client,
+      );
+      return deviceKeysList?.deviceKeys[deviceId];
+    }
+    return null;
   }
 }
 

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -743,7 +743,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
           final userDeviceKeys = await _userDeviceKeysBox.getAllValues();
           final userCrossSigningKeys = await _userCrossSigningKeysBox
               .getAllValues();
-          for (final userId in deviceKeysOutdated.keys) {
+          final ownUserId = client.userID;
+
+          DeviceKeysList buildList(String userId, {DeviceKeysList? ownKeys}) {
             final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
               final tupleKey = TupleKey.fromString(tuple);
               return tupleKey.parts.first == userId;
@@ -764,7 +766,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
               if (crossSigningKey == null) return null;
               return copyMap(crossSigningKey);
             });
-            res[userId] = DeviceKeysList.fromDbJson(
+            return DeviceKeysList.fromDbJson(
               {
                 'client_id': client.id,
                 'user_id': userId,
@@ -779,7 +781,19 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
                   .toList()
                   .cast<Map<String, dynamic>>(),
               client,
+              ownKeys: ownKeys,
             );
+          }
+
+          if (ownUserId != null && deviceKeysOutdated.containsKey(ownUserId)) {
+            res[ownUserId] = buildList(ownUserId);
+          }
+          final ownKeys =
+              res[ownUserId] ??
+              (ownUserId != null ? DeviceKeysList(ownUserId, client) : null);
+          for (final userId in deviceKeysOutdated.keys) {
+            if (userId == ownUserId) continue;
+            res[userId] = buildList(userId, ownKeys: ownKeys);
           }
           return res;
         },
@@ -1829,6 +1843,14 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         return copyMap(crossSigningKey);
       }),
     );
+
+    DeviceKeysList? ownKeys;
+    final ownUserId = client.userID;
+    if (ownUserId != null && userId != ownUserId) {
+      ownKeys = await getUserDeviceKeysList(ownUserId, client);
+      ownKeys ??= DeviceKeysList(ownUserId, client);
+    }
+
     return DeviceKeysList.fromDbJson(
       {'client_id': client.id, 'user_id': userId, 'outdated': outdated},
       childEntries
@@ -1840,6 +1862,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
           .toList()
           .cast<Map<String, dynamic>>(),
       client,
+      ownKeys: ownKeys,
     );
   }
 }

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1794,6 +1794,55 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String roomId,
     LatestReceiptState receiptState,
   ) => _readReceiptsBox.put(roomId, receiptState.toJson());
+
+  @override
+  Future<DeviceKeysList?> getUserDeviceKeysList(
+    String userId,
+    Client client,
+  ) async {
+    final userDeviceKeysKeys = await _userDeviceKeysBox.getAllKeys();
+    final userCrossSigningKeysKeys = await _userCrossSigningKeysBox
+        .getAllKeys();
+
+    final deviceKeysBoxKeys = userDeviceKeysKeys.where((tuple) {
+      final tupleKey = TupleKey.fromString(tuple);
+      return tupleKey.parts.first == userId;
+    });
+    final crossSigningKeysBoxKeys = userCrossSigningKeysKeys.where((tuple) {
+      final tupleKey = TupleKey.fromString(tuple);
+      return tupleKey.parts.first == userId;
+    });
+    final childEntries = await Future.wait(
+      deviceKeysBoxKeys.map((key) async {
+        final userDeviceKey = await _userDeviceKeysBox.get(key);
+        if (userDeviceKey == null) return null;
+        return copyMap(userDeviceKey);
+      }),
+    );
+    final crossSigningEntries = await Future.wait(
+      crossSigningKeysBoxKeys.map((key) async {
+        final crossSigningKey = await _userCrossSigningKeysBox.get(key);
+        if (crossSigningKey == null) return null;
+        return copyMap(crossSigningKey);
+      }),
+    );
+    return DeviceKeysList.fromDbJson(
+      {
+        'client_id': client.id,
+        'user_id': userId,
+        'outdated': await _userDeviceKeysOutdatedBox.get(userId),
+      },
+      childEntries
+          .where((c) => c != null)
+          .toList()
+          .cast<Map<String, dynamic>>(),
+      crossSigningEntries
+          .where((c) => c != null)
+          .toList()
+          .cast<Map<String, dynamic>>(),
+      client,
+    );
+  }
 }
 
 class TupleKey {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -1800,6 +1800,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     Client client,
   ) async {
+    final outdated = await _userDeviceKeysOutdatedBox.get(userId);
+    if (outdated == null) return null;
+
     final userDeviceKeysKeys = await _userDeviceKeysBox.getAllKeys();
     final userCrossSigningKeysKeys = await _userCrossSigningKeysBox
         .getAllKeys();
@@ -1827,11 +1830,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       }),
     );
     return DeviceKeysList.fromDbJson(
-      {
-        'client_id': client.id,
-        'user_id': userId,
-        'outdated': await _userDeviceKeysOutdatedBox.get(userId),
-      },
+      {'client_id': client.id, 'user_id': userId, 'outdated': outdated},
       childEntries
           .where((c) => c != null)
           .toList()

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1190,8 +1190,7 @@ class Room {
     users.removeWhere((u) => !allDeviceKeys.containsKey(u.id));
 
     for (final u in users) {
-      if ((await allDeviceKeys[u.id]!.verified) !=
-          UserVerifiedStatus.verified) {
+      if ((allDeviceKeys[u.id]!.verified) != UserVerifiedStatus.verified) {
         return EncryptionHealthState.unverifiedDevices;
       }
     }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -2698,7 +2698,6 @@ class Room {
 
   /// Returns all known device keys for all participants in this room.
   Future<List<DeviceKeys>> getUserDeviceKeys() async {
-    await client.userDeviceKeysLoading;
     final deviceKeys = <DeviceKeys>[];
 
     final users = await requestParticipants(
@@ -2713,24 +2712,12 @@ class Room {
       (user) => ![Membership.invite, Membership.join].contains(user.membership),
     );
 
-    // Safety net: if we have participants we have never fetched the device
-    // keys of (e.g. their membership event came down while the room was only
-    // partially loaded or got lost in a gappy sync), fetch them now instead
-    // of silently encrypting without them, as they would otherwise never be
-    // able to decrypt any message in this room.
-    final missingUserIds = users
-        .map((user) => user.id)
-        .where((userId) => client.userDeviceKeys[userId] == null)
-        .toSet();
-    if (missingUserIds.isNotEmpty) {
-      Logs().i(
-        '[E2EE] Fetching device keys of ${missingUserIds.length} untracked users in $id before encrypting',
-      );
-      await client.updateUserDeviceKeys(additionalUsers: missingUserIds);
-    }
+    final userDeviceKeysLists = await client.fetchUserDeviceKeysLists(
+      users.map((user) => user.id).toSet(),
+    );
 
     for (final user in users) {
-      final userDeviceKeys = client.userDeviceKeys[user.id]?.deviceKeys.values;
+      final userDeviceKeys = userDeviceKeysLists[user.id]?.deviceKeys.values;
       if (userDeviceKeys != null) {
         deviceKeys.addAll(userDeviceKeys);
       }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1183,16 +1183,17 @@ class Room {
   Future<EncryptionHealthState> calcEncryptionHealthState() async {
     final users = await requestParticipants();
     users.removeWhere(
-      (u) =>
-          !{Membership.invite, Membership.join}.contains(u.membership) ||
-          !client.userDeviceKeys.containsKey(u.id),
+      (u) => !{Membership.invite, Membership.join}.contains(u.membership),
     );
+    final userIds = users.map((u) => u.id).toSet();
+    final allDeviceKeys = await client.fetchUserDeviceKeysLists(userIds);
+    users.removeWhere((u) => !allDeviceKeys.containsKey(u.id));
 
-    if (users.any(
-      (u) =>
-          client.userDeviceKeys[u.id]!.verified != UserVerifiedStatus.verified,
-    )) {
-      return EncryptionHealthState.unverifiedDevices;
+    for (final u in users) {
+      if ((await allDeviceKeys[u.id]!.verified) !=
+          UserVerifiedStatus.verified) {
+        return EncryptionHealthState.unverifiedDevices;
+      }
     }
 
     return EncryptionHealthState.allVerified;

--- a/lib/src/utils/device_keys_list.dart
+++ b/lib/src/utils/device_keys_list.dart
@@ -29,20 +29,22 @@ class DeviceKeysList {
   CrossSigningKey? get selfSigningKey => getCrossSigningKey('self_signing');
   CrossSigningKey? get userSigningKey => getCrossSigningKey('user_signing');
 
-  UserVerifiedStatus get verified {
+  Future<UserVerifiedStatus> get verified async {
     if (masterKey == null) {
       return UserVerifiedStatus.unknown;
     }
-    if (masterKey!.verified) {
+    if (await masterKey!.verified) {
       for (final key in deviceKeys.values) {
-        if (!key.verified) {
+        final verified = await key.verified;
+        if (!verified) {
           return UserVerifiedStatus.unknownDevice;
         }
       }
       return UserVerifiedStatus.verified;
     } else {
       for (final key in deviceKeys.values) {
-        if (!key.verified) {
+        final verified = await key.verified;
+        if (!verified) {
           return UserVerifiedStatus.unknown;
         }
       }
@@ -170,12 +172,14 @@ abstract class SignableKey extends MatrixSignableKey {
   bool? _blocked;
 
   String? get ed25519Key => keys['ed25519:$identifier'];
-  bool get verified =>
-      identifier != null && (directVerified || crossVerified) && !(blocked);
+  Future<bool> get verified async =>
+      identifier != null &&
+      (directVerified || (await crossVerified)) &&
+      !(blocked);
   bool get blocked => _blocked ?? false;
   set blocked(bool isBlocked) => _blocked = isBlocked;
 
-  bool get encryptToDevice {
+  Future<bool> get encryptToDevice async {
     if (blocked) return false;
 
     if (identifier == null || ed25519Key == null) return false;
@@ -184,7 +188,8 @@ abstract class SignableKey extends MatrixSignableKey {
       case ShareKeysWith.all:
         return true;
       case ShareKeysWith.crossVerifiedIfEnabled:
-        if (client.userDeviceKeys[userId]?.masterKey == null) return true;
+        final keys = await client.fetchUserDeviceKeysList(userId);
+        if (keys?.masterKey == null) return true;
         return hasValidSignatureChain(verifiedByTheirMasterKey: true);
       case ShareKeysWith.crossVerified:
         return hasValidSignatureChain(verifiedByTheirMasterKey: true);
@@ -198,8 +203,8 @@ abstract class SignableKey extends MatrixSignableKey {
   }
 
   bool get directVerified => _verified ?? false;
-  bool get crossVerified => hasValidSignatureChain();
-  bool get signed => hasValidSignatureChain(verifiedOnly: false);
+  Future<bool> get crossVerified => hasValidSignatureChain();
+  Future<bool> get signed => hasValidSignatureChain(verifiedOnly: false);
 
   SignableKey.fromJson(Map<String, dynamic> super.json, this.client)
     : super.fromJson() {
@@ -245,14 +250,14 @@ abstract class SignableKey extends MatrixSignableKey {
     return valid;
   }
 
-  bool hasValidSignatureChain({
+  Future<bool> hasValidSignatureChain({
     bool verifiedOnly = true,
     Set<String>? visited,
     Set<String>? onlyValidateUserIds,
 
     /// Only check if this key is verified by their Master key.
     bool verifiedByTheirMasterKey = false,
-  }) {
+  }) async {
     if (!client.encryptionEnabled) {
       return false;
     }
@@ -272,7 +277,8 @@ abstract class SignableKey extends MatrixSignableKey {
 
     for (final signatureEntries in signatures!.entries) {
       final otherUserId = signatureEntries.key;
-      if (!client.userDeviceKeys.containsKey(otherUserId)) {
+      final otherUserKeys = await client.fetchUserDeviceKeysList(otherUserId);
+      if (otherUserKeys == null) {
         continue;
       }
       // we don't allow transitive trust unless it is for ourself
@@ -289,8 +295,8 @@ abstract class SignableKey extends MatrixSignableKey {
         }
 
         final key =
-            client.userDeviceKeys[otherUserId]?.deviceKeys[keyId] ??
-            client.userDeviceKeys[otherUserId]?.crossSigningKeys[keyId];
+            otherUserKeys.deviceKeys[keyId] ??
+            otherUserKeys.crossSigningKeys[keyId];
         if (key == null) {
           continue;
         }
@@ -339,7 +345,7 @@ abstract class SignableKey extends MatrixSignableKey {
           return true; // we verified this key and it is valid...all checks out!
         }
         // or else we just recurse into that key and check if it works out
-        final haveChain = key.hasValidSignatureChain(
+        final haveChain = await key.hasValidSignatureChain(
           verifiedOnly: verifiedOnly,
           visited: visited_,
           onlyValidateUserIds: onlyValidateUserIds,
@@ -415,7 +421,7 @@ class CrossSigningKey extends SignableKey {
     since ??= DateTime.now();
     if (updateInDatabase) {
       await client.database.setVerifiedUserCrossSigningKey(
-        verified,
+        await verified,
         userId,
         publicKey!,
         trustOnFirstUseSince: since,

--- a/lib/src/utils/device_keys_list.dart
+++ b/lib/src/utils/device_keys_list.dart
@@ -29,22 +29,20 @@ class DeviceKeysList {
   CrossSigningKey? get selfSigningKey => getCrossSigningKey('self_signing');
   CrossSigningKey? get userSigningKey => getCrossSigningKey('user_signing');
 
-  Future<UserVerifiedStatus> get verified async {
+  UserVerifiedStatus get verified {
     if (masterKey == null) {
       return UserVerifiedStatus.unknown;
     }
-    if (await masterKey!.verified) {
+    if (masterKey!.verified) {
       for (final key in deviceKeys.values) {
-        final verified = await key.verified;
-        if (!verified) {
+        if (!key.verified) {
           return UserVerifiedStatus.unknownDevice;
         }
       }
       return UserVerifiedStatus.verified;
     } else {
       for (final key in deviceKeys.values) {
-        final verified = await key.verified;
-        if (!verified) {
+        if (!key.verified) {
           return UserVerifiedStatus.unknown;
         }
       }
@@ -128,13 +126,20 @@ class DeviceKeysList {
     Map<String, dynamic> dbEntry,
     List<Map<String, dynamic>> childEntries,
     List<Map<String, dynamic>> crossSigningEntries,
-    this.client,
-  ) : userId = dbEntry['user_id'] ?? '' {
+    this.client, {
+    DeviceKeysList? ownKeys,
+  }) : userId = dbEntry['user_id'] ?? '' {
     outdated = dbEntry['outdated'];
     deviceKeys = {};
+    final effectiveOwnKeys = ownKeys ?? this;
     for (final childEntry in childEntries) {
       try {
-        final entry = DeviceKeys.fromDb(childEntry, client);
+        final entry = DeviceKeys.fromDb(
+          childEntry,
+          this,
+          effectiveOwnKeys,
+          client,
+        );
         if (!entry.isValid) throw Exception('Invalid device keys');
         deviceKeys[childEntry['device_id']] = entry;
       } catch (e, s) {
@@ -144,7 +149,12 @@ class DeviceKeysList {
     }
     for (final crossSigningEntry in crossSigningEntries) {
       try {
-        final entry = CrossSigningKey.fromDbJson(crossSigningEntry, client);
+        final entry = CrossSigningKey.fromDbJson(
+          crossSigningEntry,
+          this,
+          effectiveOwnKeys,
+          client,
+        );
         if (!entry.isValid) throw Exception('Invalid device keys');
         crossSigningKeys[crossSigningEntry['public_key']] = entry;
       } catch (e, s) {
@@ -171,15 +181,20 @@ abstract class SignableKey extends MatrixSignableKey {
   bool? _verified;
   bool? _blocked;
 
+  /// Device keys of [userId], used to resolve same-user signatures.
+  final DeviceKeysList userKeys;
+
+  /// Device keys of [Client.userID], used to resolve cross-user signatures
+  /// (e.g. our user-signing key signing their master key).
+  final DeviceKeysList ownKeys;
+
   String? get ed25519Key => keys['ed25519:$identifier'];
-  Future<bool> get verified async =>
-      identifier != null &&
-      (directVerified || (await crossVerified)) &&
-      !(blocked);
+  bool get verified =>
+      identifier != null && (directVerified || crossVerified) && !(blocked);
   bool get blocked => _blocked ?? false;
   set blocked(bool isBlocked) => _blocked = isBlocked;
 
-  Future<bool> get encryptToDevice async {
+  bool get encryptToDevice {
     if (blocked) return false;
 
     if (identifier == null || ed25519Key == null) return false;
@@ -188,8 +203,7 @@ abstract class SignableKey extends MatrixSignableKey {
       case ShareKeysWith.all:
         return true;
       case ShareKeysWith.crossVerifiedIfEnabled:
-        final keys = await client.fetchUserDeviceKeysList(userId);
-        if (keys?.masterKey == null) return true;
+        if (userKeys.masterKey == null) return true;
         return hasValidSignatureChain(verifiedByTheirMasterKey: true);
       case ShareKeysWith.crossVerified:
         return hasValidSignatureChain(verifiedByTheirMasterKey: true);
@@ -203,11 +217,15 @@ abstract class SignableKey extends MatrixSignableKey {
   }
 
   bool get directVerified => _verified ?? false;
-  Future<bool> get crossVerified => hasValidSignatureChain();
-  Future<bool> get signed => hasValidSignatureChain(verifiedOnly: false);
+  bool get crossVerified => hasValidSignatureChain();
+  bool get signed => hasValidSignatureChain(verifiedOnly: false);
 
-  SignableKey.fromJson(Map<String, dynamic> super.json, this.client)
-    : super.fromJson() {
+  SignableKey.fromJson(
+    Map<String, dynamic> super.json,
+    this.userKeys,
+    this.ownKeys,
+    this.client,
+  ) : super.fromJson() {
     _verified = false;
     _blocked = false;
   }
@@ -250,14 +268,14 @@ abstract class SignableKey extends MatrixSignableKey {
     return valid;
   }
 
-  Future<bool> hasValidSignatureChain({
+  bool hasValidSignatureChain({
     bool verifiedOnly = true,
     Set<String>? visited,
     Set<String>? onlyValidateUserIds,
 
     /// Only check if this key is verified by their Master key.
     bool verifiedByTheirMasterKey = false,
-  }) async {
+  }) {
     if (!client.encryptionEnabled) {
       return false;
     }
@@ -277,14 +295,11 @@ abstract class SignableKey extends MatrixSignableKey {
 
     for (final signatureEntries in signatures!.entries) {
       final otherUserId = signatureEntries.key;
-      final otherUserKeys = await client.fetchUserDeviceKeysList(otherUserId);
-      if (otherUserKeys == null) {
-        continue;
-      }
       // we don't allow transitive trust unless it is for ourself
       if (otherUserId != userId && otherUserId != client.userID) {
         continue;
       }
+      final otherUserKeys = otherUserId == userId ? userKeys : ownKeys;
       for (final signatureEntry in signatureEntries.value.entries) {
         final fullKeyId = signatureEntry.key;
         final signature = signatureEntry.value;
@@ -345,7 +360,7 @@ abstract class SignableKey extends MatrixSignableKey {
           return true; // we verified this key and it is valid...all checks out!
         }
         // or else we just recurse into that key and check if it works out
-        final haveChain = await key.hasValidSignatureChain(
+        final haveChain = key.hasValidSignatureChain(
           verifiedOnly: verifiedOnly,
           visited: visited_,
           onlyValidateUserIds: onlyValidateUserIds,
@@ -359,6 +374,11 @@ abstract class SignableKey extends MatrixSignableKey {
     return false;
   }
 
+  /// Sets whether this key is directly verified.
+  ///
+  /// Persists to the database and updates this instance. Other
+  /// [DeviceKeysList] snapshots from earlier [Client.fetchUserDeviceKeysList]
+  /// calls are not updated — fetch again if you still hold them.
   Future<void> setVerified(bool newVerified, [bool sign = true]) async {
     _verified = newVerified;
     final encryption = client.encryption;
@@ -373,6 +393,11 @@ abstract class SignableKey extends MatrixSignableKey {
     }
   }
 
+  /// Sets whether this key is blocked.
+  ///
+  /// Persists to the database and updates this instance. Other
+  /// [DeviceKeysList] snapshots from earlier [Client.fetchUserDeviceKeysList]
+  /// calls are not updated — fetch again if you still hold them.
   Future<void> setBlocked(bool newBlocked);
 
   @override
@@ -421,7 +446,7 @@ class CrossSigningKey extends SignableKey {
     since ??= DateTime.now();
     if (updateInDatabase) {
       await client.database.setVerifiedUserCrossSigningKey(
-        await verified,
+        verified,
         userId,
         publicKey!,
         trustOnFirstUseSince: since,
@@ -459,8 +484,10 @@ class CrossSigningKey extends SignableKey {
 
   CrossSigningKey.fromMatrixCrossSigningKey(
     MatrixCrossSigningKey key,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
     Client client,
-  ) : super.fromJson(key.toJson().copy(), client) {
+  ) : super.fromJson(key.toJson().copy(), userKeys, ownKeys, client) {
     final json = toJson();
     identifier = key.publicKey;
     usage = json['usage'].cast<String>();
@@ -469,8 +496,17 @@ class CrossSigningKey extends SignableKey {
         : DateTime.fromMillisecondsSinceEpoch(json['tofu'] as int);
   }
 
-  CrossSigningKey.fromDbJson(Map<String, dynamic> dbEntry, Client client)
-    : super.fromJson(Event.getMapFromPayload(dbEntry['content']), client) {
+  CrossSigningKey.fromDbJson(
+    Map<String, dynamic> dbEntry,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
+    Client client,
+  ) : super.fromJson(
+        Event.getMapFromPayload(dbEntry['content']),
+        userKeys,
+        ownKeys,
+        client,
+      ) {
     final json = toJson();
     identifier = dbEntry['public_key'];
     usage = json['usage'].cast<String>();
@@ -481,8 +517,12 @@ class CrossSigningKey extends SignableKey {
         : DateTime.fromMillisecondsSinceEpoch(dbEntry['tofu'] as int);
   }
 
-  CrossSigningKey.fromJson(Map<String, dynamic> json, Client client)
-    : super.fromJson(json.copy(), client) {
+  CrossSigningKey.fromJson(
+    Map<String, dynamic> json,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
+    Client client,
+  ) : super.fromJson(json.copy(), userKeys, ownKeys, client) {
     final json = toJson();
     usage = json['usage'].cast<String>();
     _trustOnFirstUseSince = json['tofu'] == null
@@ -561,17 +601,28 @@ class DeviceKeys extends SignableKey {
 
   DeviceKeys.fromMatrixDeviceKeys(
     MatrixDeviceKeys keys,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
     Client client, [
     DateTime? lastActiveTs,
-  ]) : super.fromJson(keys.toJson().copy(), client) {
+  ]) : super.fromJson(keys.toJson().copy(), userKeys, ownKeys, client) {
     final json = toJson();
     identifier = keys.deviceId;
     algorithms = json['algorithms'].cast<String>();
     lastActive = lastActiveTs ?? DateTime.now();
   }
 
-  DeviceKeys.fromDb(Map<String, dynamic> dbEntry, Client client)
-    : super.fromJson(Event.getMapFromPayload(dbEntry['content']), client) {
+  DeviceKeys.fromDb(
+    Map<String, dynamic> dbEntry,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
+    Client client,
+  ) : super.fromJson(
+        Event.getMapFromPayload(dbEntry['content']),
+        userKeys,
+        ownKeys,
+        client,
+      ) {
     final json = toJson();
     identifier = dbEntry['device_id'];
     algorithms = json['algorithms'].cast<String>();
@@ -582,8 +633,12 @@ class DeviceKeys extends SignableKey {
     );
   }
 
-  DeviceKeys.fromJson(Map<String, dynamic> json, Client client)
-    : super.fromJson(json.copy(), client) {
+  DeviceKeys.fromJson(
+    Map<String, dynamic> json,
+    DeviceKeysList userKeys,
+    DeviceKeysList ownKeys,
+    Client client,
+  ) : super.fromJson(json.copy(), userKeys, ownKeys, client) {
     final json = toJson();
     identifier = json['device_id'];
     algorithms = json['algorithms'].cast<String>();

--- a/lib/src/voip/backend/livekit_backend.dart
+++ b/lib/src/voip/backend/livekit_backend.dart
@@ -325,7 +325,6 @@ class LiveKitBackend extends CallBackend {
     for (final participant in remoteParticipants) {
       if (participant.deviceId == null) continue;
       if (mustEncrypt) {
-        await groupCall.client.userDeviceKeysLoading;
         final deviceKey = groupCall
             .client
             .userDeviceKeys[participant.userId]

--- a/lib/src/voip/backend/livekit_backend.dart
+++ b/lib/src/voip/backend/livekit_backend.dart
@@ -322,12 +322,18 @@ class LiveKitBackend extends CallBackend {
     final mustEncryptkeysToSendTo = <DeviceKeys>[];
     final unencryptedDataToSend = <String, Map<String, Map<String, Object>>>{};
 
+    final participantUserIds = remoteParticipants
+        .where((p) => p.deviceId != null)
+        .map((p) => p.userId)
+        .toSet();
+    final participantKeys = mustEncrypt && participantUserIds.isNotEmpty
+        ? await groupCall.client.fetchUserDeviceKeysLists(participantUserIds)
+        : <String, DeviceKeysList>{};
+
     for (final participant in remoteParticipants) {
       if (participant.deviceId == null) continue;
       if (mustEncrypt) {
-        final deviceKey = groupCall
-            .client
-            .userDeviceKeys[participant.userId]
+        final deviceKey = participantKeys[participant.userId]
             ?.deviceKeys[participant.deviceId];
         if (deviceKey != null) {
           mustEncryptkeysToSendTo.add(deviceKey);

--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -1851,7 +1851,6 @@ class CallSession {
       };
 
       if (mustEncrypt) {
-        await client.userDeviceKeysLoading;
         if (client.userDeviceKeys[remoteUserId]?.deviceKeys[remoteDeviceId] !=
             null) {
           await client.sendToDeviceEncrypted(

--- a/lib/src/voip/call_session.dart
+++ b/lib/src/voip/call_session.dart
@@ -1851,13 +1851,10 @@ class CallSession {
       };
 
       if (mustEncrypt) {
-        if (client.userDeviceKeys[remoteUserId]?.deviceKeys[remoteDeviceId] !=
-            null) {
-          await client.sendToDeviceEncrypted(
-            [client.userDeviceKeys[remoteUserId]!.deviceKeys[remoteDeviceId]!],
-            type,
-            data,
-          );
+        final remoteKeys = await client.fetchUserDeviceKeysList(remoteUserId!);
+        final remoteDeviceKey = remoteKeys?.deviceKeys[remoteDeviceId];
+        if (remoteDeviceKey != null) {
+          await client.sendToDeviceEncrypted([remoteDeviceKey], type, data);
         } else {
           Logs().w(
             '[VOIP] _sendCallContent missing device keys for $remoteUserId',

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -238,18 +238,20 @@ void main() {
       expect(presenceCounter, 1);
       expect(accountDataCounter, 10);
 
-      expect(matrix.userDeviceKeys.keys.toSet(), {
+      final keys = await matrix.fetchUserDeviceKeysLists({
         '@alice:example.com',
         '@othertest:fakeServer.notExisting',
         '@test:fakeServer.notExisting',
       });
-      expect(matrix.userDeviceKeys['@alice:example.com']?.outdated, false);
-      expect(matrix.userDeviceKeys['@alice:example.com']?.deviceKeys.length, 2);
+      expect(keys.keys.toSet(), {
+        '@alice:example.com',
+        '@othertest:fakeServer.notExisting',
+        '@test:fakeServer.notExisting',
+      });
+      expect(keys['@alice:example.com']?.outdated, false);
+      expect(keys['@alice:example.com']!.deviceKeys.length, 2);
       expect(
-        matrix
-            .userDeviceKeys['@alice:example.com']
-            ?.deviceKeys['JLAFKJWSCS']
-            ?.verified,
+        await keys['@alice:example.com']?.deviceKeys['JLAFKJWSCS']?.verified,
         false,
       );
 
@@ -263,8 +265,19 @@ void main() {
         }),
       );
       await Future.delayed(Duration(milliseconds: 50));
-      expect(matrix.userDeviceKeys.length, 3);
-      expect(matrix.userDeviceKeys['@alice:example.com']?.outdated, true);
+      final cachedAlice = await matrix.database.getUserDeviceKeysList(
+        '@alice:example.com',
+        matrix,
+      );
+      expect(cachedAlice?.outdated, true);
+      final keysAfterSync = await matrix.fetchUserDeviceKeysLists({
+        '@alice:example.com',
+        '@othertest:fakeServer.notExisting',
+        '@test:fakeServer.notExisting',
+      });
+      expect(keysAfterSync.length, 3);
+      // fetch refreshes outdated keys
+      expect(keysAfterSync['@alice:example.com']?.outdated, false);
 
       await matrix.handleSync(
         SyncUpdate.fromJson({
@@ -1100,8 +1113,11 @@ void main() {
     test('sendToDeviceEncrypted', () async {
       FakeMatrixApi.calledEndpoints.clear();
 
+      final aliceKeys = await matrix.fetchUserDeviceKeysList(
+        '@alice:example.com',
+      );
       await matrix.sendToDeviceEncrypted(
-        matrix.userDeviceKeys['@alice:example.com']!.deviceKeys.values.toList(),
+        aliceKeys!.deviceKeys.values.toList(),
         'm.message',
         {'msgtype': 'm.text', 'body': 'Hello world'},
       );
@@ -1114,8 +1130,11 @@ void main() {
     });
     test('sendToDeviceEncryptedChunked', () async {
       FakeMatrixApi.calledEndpoints.clear();
+      final aliceKeys = await matrix.fetchUserDeviceKeysList(
+        '@alice:example.com',
+      );
       await matrix.sendToDeviceEncryptedChunked(
-        matrix.userDeviceKeys['@alice:example.com']!.deviceKeys.values.toList(),
+        aliceKeys!.deviceKeys.values.toList(),
         'm.message',
         {'msgtype': 'm.text', 'body': 'Hello world'},
       );

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -251,7 +251,7 @@ void main() {
       expect(keys['@alice:example.com']?.outdated, false);
       expect(keys['@alice:example.com']!.deviceKeys.length, 2);
       expect(
-        await keys['@alice:example.com']?.deviceKeys['JLAFKJWSCS']?.verified,
+        keys['@alice:example.com']?.deviceKeys['JLAFKJWSCS']?.verified,
         false,
       );
 
@@ -1172,7 +1172,8 @@ void main() {
         keyObj['signatures'] = {
           userId: {'ed25519:$deviceId': signature.toBase64()},
         };
-        deviceKeys.add(DeviceKeys.fromJson(keyObj, matrix));
+        final list = DeviceKeysList(userId, matrix);
+        deviceKeys.add(DeviceKeys.fromJson(keyObj, list, list, matrix));
       }
       FakeMatrixApi.calledEndpoints.clear();
       await matrix.sendToDeviceEncryptedChunked(deviceKeys, 'm.message', {

--- a/test/device_keys_list_test.dart
+++ b/test/device_keys_list_test.dart
@@ -51,7 +51,8 @@ void main() async {
         'unsigned': {'device_display_name': "Alice's mobile phone"},
       };
 
-      final key = DeviceKeys.fromJson(rawJson, client);
+      final aliceList = DeviceKeysList('@alice:example.com', client);
+      final key = DeviceKeys.fromJson(rawJson, aliceList, aliceList, client);
       // Signature is intentionally invalid in this fixture, so mutating
       // verification/block state must fail on invalid keys.
       expect(key.isValid, false);
@@ -73,41 +74,60 @@ void main() async {
         },
         'signatures': {},
       };
-      final crossKey = CrossSigningKey.fromJson(rawJson, client);
+      final testList = DeviceKeysList('@test:fakeServer.notExisting', client);
+      final crossKey = CrossSigningKey.fromJson(
+        rawJson,
+        testList,
+        testList,
+        client,
+      );
       expect(json.encode(crossKey.toJson()), json.encode(rawJson));
       expect(crossKey.usage.first, 'master');
     });
 
     test('reject devices without self-signature', () async {
-      var key = DeviceKeys.fromJson({
-        'user_id': '@test:fakeServer.notExisting',
-        'device_id': 'BADDEVICE',
-        'algorithms': [
-          AlgorithmTypes.olmV1Curve25519AesSha2,
-          AlgorithmTypes.megolmV1AesSha2,
-        ],
-        'keys': {
-          'curve25519:BADDEVICE': 'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
-          'ed25519:BADDEVICE': 'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
+      final badList = DeviceKeysList('@test:fakeServer.notExisting', client);
+      var key = DeviceKeys.fromJson(
+        {
+          'user_id': '@test:fakeServer.notExisting',
+          'device_id': 'BADDEVICE',
+          'algorithms': [
+            AlgorithmTypes.olmV1Curve25519AesSha2,
+            AlgorithmTypes.megolmV1AesSha2,
+          ],
+          'keys': {
+            'curve25519:BADDEVICE':
+                'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
+            'ed25519:BADDEVICE': 'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
+          },
         },
-      }, client);
+        badList,
+        badList,
+        client,
+      );
       expect(key.isValid, false);
       expect(key.selfSigned, false);
-      key = DeviceKeys.fromJson({
-        'user_id': '@test:fakeServer.notExisting',
-        'device_id': 'BADDEVICE',
-        'algorithms': [
-          AlgorithmTypes.olmV1Curve25519AesSha2,
-          AlgorithmTypes.megolmV1AesSha2,
-        ],
-        'keys': {
-          'curve25519:BADDEVICE': 'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
-          'ed25519:BADDEVICE': 'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
+      key = DeviceKeys.fromJson(
+        {
+          'user_id': '@test:fakeServer.notExisting',
+          'device_id': 'BADDEVICE',
+          'algorithms': [
+            AlgorithmTypes.olmV1Curve25519AesSha2,
+            AlgorithmTypes.megolmV1AesSha2,
+          ],
+          'keys': {
+            'curve25519:BADDEVICE':
+                'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
+            'ed25519:BADDEVICE': 'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
+          },
+          'signatures': {
+            '@test:fakeServer.notExisting': {'ed25519:BADDEVICE': 'invalid'},
+          },
         },
-        'signatures': {
-          '@test:fakeServer.notExisting': {'ed25519:BADDEVICE': 'invalid'},
-        },
-      }, client);
+        badList,
+        badList,
+        client,
+      );
       expect(key.isValid, false);
       expect(key.selfSigned, false);
     });
@@ -115,57 +135,67 @@ void main() async {
     test('set blocked / verified', () async {
       final ownKeys = (await client.fetchUserDeviceKeysList(client.userID!))!;
       final key = ownKeys.deviceKeys['OTHERDEVICE']!;
-      ownKeys.deviceKeys['UNSIGNEDDEVICE'] = DeviceKeys.fromJson({
-        'user_id': '@test:fakeServer.notExisting',
-        'device_id': 'UNSIGNEDDEVICE',
-        'algorithms': [
-          AlgorithmTypes.olmV1Curve25519AesSha2,
-          AlgorithmTypes.megolmV1AesSha2,
-        ],
-        'keys': {
-          'curve25519:UNSIGNEDDEVICE':
-              'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
-          'ed25519:UNSIGNEDDEVICE':
-              'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
-        },
-        'signatures': {
-          '@test:fakeServer.notExisting': {
+      ownKeys.deviceKeys['UNSIGNEDDEVICE'] = DeviceKeys.fromJson(
+        {
+          'user_id': '@test:fakeServer.notExisting',
+          'device_id': 'UNSIGNEDDEVICE',
+          'algorithms': [
+            AlgorithmTypes.olmV1Curve25519AesSha2,
+            AlgorithmTypes.megolmV1AesSha2,
+          ],
+          'keys': {
+            'curve25519:UNSIGNEDDEVICE':
+                'ds6+bItpDiWyRaT/b0ofoz1R+GCy7YTbORLJI4dmYho',
             'ed25519:UNSIGNEDDEVICE':
-                'f2p1kv6PIz+hnoFYnHEurhUKIyRsdxwR2RTKT1EnQ3aF2zlZOjmnndOCtIT24Q8vs2PovRw+/jkHKj4ge2yDDw',
+                'CdDKVf44LO2QlfWopP6VWmqedSrRaf9rhHKvdVyH38w',
+          },
+          'signatures': {
+            '@test:fakeServer.notExisting': {
+              'ed25519:UNSIGNEDDEVICE':
+                  'f2p1kv6PIz+hnoFYnHEurhUKIyRsdxwR2RTKT1EnQ3aF2zlZOjmnndOCtIT24Q8vs2PovRw+/jkHKj4ge2yDDw',
+            },
           },
         },
-      }, client);
+        ownKeys,
+        ownKeys,
+        client,
+      );
 
       client.shareKeysWith = ShareKeysWith.all;
-      expect(await key.encryptToDevice, true);
+      expect(key.encryptToDevice, true);
 
       client.shareKeysWith = ShareKeysWith.directlyVerifiedOnly;
-      expect(await key.encryptToDevice, false);
+      expect(key.encryptToDevice, false);
       await key.setVerified(true);
-      expect(await key.encryptToDevice, true);
+      expect(key.encryptToDevice, true);
       await key.setVerified(false);
 
       client.shareKeysWith = ShareKeysWith.crossVerified;
-      expect(await key.encryptToDevice, true);
+      expect(key.encryptToDevice, true);
       client.shareKeysWith = ShareKeysWith.crossVerified;
       // Disable cross signing for this user manually so encryptToDevice should return `false`
+      final masterPublicKey = ownKeys.masterKey!.publicKey!;
+      final removedMasterKey = ownKeys.crossSigningKeys.remove(
+        masterPublicKey,
+      )!;
       await client.database.removeUserCrossSigningKey(
         ownKeys.userId,
-        ownKeys.masterKey!.publicKey!,
+        masterPublicKey,
       );
 
-      expect(await key.encryptToDevice, false);
+      expect(key.encryptToDevice, false);
       // But crossVerifiedIfEnabled should return `true` now:
       client.shareKeysWith = ShareKeysWith.crossVerifiedIfEnabled;
-      expect(await key.encryptToDevice, true);
+      expect(key.encryptToDevice, true);
 
+      ownKeys.crossSigningKeys[masterPublicKey] = removedMasterKey;
       await client.database.storeUserCrossSigningKey(
         ownKeys.userId,
-        ownKeys.masterKey!.publicKey!,
-        json.encode(ownKeys.masterKey!.toJson()),
-        ownKeys.masterKey!.directVerified,
-        ownKeys.masterKey!.blocked,
-        trustOnFirstUseSince: ownKeys.masterKey!.trustOnFirstUseSince,
+        masterPublicKey,
+        json.encode(removedMasterKey.toJson()),
+        removedMasterKey.directVerified,
+        removedMasterKey.blocked,
+        trustOnFirstUseSince: removedMasterKey.trustOnFirstUseSince,
       );
       client.shareKeysWith = ShareKeysWith.all;
       final masterKey = ownKeys.masterKey!;
@@ -175,23 +205,23 @@ void main() async {
       await handle.unlock(recoveryKey: ssssKey);
       await handle.maybeCacheAll();
 
-      expect(await key.verified, true);
-      expect(await key.encryptToDevice, true);
+      expect(key.verified, true);
+      expect(key.encryptToDevice, true);
       await key.setBlocked(true);
-      expect(await key.verified, false);
-      expect(await key.encryptToDevice, false);
+      expect(key.verified, false);
+      expect(key.encryptToDevice, false);
       await key.setBlocked(false);
       expect(key.directVerified, false);
-      expect(await key.verified, true); // still verified via cross-sgining
-      expect(await key.encryptToDevice, true);
-      expect(await ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
+      expect(key.verified, true); // still verified via cross-sgining
+      expect(key.encryptToDevice, true);
+      expect(ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
 
-      expect(await masterKey.verified, true);
+      expect(masterKey.verified, true);
       await masterKey.setBlocked(true);
-      expect(await masterKey.verified, false);
-      expect(await ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
+      expect(masterKey.verified, false);
+      expect(ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
       await masterKey.setBlocked(false);
-      expect(await masterKey.verified, true);
+      expect(masterKey.verified, true);
 
       FakeMatrixApi.calledEndpoints.clear();
       await key.setVerified(true);
@@ -220,26 +250,26 @@ void main() async {
     test('verification based on signatures', () async {
       final user = await client.fetchUserDeviceKeysList(client.userID!);
       user!.masterKey!.setDirectVerified(true);
-      expect(await user.deviceKeys['GHTYAJCE']?.crossVerified, true);
-      expect(await user.deviceKeys['GHTYAJCE']?.signed, true);
-      expect(await user.getKey('GHTYAJCE')?.crossVerified, true);
-      expect(await user.deviceKeys['OTHERDEVICE']?.crossVerified, true);
-      expect(await user.selfSigningKey?.crossVerified, true);
+      expect(user.deviceKeys['GHTYAJCE']?.crossVerified, true);
+      expect(user.deviceKeys['GHTYAJCE']?.signed, true);
+      expect(user.getKey('GHTYAJCE')?.crossVerified, true);
+      expect(user.deviceKeys['OTHERDEVICE']?.crossVerified, true);
+      expect(user.selfSigningKey?.crossVerified, true);
       expect(
-        await user
+        user
             .getKey('F9ypFzgbISXCzxQhhSnXMkc1vq12Luna3Nw5rqViOJY')
             ?.crossVerified,
         true,
       );
-      expect(await user.userSigningKey?.crossVerified, true);
-      expect(await user.verified, UserVerifiedStatus.verified);
+      expect(user.userSigningKey?.crossVerified, true);
+      expect(user.verified, UserVerifiedStatus.verified);
       await user.masterKey?.setVerified(false);
-      expect(await user.deviceKeys['GHTYAJCE']?.crossVerified, false);
-      expect(await user.deviceKeys['OTHERDEVICE']?.crossVerified, false);
-      expect(await user.verified, UserVerifiedStatus.unknown);
+      expect(user.deviceKeys['GHTYAJCE']?.crossVerified, false);
+      expect(user.deviceKeys['OTHERDEVICE']?.crossVerified, false);
+      expect(user.verified, UserVerifiedStatus.unknown);
 
       user.deviceKeys['OTHERDEVICE']?.setDirectVerified(true);
-      expect(await user.verified, UserVerifiedStatus.verified);
+      expect(user.verified, UserVerifiedStatus.verified);
       user.deviceKeys['OTHERDEVICE']?.setDirectVerified(false);
 
       await user.masterKey!.setVerified(true);
@@ -247,15 +277,15 @@ void main() async {
         (k, v) => k != 'ed25519:GHTYAJCE',
       );
       expect(
-        await user.deviceKeys['GHTYAJCE']?.verified,
+        user.deviceKeys['GHTYAJCE']?.verified,
         true,
       ); // it's our own device, should be direct verified
       expect(
-        await user.deviceKeys['GHTYAJCE']?.signed,
+        user.deviceKeys['GHTYAJCE']?.signed,
         false,
       ); // not verified for others
       user.deviceKeys['OTHERDEVICE']?.signatures?.clear();
-      expect(await user.verified, UserVerifiedStatus.unknownDevice);
+      expect(user.verified, UserVerifiedStatus.unknownDevice);
     });
 
     test('start verification', () async {

--- a/test/device_keys_list_test.dart
+++ b/test/device_keys_list_test.dart
@@ -113,11 +113,9 @@ void main() async {
     });
 
     test('set blocked / verified', () async {
-      final key =
-          client.userDeviceKeys[client.userID]!.deviceKeys['OTHERDEVICE']!;
-      client
-          .userDeviceKeys[client.userID]
-          ?.deviceKeys['UNSIGNEDDEVICE'] = DeviceKeys.fromJson({
+      final ownKeys = (await client.fetchUserDeviceKeysList(client.userID!))!;
+      final key = ownKeys.deviceKeys['OTHERDEVICE']!;
+      ownKeys.deviceKeys['UNSIGNEDDEVICE'] = DeviceKeys.fromJson({
         'user_id': '@test:fakeServer.notExisting',
         'device_id': 'UNSIGNEDDEVICE',
         'algorithms': [
@@ -139,63 +137,61 @@ void main() async {
       }, client);
 
       client.shareKeysWith = ShareKeysWith.all;
-      expect(key.encryptToDevice, true);
+      expect(await key.encryptToDevice, true);
 
       client.shareKeysWith = ShareKeysWith.directlyVerifiedOnly;
-      expect(key.encryptToDevice, false);
+      expect(await key.encryptToDevice, false);
       await key.setVerified(true);
-      expect(key.encryptToDevice, true);
+      expect(await key.encryptToDevice, true);
       await key.setVerified(false);
 
       client.shareKeysWith = ShareKeysWith.crossVerified;
-      expect(key.encryptToDevice, true);
-
+      expect(await key.encryptToDevice, true);
       client.shareKeysWith = ShareKeysWith.crossVerified;
       // Disable cross signing for this user manually so encryptToDevice should return `false`
-      final dropUserDeviceKeys = client.userDeviceKeys.remove(key.userId);
-      expect(key.encryptToDevice, false);
+      await client.database.removeUserCrossSigningKey(
+        ownKeys.userId,
+        ownKeys.masterKey!.publicKey!,
+      );
+
+      expect(await key.encryptToDevice, false);
       // But crossVerifiedIfEnabled should return `true` now:
       client.shareKeysWith = ShareKeysWith.crossVerifiedIfEnabled;
-      expect(key.encryptToDevice, true);
+      expect(await key.encryptToDevice, true);
 
-      client.userDeviceKeys[key.userId] = dropUserDeviceKeys!;
+      await client.database.storeUserCrossSigningKey(
+        ownKeys.userId,
+        ownKeys.masterKey!.publicKey!,
+        json.encode(ownKeys.masterKey!.toJson()),
+        ownKeys.masterKey!.directVerified,
+        ownKeys.masterKey!.blocked,
+        trustOnFirstUseSince: ownKeys.masterKey!.trustOnFirstUseSince,
+      );
       client.shareKeysWith = ShareKeysWith.all;
-      final masterKey = client.userDeviceKeys[client.userID]!.masterKey!;
+      final masterKey = ownKeys.masterKey!;
       masterKey.setDirectVerified(true);
       // we need to populate the ssss cache to be able to test signing easily
       final handle = client.encryption!.ssss.open();
       await handle.unlock(recoveryKey: ssssKey);
       await handle.maybeCacheAll();
 
-      expect(key.verified, true);
-      expect(key.encryptToDevice, true);
+      expect(await key.verified, true);
+      expect(await key.encryptToDevice, true);
       await key.setBlocked(true);
-      expect(key.verified, false);
-      expect(key.encryptToDevice, false);
+      expect(await key.verified, false);
+      expect(await key.encryptToDevice, false);
       await key.setBlocked(false);
       expect(key.directVerified, false);
-      expect(key.verified, true); // still verified via cross-sgining
-      expect(key.encryptToDevice, true);
-      expect(
-        client
-            .userDeviceKeys[client.userID]
-            ?.deviceKeys['UNSIGNEDDEVICE']
-            ?.encryptToDevice,
-        true,
-      );
+      expect(await key.verified, true); // still verified via cross-sgining
+      expect(await key.encryptToDevice, true);
+      expect(await ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
 
-      expect(masterKey.verified, true);
+      expect(await masterKey.verified, true);
       await masterKey.setBlocked(true);
-      expect(masterKey.verified, false);
-      expect(
-        client
-            .userDeviceKeys[client.userID]
-            ?.deviceKeys['UNSIGNEDDEVICE']
-            ?.encryptToDevice,
-        true,
-      );
+      expect(await masterKey.verified, false);
+      expect(await ownKeys.deviceKeys['UNSIGNEDDEVICE']?.encryptToDevice, true);
       await masterKey.setBlocked(false);
-      expect(masterKey.verified, true);
+      expect(await masterKey.verified, true);
 
       FakeMatrixApi.calledEndpoints.clear();
       await key.setVerified(true);
@@ -218,55 +214,55 @@ void main() async {
         false,
       );
       expect(key.directVerified, false);
-      client.userDeviceKeys[client.userID]?.deviceKeys.remove('UNSIGNEDDEVICE');
+      ownKeys.deviceKeys.remove('UNSIGNEDDEVICE');
     });
 
     test('verification based on signatures', () async {
-      final user = client.userDeviceKeys[client.userID]!;
-      user.masterKey?.setDirectVerified(true);
-      expect(user.deviceKeys['GHTYAJCE']?.crossVerified, true);
-      expect(user.deviceKeys['GHTYAJCE']?.signed, true);
-      expect(user.getKey('GHTYAJCE')?.crossVerified, true);
-      expect(user.deviceKeys['OTHERDEVICE']?.crossVerified, true);
-      expect(user.selfSigningKey?.crossVerified, true);
+      final user = await client.fetchUserDeviceKeysList(client.userID!);
+      user!.masterKey!.setDirectVerified(true);
+      expect(await user.deviceKeys['GHTYAJCE']?.crossVerified, true);
+      expect(await user.deviceKeys['GHTYAJCE']?.signed, true);
+      expect(await user.getKey('GHTYAJCE')?.crossVerified, true);
+      expect(await user.deviceKeys['OTHERDEVICE']?.crossVerified, true);
+      expect(await user.selfSigningKey?.crossVerified, true);
       expect(
-        user
+        await user
             .getKey('F9ypFzgbISXCzxQhhSnXMkc1vq12Luna3Nw5rqViOJY')
             ?.crossVerified,
         true,
       );
-      expect(user.userSigningKey?.crossVerified, true);
-      expect(user.verified, UserVerifiedStatus.verified);
-      user.masterKey?.setDirectVerified(false);
-      expect(user.deviceKeys['GHTYAJCE']?.crossVerified, false);
-      expect(user.deviceKeys['OTHERDEVICE']?.crossVerified, false);
-      expect(user.verified, UserVerifiedStatus.unknown);
+      expect(await user.userSigningKey?.crossVerified, true);
+      expect(await user.verified, UserVerifiedStatus.verified);
+      await user.masterKey?.setVerified(false);
+      expect(await user.deviceKeys['GHTYAJCE']?.crossVerified, false);
+      expect(await user.deviceKeys['OTHERDEVICE']?.crossVerified, false);
+      expect(await user.verified, UserVerifiedStatus.unknown);
 
       user.deviceKeys['OTHERDEVICE']?.setDirectVerified(true);
-      expect(user.verified, UserVerifiedStatus.verified);
+      expect(await user.verified, UserVerifiedStatus.verified);
       user.deviceKeys['OTHERDEVICE']?.setDirectVerified(false);
 
-      user.masterKey?.setDirectVerified(true);
+      await user.masterKey!.setVerified(true);
       user.deviceKeys['GHTYAJCE']?.signatures?[client.userID]?.removeWhere(
         (k, v) => k != 'ed25519:GHTYAJCE',
       );
       expect(
-        user.deviceKeys['GHTYAJCE']?.verified,
+        await user.deviceKeys['GHTYAJCE']?.verified,
         true,
       ); // it's our own device, should be direct verified
       expect(
-        user.deviceKeys['GHTYAJCE']?.signed,
+        await user.deviceKeys['GHTYAJCE']?.signed,
         false,
       ); // not verified for others
       user.deviceKeys['OTHERDEVICE']?.signatures?.clear();
-      expect(user.verified, UserVerifiedStatus.unknownDevice);
+      expect(await user.verified, UserVerifiedStatus.unknownDevice);
     });
 
     test('start verification', () async {
-      var req = await client
-          .userDeviceKeys['@alice:example.com']
-          ?.deviceKeys['JLAFKJWSCS']
-          ?.startVerification();
+      final aliceKeys = (await client.fetchUserDeviceKeysList(
+        '@alice:example.com',
+      ))!;
+      var req = await aliceKeys.deviceKeys['JLAFKJWSCS']?.startVerification();
       expect(req != null, true);
       expect(req?.room != null, false);
 
@@ -274,8 +270,9 @@ void main() async {
           FakeMatrixApi.calledEndpoints['/client/v3/createRoom']?.length ?? 0;
 
       Future<void> verifyDeviceKeys() async {
-        req = await client.userDeviceKeys['@alice:example.com']
-            ?.startVerification(newDirectChatEnableEncryption: false);
+        req = await aliceKeys.startVerification(
+          newDirectChatEnableEncryption: false,
+        );
         expect(req != null, true);
         expect(req?.room != null, true);
       }

--- a/test/encryption/bootstrap_test.dart
+++ b/test/encryption/bootstrap_test.dart
@@ -63,12 +63,8 @@ void main() {
         );
         final keyObj = vod.PkSigning.fromSecretKey(privateKey);
         final pubKey = keyObj.publicKey.toBase64();
-        expect(
-          pubKey,
-          client.userDeviceKeys[client.userID]
-              ?.getCrossSigningKey(keyType)
-              ?.publicKey,
-        );
+        final keys = await client.fetchUserDeviceKeysList(client.userID!);
+        expect(pubKey, keys?.getCrossSigningKey(keyType)?.publicKey);
       }
 
       await defaultKey.store('foxes', 'floof');
@@ -113,12 +109,8 @@ void main() {
         );
         final keyObj = vod.PkSigning.fromSecretKey(privateKey);
         final pubKey = keyObj.publicKey.toBase64();
-        expect(
-          pubKey,
-          client.userDeviceKeys[client.userID]
-              ?.getCrossSigningKey(keyType)
-              ?.publicKey,
-        );
+        final keys = await client.fetchUserDeviceKeysList(client.userID!);
+        expect(pubKey, keys?.getCrossSigningKey(keyType)?.publicKey);
       }
 
       expect(await defaultKey.getStored('foxes'), 'floof');
@@ -232,12 +224,8 @@ void main() {
           );
           final keyObj = vod.PkSigning.fromSecretKey(privateKey);
           final pubKey = keyObj.publicKey.toBase64();
-          expect(
-            pubKey,
-            client.userDeviceKeys[client.userID]
-                ?.getCrossSigningKey(keyType)
-                ?.publicKey,
-          );
+          final keys = await client.fetchUserDeviceKeysList(client.userID!);
+          expect(pubKey, keys?.getCrossSigningKey(keyType)?.publicKey);
         }
 
         expect(await defaultKey.getStored('foxes'), 'floof');

--- a/test/encryption/cross_signing_test.dart
+++ b/test/encryption/cross_signing_test.dart
@@ -28,11 +28,13 @@ void main() {
     });
 
     test('selfSign', () async {
-      final key = client.userDeviceKeys[client.userID]!.masterKey!;
-      key.setDirectVerified(false);
+      final keys = await client.fetchUserDeviceKeysList(client.userID!);
+      final key = keys!.masterKey!;
+      await key.setVerified(false, false);
       FakeMatrixApi.calledEndpoints.clear();
       await client.encryption!.crossSigning.selfSign(recoveryKey: ssssKey);
-      expect(key.directVerified, true);
+      final updated = await client.fetchUserDeviceKeysList(client.userID!);
+      expect(updated!.masterKey!.directVerified, true);
       expect(
         FakeMatrixApi.calledEndpoints.containsKey(
           '/client/v3/keys/signatures/upload',
@@ -43,40 +45,46 @@ void main() {
     });
 
     test('signable', () async {
+      final keys = await client.fetchUserDeviceKeysLists({
+        client.userID!,
+        '@alice:example.com',
+      });
       expect(
         client.encryption!.crossSigning.signable([
-          client.userDeviceKeys[client.userID!]!.masterKey!,
+          keys[client.userID!]!.masterKey!,
         ]),
         true,
       );
       expect(
         client.encryption!.crossSigning.signable([
-          client.userDeviceKeys[client.userID!]!.deviceKeys[client.deviceID!]!,
+          keys[client.userID!]!.deviceKeys[client.deviceID!]!,
         ]),
         false,
       );
       expect(
         client.encryption!.crossSigning.signable([
-          client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!,
+          keys[client.userID!]!.deviceKeys['OTHERDEVICE']!,
         ]),
         true,
       );
       expect(
         client.encryption!.crossSigning.signable([
-          client
-              .userDeviceKeys['@alice:example.com']!
-              .deviceKeys['JLAFKJWSCS']!,
+          keys['@alice:example.com']!.deviceKeys['JLAFKJWSCS']!,
         ]),
         false,
       );
     });
 
     test('sign', () async {
+      final keys = await client.fetchUserDeviceKeysLists({
+        client.userID!,
+        '@othertest:fakeServer.notExisting',
+      });
       FakeMatrixApi.calledEndpoints.clear();
       await client.encryption!.crossSigning.sign([
-        client.userDeviceKeys[client.userID!]!.masterKey!,
-        client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!,
-        client.userDeviceKeys['@othertest:fakeServer.notExisting']!.masterKey!,
+        keys[client.userID!]!.masterKey!,
+        keys[client.userID!]!.deviceKeys['OTHERDEVICE']!,
+        keys['@othertest:fakeServer.notExisting']!.masterKey!,
       ]);
       final body = json.decode(
         FakeMatrixApi
@@ -89,16 +97,13 @@ void main() {
       );
       expect(
         body['@test:fakeServer.notExisting'].containsKey(
-          client.userDeviceKeys[client.userID]!.masterKey!.publicKey,
+          keys[client.userID!]!.masterKey!.publicKey,
         ),
         true,
       );
       expect(
         body['@othertest:fakeServer.notExisting'].containsKey(
-          client
-              .userDeviceKeys['@othertest:fakeServer.notExisting']
-              ?.masterKey
-              ?.publicKey,
+          keys['@othertest:fakeServer.notExisting']?.masterKey?.publicKey,
         ),
         true,
       );

--- a/test/encryption/crypto_setup_test.dart
+++ b/test/encryption/crypto_setup_test.dart
@@ -95,8 +95,8 @@ void main() {
         final client = await getClient();
         final recoveryKey = await client.initCryptoIdentity();
         final defaultKeyId = client.encryption!.ssss.defaultKeyId;
-        final masterPub =
-            client.userDeviceKeys[client.userID]!.masterKey!.ed25519Key;
+        final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+        final masterPub = ownKeys!.masterKey!.ed25519Key;
 
         Future<String> healInPlace() async {
           final ssss = client.encryption!.ssss;
@@ -123,10 +123,7 @@ void main() {
         expect(state.initialized, true);
         expect(state.connected, true);
         expect(client.encryption!.ssss.defaultKeyId, defaultKeyId);
-        expect(
-          client.userDeviceKeys[client.userID]!.masterKey!.ed25519Key,
-          masterPub,
-        );
+        expect(ownKeys.masterKey!.ed25519Key, masterPub);
 
         // Preserve master: only self/user signing secrets missing.
         for (final type in [
@@ -146,10 +143,7 @@ void main() {
         expect(state.initialized, true);
         expect(state.connected, true);
         expect(client.encryption!.ssss.defaultKeyId, defaultKeyId);
-        expect(
-          client.userDeviceKeys[client.userID]!.masterKey!.ed25519Key,
-          masterPub,
-        );
+        expect(ownKeys.masterKey!.ed25519Key, masterPub);
 
         await client.encryption!.ssss.clearCache();
         var open = client.encryption!.ssss.open();

--- a/test/encryption/encrypt_decrypt_to_device_test.dart
+++ b/test/encryption/encrypt_decrypt_to_device_test.dart
@@ -47,18 +47,24 @@ void main() async {
       await otherClient.abortSync();
 
       await Future.delayed(Duration(milliseconds: 10));
-      device = DeviceKeys.fromJson({
-        'user_id': client.userID,
-        'device_id': client.deviceID,
-        'algorithms': [
-          AlgorithmTypes.olmV1Curve25519AesSha2,
-          AlgorithmTypes.megolmV1AesSha2,
-        ],
-        'keys': {
-          'curve25519:${client.deviceID}': client.identityKey,
-          'ed25519:${client.deviceID}': client.fingerprintKey,
+      final deviceList = DeviceKeysList(client.userID!, client);
+      device = DeviceKeys.fromJson(
+        {
+          'user_id': client.userID,
+          'device_id': client.deviceID,
+          'algorithms': [
+            AlgorithmTypes.olmV1Curve25519AesSha2,
+            AlgorithmTypes.megolmV1AesSha2,
+          ],
+          'keys': {
+            'curve25519:${client.deviceID}': client.identityKey,
+            'ed25519:${client.deviceID}': client.fingerprintKey,
+          },
         },
-      }, client);
+        deviceList,
+        deviceList,
+        client,
+      );
     });
 
     test('encryptToDeviceMessage', () async {

--- a/test/encryption/key_manager_test.dart
+++ b/test/encryption/key_manager_test.dart
@@ -126,11 +126,10 @@ void main() {
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
         roomId,
       );
-      client
-              .userDeviceKeys['@alice:example.com']!
-              .deviceKeys['JLAFKJWSCS']!
-              .blocked =
-          true;
+      await client
+          .userDeviceKeys['@alice:example.com']!
+          .deviceKeys['JLAFKJWSCS']!
+          .setBlocked(true);
       await client.encryption!.keyManager.clearOrUseOutboundGroupSession(
         roomId,
       );
@@ -138,22 +137,20 @@ void main() {
         client.encryption!.keyManager.getOutboundGroupSession(roomId) != null,
         false,
       );
-      client
-              .userDeviceKeys['@alice:example.com']!
-              .deviceKeys['JLAFKJWSCS']!
-              .blocked =
-          false;
+      await client
+          .userDeviceKeys['@alice:example.com']!
+          .deviceKeys['JLAFKJWSCS']!
+          .setBlocked(false);
 
       // lazy-create if it would rotate
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
         roomId,
       );
       final oldSessKey = sess.outboundGroupSession!.sessionKey;
-      client
-              .userDeviceKeys['@alice:example.com']!
-              .deviceKeys['JLAFKJWSCS']!
-              .blocked =
-          true;
+      await client
+          .userDeviceKeys['@alice:example.com']!
+          .deviceKeys['JLAFKJWSCS']!
+          .setBlocked(true);
       await client.encryption!.keyManager.prepareOutboundGroupSession(roomId);
       expect(
         client.encryption!.keyManager.getOutboundGroupSession(roomId) != null,
@@ -167,11 +164,10 @@ void main() {
             oldSessKey,
         true,
       );
-      client
-              .userDeviceKeys['@alice:example.com']!
-              .deviceKeys['JLAFKJWSCS']!
-              .blocked =
-          false;
+      await client
+          .userDeviceKeys['@alice:example.com']!
+          .deviceKeys['JLAFKJWSCS']!
+          .setBlocked(false);
 
       // rotate if too far in the past
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
@@ -232,6 +228,17 @@ void main() {
           },
         },
       }, client);
+      await client.database.storeUserDeviceKey(
+        '@alice:example.com',
+        'NEWDEVICE',
+        jsonEncode(
+          client.userDeviceKeys['@alice:example.com']!.deviceKeys['NEWDEVICE']!
+              .toJson(),
+        ),
+        false,
+        false,
+        DateTime.now().millisecondsSinceEpoch,
+      );
       await client.encryption!.keyManager.clearOrUseOutboundGroupSession(
         roomId,
       );

--- a/test/encryption/key_manager_test.dart
+++ b/test/encryption/key_manager_test.dart
@@ -126,10 +126,10 @@ void main() {
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
         roomId,
       );
-      await client
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['JLAFKJWSCS']!
-          .setBlocked(true);
+      final aliceKeys = (await client.fetchUserDeviceKeysList(
+        '@alice:example.com',
+      ))!;
+      await aliceKeys.deviceKeys['JLAFKJWSCS']!.setBlocked(true);
       await client.encryption!.keyManager.clearOrUseOutboundGroupSession(
         roomId,
       );
@@ -137,20 +137,14 @@ void main() {
         client.encryption!.keyManager.getOutboundGroupSession(roomId) != null,
         false,
       );
-      await client
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['JLAFKJWSCS']!
-          .setBlocked(false);
+      await aliceKeys.deviceKeys['JLAFKJWSCS']!.setBlocked(false);
 
       // lazy-create if it would rotate
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
         roomId,
       );
       final oldSessKey = sess.outboundGroupSession!.sessionKey;
-      await client
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['JLAFKJWSCS']!
-          .setBlocked(true);
+      await aliceKeys.deviceKeys['JLAFKJWSCS']!.setBlocked(true);
       await client.encryption!.keyManager.prepareOutboundGroupSession(roomId);
       expect(
         client.encryption!.keyManager.getOutboundGroupSession(roomId) != null,
@@ -164,10 +158,7 @@ void main() {
             oldSessKey,
         true,
       );
-      await client
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['JLAFKJWSCS']!
-          .setBlocked(false);
+      await aliceKeys.deviceKeys['JLAFKJWSCS']!.setBlocked(false);
 
       // rotate if too far in the past
       sess = await client.encryption!.keyManager.createOutboundGroupSession(
@@ -208,9 +199,7 @@ void main() {
       sess.outboundGroupSession!.encrypt(
         'foxies',
       ); // so that the new device will have a different index
-      client
-          .userDeviceKeys['@alice:example.com']
-          ?.deviceKeys['NEWDEVICE'] = DeviceKeys.fromJson({
+      final newDevice = DeviceKeys.fromJson({
         'user_id': '@alice:example.com',
         'device_id': 'NEWDEVICE',
         'algorithms': [
@@ -231,10 +220,7 @@ void main() {
       await client.database.storeUserDeviceKey(
         '@alice:example.com',
         'NEWDEVICE',
-        jsonEncode(
-          client.userDeviceKeys['@alice:example.com']!.deviceKeys['NEWDEVICE']!
-              .toJson(),
-        ),
+        jsonEncode(newDevice.toJson()),
         false,
         false,
         DateTime.now().millisecondsSinceEpoch,
@@ -612,14 +598,14 @@ void main() {
       Logs().level = Level.warning;
 
       // Ensure the device came from sync
-      expect(
-        client.userDeviceKeys['@alice:example.com']?.deviceKeys['JLAFKJWSCS'] !=
-            null,
-        true,
+      var aliceKeys = await client.fetchUserDeviceKeysList(
+        '@alice:example.com',
       );
+      expect(aliceKeys?.deviceKeys['JLAFKJWSCS'] != null, true);
 
       // Alice removes her device
-      client.userDeviceKeys['@alice:example.com']?.deviceKeys.remove(
+      await client.database.removeUserDeviceKey(
+        '@alice:example.com',
         'JLAFKJWSCS',
       );
 
@@ -648,11 +634,10 @@ void main() {
         };
         return oldResp;
       };
-      client.userDeviceKeys['@alice:example.com']!.outdated = true;
-      expect(
-        client.userDeviceKeys['@alice:example.com']?.deviceKeys['JLAFKJWSCS'],
-        null,
-      );
+      await client.database.storeUserDeviceKeysInfo('@alice:example.com', true);
+      aliceKeys = await client.fetchUserDeviceKeysList('@alice:example.com');
+      // Attack should be rejected: reused device ID with different keys is not stored
+      expect(aliceKeys?.deviceKeys['JLAFKJWSCS'], null);
     });
 
     test('dispose client', () async {

--- a/test/encryption/key_manager_test.dart
+++ b/test/encryption/key_manager_test.dart
@@ -199,24 +199,31 @@ void main() {
       sess.outboundGroupSession!.encrypt(
         'foxies',
       ); // so that the new device will have a different index
-      final newDevice = DeviceKeys.fromJson({
-        'user_id': '@alice:example.com',
-        'device_id': 'NEWDEVICE',
-        'algorithms': [
-          AlgorithmTypes.olmV1Curve25519AesSha2,
-          AlgorithmTypes.megolmV1AesSha2,
-        ],
-        'keys': {
-          'curve25519:NEWDEVICE': 'bnKQp6pPW0l9cGoIgHpBoK5OUi4h0gylJ7upc4asFV8',
-          'ed25519:NEWDEVICE': 'ZZhPdvWYg3MRpGy2MwtI+4MHXe74wPkBli5hiEOUi8Y',
-        },
-        'signatures': {
-          '@alice:example.com': {
-            'ed25519:NEWDEVICE':
-                '94GSg8N9vNB8wyWHJtKaaX3MGNWPVOjBatJM+TijY6B1RlDFJT5Cl1h/tjr17AoQz0CDdOf6uFhrYsBkH1/ABg',
+      final aliceList = DeviceKeysList('@alice:example.com', client);
+      final newDevice = DeviceKeys.fromJson(
+        {
+          'user_id': '@alice:example.com',
+          'device_id': 'NEWDEVICE',
+          'algorithms': [
+            AlgorithmTypes.olmV1Curve25519AesSha2,
+            AlgorithmTypes.megolmV1AesSha2,
+          ],
+          'keys': {
+            'curve25519:NEWDEVICE':
+                'bnKQp6pPW0l9cGoIgHpBoK5OUi4h0gylJ7upc4asFV8',
+            'ed25519:NEWDEVICE': 'ZZhPdvWYg3MRpGy2MwtI+4MHXe74wPkBli5hiEOUi8Y',
+          },
+          'signatures': {
+            '@alice:example.com': {
+              'ed25519:NEWDEVICE':
+                  '94GSg8N9vNB8wyWHJtKaaX3MGNWPVOjBatJM+TijY6B1RlDFJT5Cl1h/tjr17AoQz0CDdOf6uFhrYsBkH1/ABg',
+            },
           },
         },
-      }, client);
+        aliceList,
+        aliceList,
+        client,
+      );
       await client.database.storeUserDeviceKey(
         '@alice:example.com',
         'NEWDEVICE',

--- a/test/encryption/key_manager_test.dart
+++ b/test/encryption/key_manager_test.dart
@@ -649,7 +649,6 @@ void main() {
         return oldResp;
       };
       client.userDeviceKeys['@alice:example.com']!.outdated = true;
-      await client.updateUserDeviceKeys();
       expect(
         client.userDeviceKeys['@alice:example.com']?.deviceKeys['JLAFKJWSCS'],
         null,

--- a/test/encryption/key_request_test.dart
+++ b/test/encryption/key_request_test.dart
@@ -69,13 +69,13 @@ void main() {
 
       matrix.setUserId('@alice:example.com'); // we need to pretend to be alice
       FakeMatrixApi.calledEndpoints.clear();
-      await matrix
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['OTHERDEVICE']!
+      final aliceKeys = await matrix.fetchUserDeviceKeysLists({
+        '@alice:example.com',
+        '@test:fakeServer.notExisting',
+      });
+      await aliceKeys['@alice:example.com']!.deviceKeys['OTHERDEVICE']!
           .setBlocked(false);
-      await matrix
-          .userDeviceKeys['@alice:example.com']!
-          .deviceKeys['OTHERDEVICE']!
+      await aliceKeys['@alice:example.com']!.deviceKeys['OTHERDEVICE']!
           .setVerified(true);
       final session = await matrix.encryption!.keyManager
           .loadInboundGroupSession('!726s6s6q:example.com', validSessionId);
@@ -107,8 +107,7 @@ void main() {
       // test a successful foreign share
       FakeMatrixApi.calledEndpoints.clear();
       session!.allowedAtIndex['@test:fakeServer.notExisting'] = <String, int>{
-        matrix
-                .userDeviceKeys['@test:fakeServer.notExisting']!
+        aliceKeys['@test:fakeServer.notExisting']!
                 .deviceKeys['OTHERDEVICE']!
                 .curve25519Key!:
             0,

--- a/test/encryption/key_verification_test.dart
+++ b/test/encryption/key_verification_test.dart
@@ -94,11 +94,12 @@ void main() async {
       // because then we can easily intercept the payloads and inject in the other client
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       await FakeMatrixApi.firstWhere(
         (e) => e.startsWith(
           '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -241,17 +242,15 @@ void main() async {
       expect(req1.state, KeyVerificationState.done);
       expect(req2.state, KeyVerificationState.done);
       expect(
-        client1
-            .userDeviceKeys[client2.userID]
-            ?.deviceKeys[client2.deviceID]
-            ?.directVerified,
+        (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.deviceKeys[client2.deviceID]?.directVerified,
         true,
       );
       expect(
-        client2
-            .userDeviceKeys[client1.userID]
-            ?.deviceKeys[client1.deviceID]
-            ?.directVerified,
+        (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.deviceKeys[client1.deviceID]?.directVerified,
         true,
       );
       await client1.encryption!.keyVerificationManager.cleanup();
@@ -259,12 +258,13 @@ void main() async {
     });
 
     test('ask SSSS start', () async {
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(true, false);
       await client1.encryption!.ssss.clearCache();
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       expect(req1.state, KeyVerificationState.askSSSS);
       await req1.openSSSS(recoveryKey: ssssKey);
       await FakeMatrixApi.firstWhere(
@@ -281,15 +281,16 @@ void main() async {
     test('ask SSSS end', () async {
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
       // the other one has to have their master key verified to trigger asking for ssss
-      client2.userDeviceKeys[client2.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      await (await client2.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.masterKey!.setVerified(true, false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       await FakeMatrixApi.firstWhere(
         (e) => e.startsWith(
           '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -382,9 +383,9 @@ void main() async {
       }
 
       // alright, they match
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(true, false);
       await client1.encryption!.ssss.clearCache();
 
       // send mac
@@ -431,11 +432,12 @@ void main() async {
     test('reject verification', () async {
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       await FakeMatrixApi.firstWhere(
         (e) => e.startsWith(
           '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -469,11 +471,12 @@ void main() async {
     test('reject sas', () async {
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       await FakeMatrixApi.firstWhere(
         (e) => e.startsWith(
           '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -574,11 +577,12 @@ void main() async {
     test('other device accepted', () async {
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
       await FakeMatrixApi.firstWhere(
         (e) => e.startsWith(
           '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -623,27 +627,32 @@ void main() async {
 
     test('Run qr verification mode 0, ssss start', () async {
       expect(
-        client1.userDeviceKeys[client2.userID]?.masterKey!.directVerified,
+        (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.directVerified,
         false,
       );
       expect(
-        client2.userDeviceKeys[client1.userID]?.masterKey!.directVerified,
+        (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.directVerified,
         false,
       );
       // for a full run we test in-room verification in a cleartext room
       // because then we can easily intercept the payloads and inject in the other client
       FakeMatrixApi.calledEndpoints.clear();
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
-      client2.userDeviceKeys[client2.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(true, false);
+      await (await client2.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.masterKey!.setVerified(true, false);
       await client1.encryption!.ssss.clearCache();
 
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
 
       expect(req1.state, KeyVerificationState.askSSSS);
       await req1.openSSSS(recoveryKey: ssssKey);
@@ -727,11 +736,15 @@ void main() async {
       expect(req2.state, KeyVerificationState.done);
 
       expect(
-        client1.userDeviceKeys[client2.userID]?.masterKey!.directVerified,
+        (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.directVerified,
         true,
       );
       expect(
-        client2.userDeviceKeys[client1.userID]?.masterKey!.directVerified,
+        (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.directVerified,
         true,
       );
 
@@ -746,12 +759,12 @@ void main() async {
         // because then we can easily intercept the payloads and inject in the other client
         FakeMatrixApi.calledEndpoints.clear();
         // make sure our master key is *not* verified to not triger SSSS for now
-        client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-          false,
-        );
-
-        final req1 = await client1.userDeviceKeys[client2.userID]!
-            .startVerification(newDirectChatEnableEncryption: false);
+        await (await client1.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))!.masterKey!.setVerified(false, false);
+        final req1 = await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.startVerification(newDirectChatEnableEncryption: false);
         await FakeMatrixApi.firstWhere(
           (e) => e.startsWith(
             '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -813,12 +826,12 @@ void main() async {
         // because then we can easily intercept the payloads and inject in the other client
         FakeMatrixApi.calledEndpoints.clear();
         // make sure our master key is *not* verified to not triger SSSS for now
-        client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-          false,
-        );
-
-        final req1 = await client1.userDeviceKeys[client2.userID]!
-            .startVerification(newDirectChatEnableEncryption: false);
+        await (await client1.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))!.masterKey!.setVerified(false, false);
+        final req1 = await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.startVerification(newDirectChatEnableEncryption: false);
         await FakeMatrixApi.firstWhere(
           (e) => e.startsWith(
             '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',
@@ -887,12 +900,12 @@ void main() async {
         // because then we can easily intercept the payloads and inject in the other client
         FakeMatrixApi.calledEndpoints.clear();
         // make sure our master key is *not* verified to not triger SSSS for now
-        client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-          false,
-        );
-
-        final req1 = await client1.userDeviceKeys[client2.userID]!
-            .startVerification(newDirectChatEnableEncryption: false);
+        await (await client1.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))!.masterKey!.setVerified(false, false);
+        final req1 = await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.startVerification(newDirectChatEnableEncryption: false);
         await FakeMatrixApi.firstWhere(
           (e) => e.startsWith(
             '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/m.room.message',

--- a/test/encryption/key_verification_test.dart
+++ b/test/encryption/key_verification_test.dart
@@ -82,10 +82,6 @@ void main() async {
       // cancel sync to reduce background load and prevent sync overwriting which keys are tracked.
       await client1.abortSync();
       await client2.abortSync();
-
-      // get client2 device keys to start verification
-      await client1.updateUserDeviceKeys(additionalUsers: {client2.userID!});
-      await client2.updateUserDeviceKeys(additionalUsers: {client1.userID!});
     });
 
     tearDown(() async {

--- a/test/encryption/olm_manager_test.dart
+++ b/test/encryption/olm_manager_test.dart
@@ -141,8 +141,9 @@ void main() {
     test('startOutgoingOlmSessions', () async {
       // start an olm session.....with ourself!
       client.encryption!.olmManager.olmSessions.clear();
+      final keys = await client.fetchUserDeviceKeysList(client.userID!);
       await client.encryption!.olmManager.startOutgoingOlmSessions([
-        client.userDeviceKeys[client.userID!]!.deviceKeys[client.deviceID]!,
+        keys!.deviceKeys[client.deviceID]!,
       ]);
       expect(
         client.encryption!.olmManager.olmSessions.containsKey(

--- a/test/encryption/qr_verification_self_test.dart
+++ b/test/encryption/qr_verification_self_test.dart
@@ -18,26 +18,22 @@ void main() async {
     KeyVerification req1,
     KeyVerification req2,
   ) async {
-    final copyKnownVerificationMethods = List.from(
-      req2.knownVerificationMethods,
+    final copyKnownVerificationMethods = List<String>.from(
+      await req2.knownVerificationMethods,
     );
 
     // this is the same logic from `acceptVerification()` just couldn't find a
     // easy to to mock it
     // qr code only works when atleast one side has verified master key
     if (req2.userId == req2.client.userID) {
-      if (!(req2
-                  .client
-                  .userDeviceKeys[req2.client.userID]
-                  ?.deviceKeys[req2.deviceId]
-                  ?.hasValidSignatureChain(verifiedByTheirMasterKey: true) ??
+      final ownKeys = await req2.client.fetchUserDeviceKeysList(
+        req2.client.userID!,
+      );
+      if (!(await ownKeys?.deviceKeys[req2.deviceId]?.hasValidSignatureChain(
+                verifiedByTheirMasterKey: true,
+              ) ??
               false) &&
-          !(req2
-                  .client
-                  .userDeviceKeys[req2.client.userID]
-                  ?.masterKey
-                  ?.verified ??
-              false)) {
+          !(await ownKeys?.masterKey?.verified ?? false)) {
         copyKnownVerificationMethods.removeWhere(
           (element) => element.startsWith('m.qr_code'),
         );
@@ -95,38 +91,40 @@ void main() async {
 
     test('Run qr verification mode 1', () async {
       expect(
-        client1.userDeviceKeys[client2.userID]?.masterKey!.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.verified,
         false,
       );
       expect(
-        client2.userDeviceKeys[client1.userID]?.masterKey!.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.verified,
         false,
       );
       expect(
-        client1
-            .userDeviceKeys[client2.userID]
-            ?.deviceKeys[client2.deviceID]
-            ?.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.deviceKeys[client2.deviceID]?.verified,
         false,
       );
       expect(
-        client2
-            .userDeviceKeys[client1.userID]
-            ?.deviceKeys[client1.deviceID]
-            ?.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.deviceKeys[client1.deviceID]?.verified,
         false,
       );
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
-      client2.userDeviceKeys[client2.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(true, false);
+      await (await client2.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.masterKey!.setVerified(false, false);
       await client1.encryption!.ssss.clearCache();
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
 
       expect(req1.state, KeyVerificationState.askSSSS);
       await req1.openSSSS(recoveryKey: ssssKey);
@@ -141,7 +139,7 @@ void main() async {
           sender: req1.client.userID!,
           content: {
             'from_device': req1.client.deviceID,
-            'methods': req1.knownVerificationMethods,
+            'methods': await req1.knownVerificationMethods,
             'timestamp': DateTime.now().millisecondsSinceEpoch,
             'transaction_id': req1.transactionId,
           },
@@ -176,8 +174,8 @@ void main() async {
 
       expect(req1.state, KeyVerificationState.askChoice);
 
-      expect(req1.getOurQRMode(), QRMode.verifySelfTrusted);
-      expect(req2.getOurQRMode(), QRMode.verifySelfUntrusted);
+      expect(await req1.getOurQRMode(), QRMode.verifySelfTrusted);
+      expect(await req2.getOurQRMode(), QRMode.verifySelfUntrusted);
 
       // send start
       await req1.continueVerification(
@@ -220,21 +218,29 @@ void main() async {
       expect(req1.state, KeyVerificationState.done);
       expect(req2.state, KeyVerificationState.done);
 
-      expect(client1.userDeviceKeys[client2.userID]?.masterKey!.verified, true);
-      expect(client2.userDeviceKeys[client1.userID]?.masterKey!.verified, true);
-
       expect(
-        client1
-            .userDeviceKeys[client2.userID]
-            ?.deviceKeys[client2.deviceID]
-            ?.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.verified,
         true,
       );
       expect(
-        client2
-            .userDeviceKeys[client1.userID]
-            ?.deviceKeys[client1.deviceID]
-            ?.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.verified,
+        true,
+      );
+
+      expect(
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.deviceKeys[client2.deviceID]?.verified,
+        true,
+      );
+      expect(
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.deviceKeys[client1.deviceID]?.verified,
         true,
       );
 
@@ -246,37 +252,40 @@ void main() async {
 
     test('Run qr verification mode 2', () async {
       expect(
-        client1.userDeviceKeys[client2.userID]?.masterKey!.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.verified,
         false,
       );
       expect(
-        client2.userDeviceKeys[client1.userID]?.masterKey!.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.verified,
         false,
       );
       expect(
-        client1
-            .userDeviceKeys[client2.userID]
-            ?.deviceKeys[client2.deviceID]
-            ?.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.deviceKeys[client2.deviceID]?.verified,
         false,
       );
       expect(
-        client2
-            .userDeviceKeys[client1.userID]
-            ?.deviceKeys[client1.deviceID]
-            ?.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.deviceKeys[client1.deviceID]?.verified,
         false,
       );
       // make sure our master key is *not* verified to not triger SSSS for now
-      client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-        false,
-      );
-      client2.userDeviceKeys[client2.userID]!.masterKey!.setDirectVerified(
-        true,
-      );
+      await (await client1.fetchUserDeviceKeysList(
+        client1.userID!,
+      ))!.masterKey!.setVerified(false, false);
+      await (await client2.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.masterKey!.setVerified(true, false);
       // await client1.encryption!.ssss.clearCache();
-      final req1 = await client1.userDeviceKeys[client2.userID]!
-          .startVerification(newDirectChatEnableEncryption: false);
+      final req1 = await (await client1.fetchUserDeviceKeysList(
+        client2.userID!,
+      ))!.startVerification(newDirectChatEnableEncryption: false);
 
       expect(req1.state, KeyVerificationState.waitingAccept);
 
@@ -288,7 +297,7 @@ void main() async {
           sender: req1.client.userID!,
           content: {
             'from_device': req1.client.deviceID,
-            'methods': req1.knownVerificationMethods,
+            'methods': await req1.knownVerificationMethods,
             'timestamp': DateTime.now().millisecondsSinceEpoch,
             'transaction_id': req1.transactionId,
           },
@@ -324,8 +333,8 @@ void main() async {
 
       expect(req1.state, KeyVerificationState.askChoice);
 
-      expect(req1.getOurQRMode(), QRMode.verifySelfUntrusted);
-      expect(req2.getOurQRMode(), QRMode.verifySelfTrusted);
+      expect(await req1.getOurQRMode(), QRMode.verifySelfUntrusted);
+      expect(await req2.getOurQRMode(), QRMode.verifySelfTrusted);
 
       // send start
       await req1.continueVerification(
@@ -370,21 +379,29 @@ void main() async {
       await req2.openSSSS(recoveryKey: ssssKey);
       expect(req2.state, KeyVerificationState.done);
 
-      expect(client1.userDeviceKeys[client2.userID]?.masterKey!.verified, true);
-      expect(client2.userDeviceKeys[client1.userID]?.masterKey!.verified, true);
-
       expect(
-        client1
-            .userDeviceKeys[client2.userID]
-            ?.deviceKeys[client2.deviceID]
-            ?.verified,
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.masterKey!.verified,
         true,
       );
       expect(
-        client2
-            .userDeviceKeys[client1.userID]
-            ?.deviceKeys[client1.deviceID]
-            ?.verified,
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.masterKey!.verified,
+        true,
+      );
+
+      expect(
+        await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))?.deviceKeys[client2.deviceID]?.verified,
+        true,
+      );
+      expect(
+        await (await client2.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))?.deviceKeys[client1.deviceID]?.verified,
         true,
       );
 
@@ -396,16 +413,16 @@ void main() async {
       'Run qr verification mode 1, but fail because incorrect secret',
       () async {
         // make sure our master key is *not* verified to not triger SSSS for now
-        client1.userDeviceKeys[client1.userID]!.masterKey!.setDirectVerified(
-          true,
-        );
-        client2.userDeviceKeys[client2.userID]!.masterKey!.setDirectVerified(
-          false,
-        );
-
+        await (await client1.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))!.masterKey!.setVerified(true, false);
+        await (await client2.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.masterKey!.setVerified(false, false);
         await client1.encryption!.ssss.clearCache();
-        final req1 = await client1.userDeviceKeys[client2.userID]!
-            .startVerification(newDirectChatEnableEncryption: false);
+        final req1 = await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.startVerification(newDirectChatEnableEncryption: false);
 
         expect(req1.state, KeyVerificationState.askSSSS);
         await req1.openSSSS(recoveryKey: ssssKey);
@@ -422,7 +439,7 @@ void main() async {
             sender: req1.client.userID!,
             content: {
               'from_device': req1.client.deviceID,
-              'methods': req1.knownVerificationMethods,
+              'methods': await req1.knownVerificationMethods,
               'timestamp': DateTime.now().millisecondsSinceEpoch,
               'transaction_id': req1.transactionId,
             },
@@ -459,8 +476,8 @@ void main() async {
 
         expect(req1.state, KeyVerificationState.askChoice);
 
-        expect(req1.getOurQRMode(), QRMode.verifySelfTrusted);
-        expect(req2.getOurQRMode(), QRMode.verifySelfUntrusted);
+        expect(await req1.getOurQRMode(), QRMode.verifySelfTrusted);
+        expect(await req2.getOurQRMode(), QRMode.verifySelfUntrusted);
 
         // send start
         await req1.continueVerification(
@@ -503,15 +520,16 @@ void main() async {
       'Run qr verification mode 2, but both unverified master key',
       () async {
         // make sure our master key is *not* verified to not triger SSSS for now
-        await client1.userDeviceKeys[client1.userID]!.masterKey!.setBlocked(
-          true,
-        );
-        await client2.userDeviceKeys[client2.userID]!.masterKey!.setBlocked(
-          true,
-        );
+        await (await client1.fetchUserDeviceKeysList(
+          client1.userID!,
+        ))!.masterKey!.setBlocked(true);
+        await (await client2.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.masterKey!.setBlocked(true);
         // await client1.encryption!.ssss.clearCache();
-        final req1 = await client1.userDeviceKeys[client2.userID]!
-            .startVerification(newDirectChatEnableEncryption: false);
+        final req1 = await (await client1.fetchUserDeviceKeysList(
+          client2.userID!,
+        ))!.startVerification(newDirectChatEnableEncryption: false);
 
         expect(req1.state, KeyVerificationState.waitingAccept);
 
@@ -525,7 +543,7 @@ void main() async {
             sender: req1.client.userID!,
             content: {
               'from_device': req1.client.deviceID,
-              'methods': req1.knownVerificationMethods,
+              'methods': await req1.knownVerificationMethods,
               'timestamp': DateTime.now().millisecondsSinceEpoch,
               'transaction_id': req1.transactionId,
             },
@@ -552,8 +570,8 @@ void main() async {
 
         expect(req1.state, KeyVerificationState.waitingAccept);
 
-        expect(req1.getOurQRMode(), QRMode.verifySelfUntrusted);
-        expect(req2.getOurQRMode(), QRMode.verifySelfUntrusted);
+        expect(await req1.getOurQRMode(), QRMode.verifySelfUntrusted);
+        expect(await req2.getOurQRMode(), QRMode.verifySelfUntrusted);
 
         // send start
         await req1.continueVerification(

--- a/test/encryption/qr_verification_self_test.dart
+++ b/test/encryption/qr_verification_self_test.dart
@@ -29,11 +29,11 @@ void main() async {
       final ownKeys = await req2.client.fetchUserDeviceKeysList(
         req2.client.userID!,
       );
-      if (!(await ownKeys?.deviceKeys[req2.deviceId]?.hasValidSignatureChain(
+      if (!(ownKeys?.deviceKeys[req2.deviceId]?.hasValidSignatureChain(
                 verifiedByTheirMasterKey: true,
               ) ??
               false) &&
-          !(await ownKeys?.masterKey?.verified ?? false)) {
+          !(ownKeys?.masterKey?.verified ?? false)) {
         copyKnownVerificationMethods.removeWhere(
           (element) => element.startsWith('m.qr_code'),
         );
@@ -69,6 +69,9 @@ void main() async {
       await vodInit;
       client1 = await getClient();
       client2 = await getOtherClient();
+      // Avoid background key refreshes racing with setVerified/setBlocked.
+      await client1.abortSync();
+      await client2.abortSync();
 
       await Future.delayed(Duration(milliseconds: 10));
       client1.verificationMethods = {
@@ -91,25 +94,25 @@ void main() async {
 
     test('Run qr verification mode 1', () async {
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.masterKey!.verified,
         false,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.masterKey!.verified,
         false,
       );
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.deviceKeys[client2.deviceID]?.verified,
         false,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.deviceKeys[client1.deviceID]?.verified,
         false,
@@ -219,26 +222,26 @@ void main() async {
       expect(req2.state, KeyVerificationState.done);
 
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.masterKey!.verified,
         true,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.masterKey!.verified,
         true,
       );
 
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.deviceKeys[client2.deviceID]?.verified,
         true,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.deviceKeys[client1.deviceID]?.verified,
         true,
@@ -252,25 +255,25 @@ void main() async {
 
     test('Run qr verification mode 2', () async {
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.masterKey!.verified,
         false,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.masterKey!.verified,
         false,
       );
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.deviceKeys[client2.deviceID]?.verified,
         false,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.deviceKeys[client1.deviceID]?.verified,
         false,
@@ -380,26 +383,26 @@ void main() async {
       expect(req2.state, KeyVerificationState.done);
 
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.masterKey!.verified,
         true,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.masterKey!.verified,
         true,
       );
 
       expect(
-        await (await client1.fetchUserDeviceKeysList(
+        (await client1.fetchUserDeviceKeysList(
           client2.userID!,
         ))?.deviceKeys[client2.deviceID]?.verified,
         true,
       );
       expect(
-        await (await client2.fetchUserDeviceKeysList(
+        (await client2.fetchUserDeviceKeysList(
           client1.userID!,
         ))?.deviceKeys[client1.deviceID]?.verified,
         true,
@@ -526,6 +529,19 @@ void main() async {
         await (await client2.fetchUserDeviceKeysList(
           client2.userID!,
         ))!.masterKey!.setBlocked(true);
+        // Re-fetch so later checks use snapshots that include the block.
+        expect(
+          (await client1.fetchUserDeviceKeysList(
+            client1.userID!,
+          ))!.masterKey!.blocked,
+          true,
+        );
+        expect(
+          (await client2.fetchUserDeviceKeysList(
+            client2.userID!,
+          ))!.masterKey!.blocked,
+          true,
+        );
         // await client1.encryption!.ssss.clearCache();
         final req1 = await (await client1.fetchUserDeviceKeysList(
           client2.userID!,

--- a/test/encryption/ssss_test.dart
+++ b/test/encryption/ssss_test.dart
@@ -161,9 +161,8 @@ void main() {
 
     test('postUnlock', () async {
       await client.encryption!.ssss.clearCache();
-      client.userDeviceKeys[client.userID!]!.masterKey!.setDirectVerified(
-        false,
-      );
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      await ownKeys!.masterKey!.setVerified(false, false);
       final handle = client.encryption!.ssss.open(
         EventTypes.CrossSigningSelfSigning,
       );
@@ -187,15 +186,13 @@ void main() {
             null,
         true,
       );
-      expect(
-        client.userDeviceKeys[client.userID!]!.masterKey!.directVerified,
-        true,
-      );
+      final updated = await client.fetchUserDeviceKeysList(client.userID!);
+      expect(updated!.masterKey!.directVerified, true);
     });
 
     test('make share requests', () async {
-      final key =
-          client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!;
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      final key = ownKeys!.deviceKeys['OTHERDEVICE']!;
       key.setDirectVerified(true);
       FakeMatrixApi.calledEndpoints.clear();
       await client.encryption!.ssss.request('some.type', [key]);
@@ -290,12 +287,10 @@ void main() {
       );
 
       // device not verified
-      final key =
-          client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!;
-      key.setDirectVerified(false);
-      client.userDeviceKeys[client.userID!]!.masterKey!.setDirectVerified(
-        false,
-      );
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      final key = ownKeys!.deviceKeys['OTHERDEVICE']!;
+      await key.setVerified(false, false);
+      await ownKeys.masterKey!.setVerified(false, false);
       event = ToDeviceEvent(
         sender: client.userID!,
         type: 'm.secret.request',
@@ -314,12 +309,12 @@ void main() {
         ),
         false,
       );
-      key.setDirectVerified(true);
+      await key.setVerified(true, false);
     });
 
     test('receive share requests', () async {
-      final key =
-          client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!;
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      final key = ownKeys!.deviceKeys['OTHERDEVICE']!;
       key.setDirectVerified(true);
       final handle = client.encryption!.ssss.open(
         EventTypes.CrossSigningSelfSigning,
@@ -448,8 +443,8 @@ void main() {
     });
 
     test('request all', () async {
-      final key =
-          client.userDeviceKeys[client.userID!]!.deviceKeys['OTHERDEVICE']!;
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      final key = ownKeys!.deviceKeys['OTHERDEVICE']!;
       key.setDirectVerified(true);
       await client.encryption!.ssss.clearCache();
       client.encryption!.ssss.pendingShareRequests.clear();
@@ -458,7 +453,8 @@ void main() {
     });
 
     test('periodicallyRequestMissingCache', () async {
-      client.userDeviceKeys[client.userID!]!.masterKey!.setDirectVerified(true);
+      final ownKeys = await client.fetchUserDeviceKeysList(client.userID!);
+      ownKeys!.masterKey!.setDirectVerified(true);
       client.encryption!.ssss = MockSSSS(client.encryption!);
       (client.encryption!.ssss as MockSSSS).requestedSecrets = false;
       await client.encryption!.ssss.periodicallyRequestMissingCache();

--- a/test/new_room_first_message_repro_test.dart
+++ b/test/new_room_first_message_repro_test.dart
@@ -109,7 +109,6 @@ void main() {
       await client.database.transaction(() async {
         await client.handleSync(update, direction: Direction.f);
       });
-      await client.updateUserDeviceKeys();
     }
 
     /// Registers keys/query + keys/claim handlers which behave like a real

--- a/test/new_room_first_message_repro_test.dart
+++ b/test/new_room_first_message_repro_test.dart
@@ -336,7 +336,10 @@ void main() {
 
         // Was dave's device list ever fetched?
         final daveKnown =
-            client.userDeviceKeys[dave.userId]?.deviceKeys.isNotEmpty ?? false;
+            (await client.fetchUserDeviceKeysList(
+              dave.userId,
+            ))?.deviceKeys.isNotEmpty ??
+            false;
 
         // Now the app sends the first message.
         FakeMatrixApi.calledEndpoints.clear();
@@ -439,7 +442,10 @@ void main() {
         );
 
         final daveKnown =
-            client.userDeviceKeys[dave.userId]?.deviceKeys.isNotEmpty ?? false;
+            (await client.fetchUserDeviceKeysList(
+              dave.userId,
+            ))?.deviceKeys.isNotEmpty ??
+            false;
 
         FakeMatrixApi.calledEndpoints.clear();
         await room.sendTextEvent('first message');
@@ -499,7 +505,10 @@ void main() {
         );
 
         final daveKnown =
-            client.userDeviceKeys[dave.userId]?.deviceKeys.isNotEmpty ?? false;
+            (await client.fetchUserDeviceKeysList(
+              dave.userId,
+            ))?.deviceKeys.isNotEmpty ??
+            false;
 
         FakeMatrixApi.calledEndpoints.clear();
         await room.sendTextEvent('first message');
@@ -683,7 +692,10 @@ void main() {
         );
 
         final erinKnown =
-            client.userDeviceKeys[erin.userId]?.deviceKeys.isNotEmpty ?? false;
+            (await client.fetchUserDeviceKeysList(
+              erin.userId,
+            ))?.deviceKeys.isNotEmpty ??
+            false;
 
         FakeMatrixApi.calledEndpoints.clear();
         await room.sendTextEvent('first message');

--- a/test_driver/matrixsdk_test.dart
+++ b/test_driver/matrixsdk_test.dart
@@ -186,10 +186,6 @@ void main() => group('Integration tests', () {
             .blocked,
         isFalse,
       );
-      await Future.wait([
-        testClientA.updateUserDeviceKeys(),
-        testClientB.updateUserDeviceKeys(),
-      ]);
       await testClientA
           .userDeviceKeys[testClientB.userID]!
           .deviceKeys[testClientB.deviceID!]!

--- a/test_driver/matrixsdk_test.dart
+++ b/test_driver/matrixsdk_test.dart
@@ -81,20 +81,14 @@ void main() => group('Integration tests', () {
       );
       expect(aliceOwnKeys, isNotNull);
       expect(aliceOwnKeys!.deviceKeys, contains(testClientA.deviceID));
-      expect(
-        await aliceOwnKeys.deviceKeys[testClientA.deviceID!]!.verified,
-        isTrue,
-      );
+      expect(aliceOwnKeys.deviceKeys[testClientA.deviceID!]!.verified, isTrue);
       expect(!aliceOwnKeys.deviceKeys[testClientA.deviceID!]!.blocked, isTrue);
       final bobOwnKeys = await testClientB.fetchUserDeviceKeysList(
         testClientB.userID!,
       );
       expect(bobOwnKeys, isNotNull);
       expect(bobOwnKeys!.deviceKeys, contains(testClientB.deviceID));
-      expect(
-        await bobOwnKeys.deviceKeys[testClientB.deviceID!]!.verified,
-        isTrue,
-      );
+      expect(bobOwnKeys.deviceKeys[testClientB.deviceID!]!.verified, isTrue);
       expect(!bobOwnKeys.deviceKeys[testClientB.deviceID!]!.blocked, isTrue);
 
       Logs().i('++++ (Alice) Create room and invite Bob ++++');
@@ -135,20 +129,14 @@ void main() => group('Integration tests', () {
       );
       expect(aliceKeys, isNotNull);
       expect(aliceKeys!.deviceKeys, contains(testClientB.deviceID));
-      expect(
-        await aliceKeys.deviceKeys[testClientB.deviceID!]!.verified,
-        isFalse,
-      );
+      expect(aliceKeys.deviceKeys[testClientB.deviceID!]!.verified, isFalse);
       expect(aliceKeys.deviceKeys[testClientB.deviceID!]!.blocked, isFalse);
       final bobKeys = await testClientB.fetchUserDeviceKeysList(
         testClientA.userID!,
       );
       expect(bobKeys, isNotNull);
       expect(bobKeys!.deviceKeys, contains(testClientA.deviceID));
-      expect(
-        await bobKeys.deviceKeys[testClientA.deviceID!]!.verified,
-        isFalse,
-      );
+      expect(bobKeys.deviceKeys[testClientA.deviceID!]!.verified, isFalse);
       expect(bobKeys.deviceKeys[testClientA.deviceID!]!.blocked, isFalse);
       await aliceKeys.deviceKeys[testClientB.deviceID!]!.setVerified(true);
 
@@ -162,9 +150,7 @@ void main() => group('Integration tests', () {
         contains(testClientA.deviceID),
       );
       expect(
-        await aliceOwnKeysAfterVerify
-            .deviceKeys[testClientA.deviceID!]!
-            .verified,
+        aliceOwnKeysAfterVerify.deviceKeys[testClientA.deviceID!]!.verified,
         isTrue,
       );
       final bobOwnKeysAfterVerify = await testClientB.fetchUserDeviceKeysList(
@@ -173,7 +159,7 @@ void main() => group('Integration tests', () {
       expect(bobOwnKeysAfterVerify, isNotNull);
       expect(bobOwnKeysAfterVerify!.deviceKeys, contains(testClientB.deviceID));
       expect(
-        await bobOwnKeysAfterVerify.deviceKeys[testClientB.deviceID!]!.verified,
+        bobOwnKeysAfterVerify.deviceKeys[testClientB.deviceID!]!.verified,
         isTrue,
       );
 

--- a/test_driver/matrixsdk_test.dart
+++ b/test_driver/matrixsdk_test.dart
@@ -76,44 +76,26 @@ void main() => group('Integration tests', () {
       }
 
       Logs().i('++++ Check if own olm device is verified by default ++++');
-      expect(testClientA.userDeviceKeys, contains(testClientA.userID));
-      expect(
-        testClientA.userDeviceKeys[testClientA.userID]!.deviceKeys,
-        contains(testClientA.deviceID),
+      final aliceOwnKeys = await testClientA.fetchUserDeviceKeysList(
+        testClientA.userID!,
       );
+      expect(aliceOwnKeys, isNotNull);
+      expect(aliceOwnKeys!.deviceKeys, contains(testClientA.deviceID));
       expect(
-        testClientA
-            .userDeviceKeys[testClientA.userID]!
-            .deviceKeys[testClientA.deviceID!]!
-            .verified,
+        await aliceOwnKeys.deviceKeys[testClientA.deviceID!]!.verified,
         isTrue,
       );
+      expect(!aliceOwnKeys.deviceKeys[testClientA.deviceID!]!.blocked, isTrue);
+      final bobOwnKeys = await testClientB.fetchUserDeviceKeysList(
+        testClientB.userID!,
+      );
+      expect(bobOwnKeys, isNotNull);
+      expect(bobOwnKeys!.deviceKeys, contains(testClientB.deviceID));
       expect(
-        !testClientA
-            .userDeviceKeys[testClientA.userID]!
-            .deviceKeys[testClientA.deviceID!]!
-            .blocked,
+        await bobOwnKeys.deviceKeys[testClientB.deviceID!]!.verified,
         isTrue,
       );
-      expect(testClientB.userDeviceKeys, contains(testClientB.userID));
-      expect(
-        testClientB.userDeviceKeys[testClientB.userID]!.deviceKeys,
-        contains(testClientB.deviceID),
-      );
-      expect(
-        testClientB
-            .userDeviceKeys[testClientB.userID]!
-            .deviceKeys[testClientB.deviceID!]!
-            .verified,
-        isTrue,
-      );
-      expect(
-        !testClientB
-            .userDeviceKeys[testClientB.userID]!
-            .deviceKeys[testClientB.deviceID!]!
-            .blocked,
-        isTrue,
-      );
+      expect(!bobOwnKeys.deviceKeys[testClientB.deviceID!]!.blocked, isTrue);
 
       Logs().i('++++ (Alice) Create room and invite Bob ++++');
       await testClientA.startDirectChat(
@@ -148,72 +130,50 @@ void main() => group('Integration tests', () {
       );
 
       Logs().i('++++ (Alice) Check known olm devices ++++');
-      expect(testClientA.userDeviceKeys, contains(testClientB.userID));
-      expect(
-        testClientA.userDeviceKeys[testClientB.userID]!.deviceKeys,
-        contains(testClientB.deviceID),
+      final aliceKeys = await testClientA.fetchUserDeviceKeysList(
+        testClientB.userID!,
       );
+      expect(aliceKeys, isNotNull);
+      expect(aliceKeys!.deviceKeys, contains(testClientB.deviceID));
       expect(
-        testClientA
-            .userDeviceKeys[testClientB.userID]!
-            .deviceKeys[testClientB.deviceID!]!
-            .verified,
+        await aliceKeys.deviceKeys[testClientB.deviceID!]!.verified,
         isFalse,
       );
+      expect(aliceKeys.deviceKeys[testClientB.deviceID!]!.blocked, isFalse);
+      final bobKeys = await testClientB.fetchUserDeviceKeysList(
+        testClientA.userID!,
+      );
+      expect(bobKeys, isNotNull);
+      expect(bobKeys!.deviceKeys, contains(testClientA.deviceID));
       expect(
-        testClientA
-            .userDeviceKeys[testClientB.userID]!
-            .deviceKeys[testClientB.deviceID!]!
-            .blocked,
+        await bobKeys.deviceKeys[testClientA.deviceID!]!.verified,
         isFalse,
       );
-      expect(testClientB.userDeviceKeys, contains(testClientA.userID));
-      expect(
-        testClientB.userDeviceKeys[testClientA.userID]!.deviceKeys,
-        contains(testClientA.deviceID),
-      );
-      expect(
-        testClientB
-            .userDeviceKeys[testClientA.userID]!
-            .deviceKeys[testClientA.deviceID!]!
-            .verified,
-        isFalse,
-      );
-      expect(
-        testClientB
-            .userDeviceKeys[testClientA.userID]!
-            .deviceKeys[testClientA.deviceID!]!
-            .blocked,
-        isFalse,
-      );
-      await testClientA
-          .userDeviceKeys[testClientB.userID]!
-          .deviceKeys[testClientB.deviceID!]!
-          .setVerified(true);
+      expect(bobKeys.deviceKeys[testClientA.deviceID!]!.blocked, isFalse);
+      await aliceKeys.deviceKeys[testClientB.deviceID!]!.setVerified(true);
 
       Logs().i('++++ Check if own olm device is verified by default ++++');
-      expect(testClientA.userDeviceKeys, contains(testClientA.userID));
+      final aliceOwnKeysAfterVerify = await testClientA.fetchUserDeviceKeysList(
+        testClientA.userID!,
+      );
+      expect(aliceOwnKeysAfterVerify, isNotNull);
       expect(
-        testClientA.userDeviceKeys[testClientA.userID]!.deviceKeys,
+        aliceOwnKeysAfterVerify!.deviceKeys,
         contains(testClientA.deviceID),
       );
       expect(
-        testClientA
-            .userDeviceKeys[testClientA.userID]!
+        await aliceOwnKeysAfterVerify
             .deviceKeys[testClientA.deviceID!]!
             .verified,
         isTrue,
       );
-      expect(testClientB.userDeviceKeys, contains(testClientB.userID));
-      expect(
-        testClientB.userDeviceKeys[testClientB.userID]!.deviceKeys,
-        contains(testClientB.deviceID),
+      final bobOwnKeysAfterVerify = await testClientB.fetchUserDeviceKeysList(
+        testClientB.userID!,
       );
+      expect(bobOwnKeysAfterVerify, isNotNull);
+      expect(bobOwnKeysAfterVerify!.deviceKeys, contains(testClientB.deviceID));
       expect(
-        testClientB
-            .userDeviceKeys[testClientB.userID]!
-            .deviceKeys[testClientB.deviceID!]!
-            .verified,
+        await bobOwnKeysAfterVerify.deviceKeys[testClientB.deviceID!]!.verified,
         isTrue,
       );
 


### PR DESCRIPTION
closes https://famedly.atlassian.net/browse/FM-758

# What does this change?

We no longer load all user device keys on app start and we no longer update them on every sync. Instead we load and update them on demand. Means `Client.userDeviceKeys[userId]` has been replaced by the async `Client.fetchUserDeviceKeysList(userId)`. This needed a very huge refactoring of the SDK as we no longer hold keys in memory but have them all database centric.

This should make the whole key handling more stable as we have no more in memory cache which can get outdated. It should also improve the performance as we no longer need to load all keys on app start. It should also speed up sync as we no longer update outdated keys on every sync.
Instead it **could** slow down sending the first encrypted message in a room for a few milliseconds. But this should actually be the better deal.

### TODOS:

- [ ] In my life test with Famedly App it seems for some reason to call POST /keys/query more often than I would expect (while not thaaat much often)
- [ ] Provide full live demo of Famedly App and FluffyChat with this