### PR TITLE
chore: reduce noisyness of update cache error

### DIFF
--- a/lib/src/utils/request_and_cache.dart
+++ b/lib/src/utils/request_and_cache.dart
@@ -25,8 +25,8 @@ extension RequestAndCache on Client {
       final content = await requestFunc();
       await database.cacheCustomObject(cacheKey, toJson(content));
       return content;
-    } catch (error, stackTrace) {
-      Logs().w('Unable to update cache for $cacheKey', error, stackTrace);
+    } catch (error) {
+      Logs().v('Unable to update cache for $cacheKey', error);
 
       if (!throwOnUpdateFailure && cachedResponse != null) {
         return fromJson(cachedResponse.content);


### PR DESCRIPTION
We really don't need to print the stacktrace here. If the app consumer is interested, they can just set throwOnUpdateFailure to true anyway.