### PR TITLE
fix: force server member refresh when creating outbound megolm session

### DIFF
--- a/lib/encryption/key_manager.dart
+++ b/lib/encryption/key_manager.dart
@@ -549,7 +549,13 @@ class KeyManager {
       );
     }
 
-    final deviceKeys = await room.getUserDeviceKeys();
+    // Force a server refresh of the member list here: this is the one place
+    // where missing a member is unrecoverable, because we bake the recipient
+    // set into a brand new megolm session. Relying on the (count-based) local
+    // completeness heuristic has been observed to silently drop invited/joined
+    // members when the server's room summary lagged during a burst of invites,
+    // leaving them permanently unable to decrypt.
+    final deviceKeys = await room.getUserDeviceKeys(forceServerRefresh: true);
     final deviceKeyIds = _getDeviceKeyIdMap(deviceKeys);
     deviceKeys.removeWhere((k) => !k.encryptToDevice);
     final outboundGroupSession = vod.GroupSession();

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1901,6 +1901,15 @@ class Room {
     ],
     bool suppressWarning = false,
     bool? cache,
+    // Set to `true` to always hit `/members` on the server even when the
+    // count-based [participantListComplete] heuristic thinks the local list is
+    // already complete. The heuristic can yield a false positive when the
+    // server's room summary transiently under-reports member counts (e.g.
+    // during a burst of invites right after room creation) and the incomplete
+    // local state happens to match those wrong counts. Callers that must not
+    // miss a member - most importantly the E2EE key-sharing path - use this to
+    // fetch the authoritative member list. See [getUserDeviceKeys].
+    bool forceServerRefresh = false,
   ]) async {
     if (!participantListComplete || partial) {
       // we aren't fully loaded, maybe the users are in the database
@@ -1914,8 +1923,10 @@ class Room {
       }
     }
 
-    // Do not request users from the server if we have already have a complete list locally.
-    if (participantListComplete) {
+    // Do not request users from the server if we have already have a complete
+    // list locally, unless the caller explicitly asks us to double check
+    // against the server.
+    if (participantListComplete && !forceServerRefresh) {
       return getParticipants(membershipFilter);
     }
 
@@ -2652,10 +2663,46 @@ class Room {
   }
 
   /// Returns all known device keys for all participants in this room.
-  Future<List<DeviceKeys>> getUserDeviceKeys() async {
+  Future<List<DeviceKeys>> getUserDeviceKeys({
+    bool forceServerRefresh = false,
+  }) async {
     await client.userDeviceKeysLoading;
     final deviceKeys = <DeviceKeys>[];
     final users = await requestParticipants();
+
+    if (forceServerRefresh) {
+      // The count-based completeness heuristic ([participantListComplete]) can
+      // report a false positive, in which case `requestParticipants()` above
+      // returned a stale, incomplete member list and members would be silently
+      // dropped from key sharing - they could then never decrypt any message
+      // in this room. When creating an outbound megolm session we therefore
+      // fetch the authoritative member list from the server and union it with
+      // what we already know locally (a union, so we never lose a member the
+      // server omitted from a lazy-loaded response). We tolerate a failed
+      // refresh and fall back to the local list rather than failing the send.
+      try {
+        final serverUsers = await requestParticipants(
+          const [Membership.join, Membership.invite, Membership.knock],
+          true, // suppressWarning
+          true, // cache
+          true, // forceServerRefresh
+        );
+        final knownIds = users.map((user) => user.id).toSet();
+        for (final user in serverUsers) {
+          if (knownIds.add(user.id)) {
+            users.add(user);
+          }
+        }
+      } catch (e, s) {
+        Logs().w(
+          '[E2EE] Could not refresh the full member list of $id before '
+          'encrypting, falling back to the locally known participants',
+          e,
+          s,
+        );
+      }
+    }
+
     users.removeWhere(
       (user) => ![Membership.invite, Membership.join].contains(user.membership),
     );

--- a/test/new_room_first_message_repro_test.dart
+++ b/test/new_room_first_message_repro_test.dart
@@ -703,5 +703,105 @@ void main() {
         );
       },
     );
+
+    test(
+      'Scenario 5: summary under-counts invites (stale participantListComplete)',
+      () async {
+        // Reproduction of the observed production incident: during a burst of
+        // invites right after room creation the server sent a room summary that
+        // under-reported the invited member count, and the (incomplete) local
+        // member state happened to match those wrong counts. The count based
+        // `participantListComplete` heuristic therefore returned `true`, so the
+        // authoritative /members list was never fetched and the invited user
+        // was silently dropped from the megolm key share - they could never
+        // decrypt any message in the room.
+        const roomId = '!1234:fakeServer.notExisting';
+        roomCounter++;
+        // grace is a real, invited member of the room. She is present in the
+        // server's /members response but *missing* from the local state we get
+        // via sync, and - crucially - not counted in the (stale) summary.
+        final grace = FakeRemoteUser(
+          '@grace$roomCounter:remote.server',
+          'GRACEDEV',
+        );
+        registerRemoteUsers([grace]);
+
+        // The authoritative member list the server would return from /members:
+        // ourselves (join) + grace (invite).
+        FakeMatrixApi
+                .currentApi!
+                .api['GET']!['/client/v3/rooms/!1234%3AfakeServer.notExisting/members'] =
+            (req) => {
+              'chunk': [
+                {
+                  'type': 'm.room.member',
+                  'content': {'membership': 'join'},
+                  'sender': client.userID!,
+                  'state_key': client.userID!,
+                  'event_id': '\$self_$roomCounter',
+                  'origin_server_ts': 100,
+                },
+                {
+                  'type': 'm.room.member',
+                  'content': {'membership': 'invite'},
+                  'sender': client.userID!,
+                  'state_key': grace.userId,
+                  'event_id': '\$grace_$roomCounter',
+                  'origin_server_ts': 104,
+                },
+              ],
+            };
+
+        // Room creation sync WITHOUT grace's invite in the timeline, and with a
+        // summary that under-reports the invite count as 0. Locally we then know
+        // 1 joined / 0 invited, which matches the summary exactly, so
+        // `participantListComplete` is a (wrong) `true`.
+        await emulateSync(
+          SyncUpdate(
+            nextBatch: 'create_$roomCounter',
+            rooms: RoomsUpdate(
+              join: {
+                roomId: newRoomUpdate(invited: [], joined: 1),
+              },
+            ),
+          ),
+        );
+
+        final room = client.getRoomById(roomId)!;
+        expect(room.encrypted, true);
+        expect(
+          room.participantListComplete,
+          true,
+          reason:
+              'Precondition: the count heuristic wrongly believes the local '
+              'member list is complete',
+        );
+        expect(
+          room.getParticipants().any((u) => u.id == grace.userId),
+          false,
+          reason: 'Precondition: grace is not in the local member list',
+        );
+
+        // Now the app sends the first message.
+        FakeMatrixApi.calledEndpoints.clear();
+        await room.sendTextEvent('first message');
+
+        final payload = toDevicePayloadFor(grace);
+        expect(
+          payload,
+          isNotNull,
+          reason:
+              'BUG: the invited member was dropped from key sharing because '
+              'the stale summary made participantListComplete return true, so '
+              '/members was never fetched. They can never decrypt this room.',
+        );
+        // And they must get it from index 0 so the very first message is
+        // decryptable for them.
+        final decrypted = grace.decryptToDevice(payload!);
+        expect(decrypted['type'], 'm.room_key');
+        final sessionKey = decrypted['content']['session_key'] as String;
+        expect(vod.InboundGroupSession(sessionKey).firstKnownIndex, 0);
+      },
+    );
   });
 }


### PR DESCRIPTION
Related to https://famedly.atlassian.net/browse/CS-1780. Only WIP from AI to test it.

When creating a new outbound group session we baked the recipient set from
the locally known member list. The count-based `participantListComplete`
heuristic can return a false positive when the server's room summary
transiently under-reports member counts (observed during a burst of invites
right after room creation) and the incomplete local state happens to match
those wrong counts. In that case `/members` was never fetched and invited or
joined members were silently dropped from the key share, leaving them
permanently unable to decrypt the room.