### PR TITLE
refactor: always fetch member list from server for first megolm session

### DIFF
--- a/lib/fake_matrix_api.dart
+++ b/lib/fake_matrix_api.dart
@@ -226,6 +226,34 @@ class FakeMatrixApi extends BaseClient {
           action.contains('/client/v1/rooms/') &&
           action.contains('/relations/')) {
         res = {'chunk': [], 'next_batch': null, 'prev_batch': null};
+      } else if (method == 'GET' &&
+          action.contains('/client/v3/rooms/') &&
+          action.split('?').first.endsWith('/members')) {
+        // First megolm session always fetches /members; return known members
+        // or an empty chunk so unstubbed rooms don't fail with M_UNRECOGNIZED.
+        final roomId = Uri.decodeComponent(
+          action.split('/client/v3/rooms/').last.split('/members').first,
+        );
+        final members = _client
+            ?.getRoomById(roomId)
+            ?.states[EventTypes.RoomMember];
+        res = {
+          'chunk':
+              members?.values
+                  .map(
+                    (e) => {
+                      'type': e.type,
+                      'content': e.content,
+                      'sender': e.senderId,
+                      'state_key': e.stateKey,
+                      'event_id': '\$member_${e.stateKey}',
+                      'origin_server_ts': 1,
+                      'room_id': roomId,
+                    },
+                  )
+                  .toList() ??
+              [],
+        };
       } else if (method == 'PUT' &&
           action.contains(
             '/client/v3/rooms/!1234%3AfakeServer.notExisting/send/',
@@ -1842,18 +1870,6 @@ class FakeMatrixApi extends BaseClient {
               },
             ],
           },
-      '/client/v3/rooms/!1234%3AfakeServer.notExisting/members': (var req) => {
-        'chunk': [
-          {
-            'type': 'm.room.member',
-            'content': {'membership': 'join'},
-            'sender': '@fakeuser:fakeServer.notExisting',
-            'state_key': '@test:fakeServer.notExisting',
-            'event_id': '\$abcd',
-            'origin_server_ts': 1783579093968,
-          },
-        ],
-      },
       '/client/v3/rooms/!696r7674:example.com/members': (var req) => {
         'chunk': [
           {

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1901,6 +1901,7 @@ class Room {
     ],
     bool suppressWarning = false,
     bool? cache,
+    bool enforceFetchFromServer = false,
   ]) async {
     if (!participantListComplete || partial) {
       // we aren't fully loaded, maybe the users are in the database
@@ -1915,7 +1916,7 @@ class Room {
     }
 
     // Do not request users from the server if we have already have a complete list locally.
-    if (participantListComplete) {
+    if (participantListComplete && !enforceFetchFromServer) {
       return getParticipants(membershipFilter);
     }
 
@@ -2694,7 +2695,15 @@ class Room {
   Future<List<DeviceKeys>> getUserDeviceKeys() async {
     await client.userDeviceKeysLoading;
     final deviceKeys = <DeviceKeys>[];
-    final users = await requestParticipants();
+
+    final users = await requestParticipants(
+      const [Membership.join, Membership.invite, Membership.knock],
+      true,
+      true,
+      // If this is our first megolm session we want to refetch all members
+      // from the server
+      client.encryption?.keyManager.getOutboundGroupSession(id) == null,
+    );
     users.removeWhere(
       (user) => ![Membership.invite, Membership.join].contains(user.membership),
     );

--- a/test/room_test.dart
+++ b/test/room_test.dart
@@ -714,6 +714,18 @@ void main() {
       expect(fetchedParticipants.length, newParticipants.length);
       room.summary.mJoinedMemberCount = 3;
       expect(room.participantListComplete, true);
+
+      // Make sure we fetch participants even if sdk assumes participant list
+      // is complete:
+      FakeMatrixApi.calledEndpoints.clear();
+      await room.getUserDeviceKeys();
+      expect(
+        FakeMatrixApi.calledEndpoints.containsKey(
+          '/client/v3/rooms/!localpart%3Aserver.abc/members',
+        ),
+        true,
+      );
+
       room.summary.mJoinedMemberCount = null;
       expect(room.participantListComplete, false);
     });


### PR DESCRIPTION
This workarounds that synapse sometimes seem to send a wrong joined member count which is used to check if we have all participants already cached locally.

fixes https://famedly.atlassian.net/browse/CS-1780