### PR TITLE
feat: add customVideoThumbnailGenerator callback to create video thumbnails on send

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -111,6 +111,9 @@ class Client extends MatrixApi {
   )?
   customImageResizer;
 
+  Future<MatrixVideoThumbnailResponse?> Function(MatrixVideoThumbnailArguments)?
+  customVideoThumbnailGenerator;
+
   /// Optional matrix-content-scanner proxy configuration.
   ///
   /// When set, media URL helpers resolve `mxc://` URIs to scanner URLs, and
@@ -159,8 +162,9 @@ class Client extends MatrixApi {
   /// enable the SDK to compute some code in background.
   /// Set [timelineEventTimeout] to the preferred time the Client should retry
   /// sending events on connection problems or to `Duration.zero` to disable it.
-  /// Set [customImageResizer] to your own implementation for a more advanced
-  /// and faster image resizing experience.
+  /// Set [customImageResizer] and [customVideoThumbnailGenerator] to your own
+  /// implementations for a more advanced and faster image resizing experience
+  /// and for generating video thumbnails, which the SDK can not do itself.
   /// Set [enableDehydratedDevices] to enable experimental support for enabling MSC3814 dehydrated devices.
   Client(
     this.clientName, {
@@ -190,6 +194,7 @@ class Client extends MatrixApi {
     Duration defaultNetworkRequestTimeout = const Duration(seconds: 35),
     this.sendTimelineEventTimeout = const Duration(minutes: 1),
     this.customImageResizer,
+    this.customVideoThumbnailGenerator,
     this.shareKeysWith = ShareKeysWith.crossVerifiedIfEnabled,
     this.enableDehydratedDevices = false,
     this.receiptsPublicByDefault = true,

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -430,10 +430,11 @@ class Event extends MatrixEvent {
       if (thumbnailBytes != null) {
         return MatrixImageFile(
           bytes: thumbnailBytes,
-          name: filename,
+          name: '$filename.thumbnail.${extensionFromMime(thumbnailMimetype)}',
           mimeType: thumbnailMimetype,
           width: thumbnailInfoMap.tryGet<int>('w'),
           height: thumbnailInfoMap.tryGet<int>('h'),
+          blurhash: thumbnailInfoMap.tryGet<String>('xyz.amorgan.blurhash'),
         );
       }
 
@@ -623,7 +624,10 @@ class Event extends MatrixEvent {
   Uri? attachmentOrThumbnailMxcUrl({bool getThumbnail = false}) {
     final fileSize = infoMap.tryGet<int>('size');
     final thumbnailFileSize = thumbnailInfoMap.tryGet<int>('size');
+    // Only images can fall back to their original bytes as a preview, so the
+    // size-based discard must not apply to other types like m.video.
     if (getThumbnail &&
+        messageType == MessageTypes.Image &&
         fileSize != null &&
         thumbnailFileSize != null &&
         fileSize <= thumbnailFileSize) {

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -17,6 +17,7 @@ import 'package:matrix/src/utils/file_send_request_credentials.dart';
 import 'package:matrix/src/utils/markdown.dart';
 import 'package:matrix/src/utils/marked_unread.dart';
 import 'package:matrix/src/utils/space_child.dart';
+import 'package:mime/mime.dart';
 
 /// max PDU size for server to accept the event with some buffer incase the server adds unsigned data f.ex age
 /// https://spec.matrix.org/v1.9/client-server-api/#size-limits
@@ -813,7 +814,8 @@ class Room {
   /// wait until the file has been uploaded.
   /// Optionally specify [extraContent] to tack on to the event.
   ///
-  /// In case [file] is a [MatrixImageFile], [thumbnail] is automatically
+  /// In case [file] is a [MatrixImageFile] or a [MatrixVideoFile] (with
+  /// [Client.customVideoThumbnailGenerator] set), [thumbnail] is automatically
   /// computed unless it is explicitly provided.
   /// Set [shrinkImageMaxDimension] to for example `1600` if you want to shrink
   /// your image before sending. This is ignored if the File is not a
@@ -922,6 +924,70 @@ class Room {
         }
       } catch (e, s) {
         Logs().e('Unable to shrink image before sending!', e, s);
+      }
+    }
+
+    final customVideoThumbnailGenerator = client.customVideoThumbnailGenerator;
+    if (file is MatrixVideoFile &&
+        thumbnail == null &&
+        customVideoThumbnailGenerator != null) {
+      syncUpdate
+              .rooms!
+              .join!
+              .values
+              .first
+              .timeline!
+              .events!
+              .first
+              .unsigned![fileSendingStatusKey] =
+          FileSendingStatus.generatingThumbnail.name;
+      try {
+        final videoThumbnail = await customVideoThumbnailGenerator(
+          MatrixVideoThumbnailArguments(
+            bytes: file.bytes,
+            fileName: file.name,
+            mimeType: file.mimeType,
+          ),
+        );
+        if (videoThumbnail != null) {
+          final thumbnailMimeType = videoThumbnail.mimeType;
+          thumbnail = MatrixImageFile(
+            bytes: videoThumbnail.bytes,
+            name:
+                '${file.name}.thumbnail.${extensionFromMime(thumbnailMimeType ?? '') ?? 'jpg'}',
+            mimeType: thumbnailMimeType,
+            width: videoThumbnail.width,
+            height: videoThumbnail.height,
+            blurhash: videoThumbnail.blurhash,
+          );
+          await client.database.storeFile(
+            Uri(scheme: 'cache', host: 'thumbnail', path: txid),
+            thumbnail.bytes,
+            DateTime.now().millisecondsSinceEpoch,
+          );
+          file = MatrixVideoFile(
+            bytes: file.bytes,
+            name: file.name,
+            mimeType: file.mimeType,
+            width: file.width ?? videoThumbnail.originalWidth,
+            height: file.height ?? videoThumbnail.originalHeight,
+            duration: file.duration ?? videoThumbnail.duration,
+          );
+          syncUpdate
+              .rooms!
+              .join!
+              .values
+              .first
+              .timeline!
+              .events!
+              .first
+              .content['info'] = {
+            ...file.info,
+            'thumbnail_info': thumbnail.info,
+          };
+        }
+      } catch (e, s) {
+        Logs().e('Unable to generate video thumbnail before sending!', e, s);
       }
     }
 
@@ -1077,8 +1143,8 @@ class Room {
           },
         if (thumbnail != null) 'thumbnail_info': thumbnail.info,
         if (thumbnail?.blurhash != null &&
-            file is MatrixImageFile &&
-            file.blurhash == null)
+            ((file is MatrixImageFile && file.blurhash == null) ||
+                file is MatrixVideoFile))
           'xyz.amorgan.blurhash': thumbnail!.blurhash,
       },
       ...?extraContent,

--- a/lib/src/utils/matrix_file.dart
+++ b/lib/src/utils/matrix_file.dart
@@ -353,6 +353,43 @@ class MatrixVideoFile extends MatrixFile {
   });
 }
 
+class MatrixVideoThumbnailArguments {
+  final Uint8List bytes;
+  final String fileName;
+  final String? mimeType;
+  final int maxDimension;
+
+  const MatrixVideoThumbnailArguments({
+    required this.bytes,
+    required this.fileName,
+    this.mimeType,
+    this.maxDimension = Client.defaultThumbnailSize,
+  });
+}
+
+class MatrixVideoThumbnailResponse {
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final String? mimeType;
+  final String? blurhash;
+
+  final int? originalWidth;
+  final int? originalHeight;
+  final int? duration;
+
+  const MatrixVideoThumbnailResponse({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    this.mimeType,
+    this.blurhash,
+    this.originalWidth,
+    this.originalHeight,
+    this.duration,
+  });
+}
+
 class MatrixAudioFile extends MatrixFile {
   final int? duration;
 

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -1405,6 +1405,182 @@ void main() {
       );
     });
 
+    test('sendFileEvent video with customVideoThumbnailGenerator', () async {
+      // A dedicated room so the sent video events don't leak into tests
+      // using the shared `room`:
+      final videoRoom = Room(
+        id: '!video:server.abc',
+        client: matrix,
+        membership: Membership.join,
+      );
+      FakeMatrixApi
+              .currentApi!
+              .api['PUT']!['/client/v3/rooms/!video%3Aserver.abc/send/m.room.message/testtxid'] =
+          (var req) => {'event_id': '\$event${FakeMatrixApi.eventCounter++}'};
+      FakeMatrixApi
+          .currentApi!
+          .api['POST']!['/media/v3/upload?filename=file.mp4'] = (var req) => {
+        'content_uri': 'mxc://example.com/videoTestMxcUri',
+      };
+      FakeMatrixApi
+              .currentApi!
+              .api['POST']!['/media/v3/upload?filename=file.mp4.thumbnail.jpg'] =
+          (var req) => {'content_uri': 'mxc://example.com/videoThumbMxcUri'};
+      MatrixVideoThumbnailArguments? receivedArguments;
+      matrix.customVideoThumbnailGenerator = (arguments) async {
+        receivedArguments = arguments;
+        return MatrixVideoThumbnailResponse(
+          // Bigger than the video itself, must still be used:
+          bytes: Uint8List(2000),
+          width: 600,
+          height: 400,
+          mimeType: 'image/jpeg',
+          blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+          originalWidth: 1920,
+          originalHeight: 1080,
+          duration: 5000,
+        );
+      };
+
+      final testFile = MatrixVideoFile(
+        bytes: Uint8List(1000),
+        name: 'file.mp4',
+      );
+      FakeMatrixApi.calledEndpoints.clear();
+      final resp = await videoRoom.sendFileEvent(testFile, txid: 'testtxid');
+      expect(resp, isNotNull);
+      expect(receivedArguments?.fileName, 'file.mp4');
+      expect(receivedArguments?.mimeType, 'video/mp4');
+      expect(receivedArguments?.bytes, testFile.bytes);
+      expect(
+        await matrix.database.getFile(
+          Uri(scheme: 'cache', host: 'thumbnail', path: 'testtxid'),
+        ),
+        null, // It is sent so shouldn't be in cache anymore
+      );
+
+      final content = json.decode(
+        FakeMatrixApi.calledEndpoints.entries
+            .firstWhere(
+              (e) => e.key.startsWith(
+                '/client/v3/rooms/!video%3Aserver.abc/send/m.room.message/testtxid',
+              ),
+            )
+            .value
+            .first,
+      );
+      expect(content, {
+        'msgtype': 'm.video',
+        'body': 'file.mp4',
+        'filename': 'file.mp4',
+        'url': 'mxc://example.com/videoTestMxcUri',
+        'info': {
+          'mimetype': 'video/mp4',
+          'size': 1000,
+          'w': 1920,
+          'h': 1080,
+          'duration': 5000,
+          'thumbnail_url': 'mxc://example.com/videoThumbMxcUri',
+          'thumbnail_info': {
+            'mimetype': 'image/jpeg',
+            'size': 2000,
+            'w': 600,
+            'h': 400,
+            'xyz.amorgan.blurhash': 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+          },
+          'xyz.amorgan.blurhash': 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+        },
+      });
+      matrix.customVideoThumbnailGenerator = null;
+    });
+
+    test('sendFileEvent video keeps generated thumbnail cached on '
+        'failure', () async {
+      final videoRoom = Room(
+        id: '!video:server.abc',
+        client: matrix,
+        membership: Membership.join,
+      );
+      final thumbnailBytes = Uint8List.fromList([1, 2, 3]);
+      matrix.customVideoThumbnailGenerator = (arguments) async =>
+          MatrixVideoThumbnailResponse(
+            bytes: thumbnailBytes,
+            width: 600,
+            height: 400,
+            mimeType: 'image/jpeg',
+          );
+      FakeMatrixApi
+          .currentApi!
+          .api['POST']!['/media/v3/upload?filename=crash.mp4'] = {
+        'errcode': 'M_UNKNOWN',
+        'error': 'Boom!',
+      };
+
+      const txnid = 'video_crash_txnid';
+      final testFile = MatrixVideoFile(
+        bytes: Uint8List(1000),
+        name: 'crash.mp4',
+      );
+      try {
+        await videoRoom.sendFileEvent(testFile, txid: txnid);
+      } catch (_) {}
+
+      expect(
+        await matrix.database.getFile(
+          Uri(scheme: 'cache', host: 'file', path: txnid),
+        ),
+        testFile.bytes,
+      );
+      expect(
+        await matrix.database.getFile(
+          Uri(scheme: 'cache', host: 'thumbnail', path: txnid),
+        ),
+        thumbnailBytes,
+      );
+      matrix.customVideoThumbnailGenerator = null;
+    });
+
+    test('sendFileEvent video ignores failing thumbnail generator', () async {
+      final videoRoom = Room(
+        id: '!video:server.abc',
+        client: matrix,
+        membership: Membership.join,
+      );
+      FakeMatrixApi
+              .currentApi!
+              .api['PUT']!['/client/v3/rooms/!video%3Aserver.abc/send/m.room.message/testtxid'] =
+          (var req) => {'event_id': '\$event${FakeMatrixApi.eventCounter++}'};
+      matrix.customVideoThumbnailGenerator = (arguments) async =>
+          throw Exception('Unable to decode video');
+
+      final testFile = MatrixVideoFile(
+        bytes: Uint8List(1000),
+        name: 'file.mp4',
+      );
+      FakeMatrixApi.calledEndpoints.clear();
+      final resp = await videoRoom.sendFileEvent(testFile, txid: 'testtxid');
+      expect(resp, isNotNull);
+
+      final content = json.decode(
+        FakeMatrixApi.calledEndpoints.entries
+            .firstWhere(
+              (e) => e.key.startsWith(
+                '/client/v3/rooms/!video%3Aserver.abc/send/m.room.message/testtxid',
+              ),
+            )
+            .value
+            .first,
+      );
+      expect(content, {
+        'msgtype': 'm.video',
+        'body': 'file.mp4',
+        'filename': 'file.mp4',
+        'url': 'mxc://example.com/videoTestMxcUri',
+        'info': {'mimetype': 'video/mp4', 'size': 1000},
+      });
+      matrix.customVideoThumbnailGenerator = null;
+    });
+
     test('pushRuleState', () async {
       expect(room.pushRuleState, PushRuleState.mentionsOnly);
       ((matrix.accountData['m.push_rules']?.content['global']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Part of [FM-567](https://famedly.atlassian.net/browse/FM-567) (no video thumbnails when sending from web).

The SDK can not decode videos itself, so `m.video` messages are sent without a thumbnail unless the app passes one explicitly (which the Famedly app only does on mobile via `video_compress`). This adds a `customVideoThumbnailGenerator` callback to `Client`, analogous to `customImageResizer`:

- `Room.sendFileEvent` invokes the callback for a `MatrixVideoFile` when no explicit `thumbnail` is provided, uploads the generated thumbnail and writes `thumbnail_url`/`thumbnail_file` + `thumbnail_info` into the event.
- The response can also carry the video's own metadata, which is used to fill in missing `w`/`h`/`duration` in the video info.
- The thumbnail's blurhash is written to the video event's `info` (`xyz.amorgan.blurhash`), as already done for images.
- A failing generator is logged and the video is sent without a thumbnail, like the image path.

The app-side browser implementation is in famedly/app (uses an `HTMLVideoElement` + canvas).

### Verification

- New tests for the happy path (thumbnail + metadata + blurhash in the sent event) and for a throwing generator.
- Full test suite passes (54/54 files), `dart analyze` and `dart format` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e8c8b3b-c66f-4bc5-a031-13cc1f17d4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e8c8b3b-c66f-4bc5-a031-13cc1f17d4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[FM-567]: https://famedly.atlassian.net/browse/FM-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ