### PR TITLE
fix(voip): stop delayed leave heartbeat when delayed event is gone

### DIFF
--- a/lib/src/voip/utils/famedly_call_extension.dart
+++ b/lib/src/voip/utils/famedly_call_extension.dart
@@ -238,10 +238,15 @@ extension FamedlyCallMemberEventsExtension on Room {
             voip.delayedEventCancellers.remove(matchingEntry.key);
           }
 
-          await client.manageDelayedEvent(
-            toCancelEvent.delayId,
-            DelayedEventAction.cancel,
-          );
+          try {
+            await client.manageDelayedEvent(
+              toCancelEvent.delayId,
+              DelayedEventAction.cancel,
+            );
+          } on MatrixException catch (e) {
+            // already sent or cancelled elsewhere, nothing left to cancel
+            if (e.error != MatrixError.M_NOT_FOUND) rethrow;
+          }
         }
 
         Map<String, List> newContent;
@@ -282,10 +287,40 @@ extension FamedlyCallMemberEventsExtension on Room {
             Logs().v(
               '[_restartDelayedLeaveEventTimer] heartbeat delayed event',
             );
-            await client.manageDelayedEvent(
-              delayedLeaveEventId,
-              DelayedEventAction.restart,
-            );
+            try {
+              await client.manageDelayedEvent(
+                delayedLeaveEventId,
+                DelayedEventAction.restart,
+              );
+            } on MatrixException catch (e, s) {
+              if (e.error == MatrixError.M_NOT_FOUND) {
+                // The delayed event no longer exists on the server (already
+                // sent or cancelled elsewhere), restarting it is futile.
+                Logs().w(
+                  '[_restartDelayedLeaveEventTimer] delayed event $delayedLeaveEventId gone, stopping heartbeat',
+                  e,
+                );
+                timer.cancel();
+                final canceller =
+                    voip.delayedEventCancellers['$id|$groupCallId|$scope'];
+                if (canceller?.delayedEventId == delayedLeaveEventId) {
+                  voip.delayedEventCancellers.remove('$id|$groupCallId|$scope');
+                }
+              } else {
+                Logs().w(
+                  '[_restartDelayedLeaveEventTimer] failed to restart delayed event',
+                  e,
+                  s,
+                );
+              }
+            } catch (e, s) {
+              // keep the heartbeat alive on transient errors (e.g. network)
+              Logs().w(
+                '[_restartDelayedLeaveEventTimer] failed to restart delayed event',
+                e,
+                s,
+              );
+            }
           }),
         );
 

--- a/test/calls_test.dart
+++ b/test/calls_test.dart
@@ -1170,6 +1170,67 @@ void main() {
       );
 
       test(
+        'delayed leave heartbeat stops when the delayed event is gone (M_NOT_FOUND)',
+        () async {
+          const callId = 'test_delayed_not_found';
+
+          // advertise msc4140 support via the cached versions response
+          await matrix.database.cacheCustomObject('get_versions', {
+            'versions': ['v1.1', 'v1.2', 'v1.11'],
+            'unstable_features': {'org.matrix.msc4140': true},
+          });
+
+          final api = FakeMatrixApi.currentApi!;
+          // no already scheduled delayed events
+          api.api['GET']!['/client/unstable/org.matrix.msc4140/delayed_events'] =
+              (var req) => {'delayed_events': []};
+          // the delayed leave state event returns a known delay id
+          api.api['PUT']!['/client/v3/rooms/${Uri.encodeComponent(room.id)}/state/${Uri.encodeComponent(EventTypes.GroupCallMember)}/${Uri.encodeComponent(matrix.userID!)}?org.matrix.msc4140.delay=400'] =
+              (var req) => {'delay_id': 'faildelayid'};
+          // every restart heartbeat fails because the delayed event is gone
+          var restartCalls = 0;
+          api.api['POST']!['/client/unstable/org.matrix.msc4140/delayed_events/faildelayid'] =
+              (var req) {
+                restartCalls++;
+                return {
+                  'errcode': 'M_NOT_FOUND',
+                  'error': 'Delayed event not found',
+                };
+              };
+
+          final shortTimerVoip = VoIP(
+            matrix,
+            MockWebRTCDelegate(),
+            timeouts: CallTimeouts(
+              delayedEventApplyLeave: Duration(milliseconds: 400),
+              delayedEventRestart: Duration(milliseconds: 50),
+            ),
+          );
+
+          await room.setFamedlyCallMemberEvent(
+            {'memberships': []},
+            shortTimerVoip,
+            callId,
+          );
+
+          expect(
+            shortTimerVoip.delayedEventCancellers.containsKey(
+              '${room.id}|$callId|m.room',
+            ),
+            isTrue,
+          );
+
+          // let the heartbeat fire; the M_NOT_FOUND response must stop the
+          // timer and remove the canceller instead of throwing unhandled
+          // errors forever
+          await Future.delayed(Duration(milliseconds: 300));
+
+          expect(shortTimerVoip.delayedEventCancellers, isEmpty);
+          expect(restartCalls, 1);
+        },
+      );
+
+      test(
         'application change mid-call: sendMemberStateEvent still works and loop continues',
         () async {
           final shortTimerVoip = VoIP(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry reports ~65k unhandled `M_NOT_FOUND: Delayed event not found` errors from `DelayedEventsHandler.manageDelayedEvent`. Root cause: the periodic restart heartbeat for the MSC4140 delayed leave event in `setFamedlyCallMemberEvent` has no error handling — once the delayed event no longer exists on the server (already sent after the delay elapsed, e.g. app suspended, or cancelled elsewhere), every tick throws an unhandled exception forever.

- Heartbeat now catches `MatrixException`: on `M_NOT_FOUND` it cancels the timer and removes the canceller; other errors are logged as warnings and the heartbeat keeps retrying.
- Cancelling already-listed scheduled delayed events now tolerates `M_NOT_FOUND` (races with the server sending them).

## Verification

- New regression test `delayed leave heartbeat stops when the delayed event is gone (M_NOT_FOUND)` in `test/calls_test.dart` — fails on `main` (unhandled async error, canceller leaked), passes with the fix, and asserts the heartbeat stops after a single failed restart.
- `dart analyze` clean, `dart format` clean, `dart test test/calls_test.dart -x olm` all 18 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea7671a3-c908-4fd6-b3b1-01a12712cd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea7671a3-c908-4fd6-b3b1-01a12712cd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

