### PR TITLE
chore: simplify database.getClient()

### DIFF
--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -428,15 +428,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   @override
   Future<Map<String, dynamic>?> getClient(String name) =>
       runBenchmarked('Get Client from store', () async {
-        final map = <String, dynamic>{};
-        final keys = await _clientBox.getAllKeys();
-        for (final key in keys) {
-          if (key == 'version') continue;
-          final value = await _clientBox.get(key);
-          if (value != null) map[key] = value;
-        }
-        if (map.isEmpty) return null;
-        return map;
+        final clientMap = await _clientBox.getAllValues();
+        clientMap.remove('version');
+        if (clientMap.isEmpty) return null;
+        return clientMap;
       });
 
   @override

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -176,9 +176,5 @@ void main() async {
       expect(user1.mentionFragments, {'@[Alice M]', '@[Alice M]#1745'});
       expect(user2.mentionFragments, {'@Bob', '@Bob#1542'});
     });
-    test('dispose client', () async {
-      await Future.delayed(Duration(milliseconds: 50));
-      await client.dispose(closeDatabase: true);
-    });
   });
 }


### PR DESCRIPTION
This actually fixes an edge case with OIDC: We have the problem of an inconsistency with the database and the quickAccessCache in the client box with the refresh token. I see it very randomly on web only so far. However as we should reconsider removing the quickAccessCache completely anyway this change here just uses the getAllValues method which is more simple to use anyway, saves some code but also does **not** use the quickAccessCache. So until we made a bigger refactoring of the database this might be a quick win.

I can not prove it but at least it happened once to me that the refreshToken was for some reason different in the quickAccessCache compared to the DB which leads to session loss! This tiny refactoring makes this impossible.

closes https://famedly.atlassian.net/browse/FM-791