### PR TITLE
Krille/refactor device keys list storing

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -4161,44 +4161,7 @@ class Client extends MatrixApi {
     Logs().d('Migrate Device Keys...');
     final userDeviceKeys = await legacyDatabase.getUserDeviceKeys(this);
     for (final userId in userDeviceKeys.keys) {
-      Logs().d('Migrate Device Keys of user $userId...');
-      final deviceKeysList = userDeviceKeys[userId];
-      for (final crossSigningKey
-          in deviceKeysList?.crossSigningKeys.values ?? <CrossSigningKey>[]) {
-        final pubKey = crossSigningKey.publicKey;
-        if (pubKey != null) {
-          Logs().d(
-            'Migrate cross signing key with usage ${crossSigningKey.usage} and verified ${crossSigningKey.directVerified}...',
-          );
-          await database.storeUserCrossSigningKey(
-            userId,
-            pubKey,
-            jsonEncode(crossSigningKey.toJson()),
-            crossSigningKey.directVerified,
-            crossSigningKey.blocked,
-            trustOnFirstUseSince: crossSigningKey.trustOnFirstUseSince,
-          );
-        }
-      }
-
-      if (deviceKeysList != null) {
-        for (final deviceKeys in deviceKeysList.deviceKeys.values) {
-          final deviceId = deviceKeys.deviceId;
-          if (deviceId != null) {
-            Logs().d('Migrate device keys for ${deviceKeys.deviceId}...');
-            await database.storeUserDeviceKey(
-              userId,
-              deviceId,
-              jsonEncode(deviceKeys.toJson()),
-              deviceKeys.directVerified,
-              deviceKeys.blocked,
-              deviceKeys.lastActive.millisecondsSinceEpoch,
-            );
-          }
-        }
-        Logs().d('Migrate user device keys info...');
-        await database.storeUserDeviceKeysInfo(userId, deviceKeysList.outdated);
-      }
+      await database.storeDeviceKeysList(userId, userDeviceKeys[userId]!);
     }
     Logs().d('Migrate inbound group sessions...');
     try {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2629,7 +2629,7 @@ class Client extends MatrixApi {
         final userKeys = _userDeviceKeys[userId];
         if (userKeys != null) {
           userKeys.outdated = true;
-          await database.storeUserDeviceKeysInfo(userId, true);
+          await database.storeDeviceKeysList(userId, userKeys);
         } else {
           // Per spec `changed` also includes users who *now* share an
           // encrypted room with us. We might not know about them yet, for
@@ -3425,6 +3425,8 @@ class Client extends MatrixApi {
         final response = await queryKeys(outdatedLists, timeout: 10000);
         if (!isLogged()) return;
 
+        final usersToPersist = <String>{};
+
         final deviceKeys = response.deviceKeys;
         if (deviceKeys != null) {
           for (final rawDeviceKeyListEntry in deviceKeys.entries) {
@@ -3509,16 +3511,6 @@ class Client extends MatrixApi {
                     // Always trust the own device
                     entry.setDirectVerified(true);
                   }
-                  dbActions.add(
-                    () => database.storeUserDeviceKey(
-                      userId,
-                      deviceId,
-                      json.encode(entry.toJson()),
-                      entry.directVerified,
-                      entry.blocked,
-                      entry.lastActive.millisecondsSinceEpoch,
-                    ),
-                  );
                 } else if (oldKeys.containsKey(deviceId)) {
                   // This shouldn't ever happen. The same device ID has gotten
                   // a new public key. So we ignore the update. TODO: ask krille
@@ -3529,20 +3521,9 @@ class Client extends MatrixApi {
                 Logs().w('Invalid device ${entry.userId}:${entry.deviceId}');
               }
             }
-            // delete old/unused entries
-            for (final oldDeviceKeyEntry in oldKeys.entries) {
-              final deviceId = oldDeviceKeyEntry.key;
-              if (!userKeys.deviceKeys.containsKey(deviceId)) {
-                // we need to remove an old key
-                dbActions.add(
-                  () => database.removeUserDeviceKey(userId, deviceId),
-                );
-              }
-            }
+            // Drop old/unused entries by not adding them back to deviceKeys.
             userKeys.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
+            usersToPersist.add(userId);
           }
         }
         // next we parse and persist the cross signing keys
@@ -3571,14 +3552,9 @@ class Client extends MatrixApi {
             for (final oldEntry in oldKeys.entries) {
               if (!oldEntry.value.usage.contains(keyType)) {
                 userKeys.crossSigningKeys[oldEntry.key] = oldEntry.value;
-              } else {
-                // There is a previous cross-signing key with  this usage, that we no
-                // longer need/use. Clear it from the database.
-                dbActions.add(
-                  () =>
-                      database.removeUserCrossSigningKey(userId, oldEntry.key),
-                );
               }
+              // Previous cross-signing keys with this usage are dropped by not
+              // adding them back; storeDeviceKeysList persists that.
             }
             final entry = CrossSigningKey.fromMatrixCrossSigningKey(
               crossSigningKeyListEntry.value,
@@ -3607,22 +3583,16 @@ class Client extends MatrixApi {
                 // if we should instead use the new key with unknown verified / blocked status
                 userKeys.crossSigningKeys[publicKey] = oldKey;
               }
-              dbActions.add(
-                () => database.storeUserCrossSigningKey(
-                  userId,
-                  publicKey,
-                  json.encode(entry.toJson()),
-                  entry.directVerified,
-                  entry.blocked,
-                  trustOnFirstUseSince: entry.trustOnFirstUseSince,
-                ),
-              );
             }
             _userDeviceKeys[userId]?.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
+            usersToPersist.add(userId);
           }
+        }
+
+        for (final userId in usersToPersist) {
+          final list = _userDeviceKeys[userId];
+          if (list == null) continue;
+          dbActions.add(() => database.storeDeviceKeysList(userId, list));
         }
 
         // now process all the failures

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3521,7 +3521,7 @@ class Client extends MatrixApi {
                 Logs().w('Invalid device ${entry.userId}:${entry.deviceId}');
               }
             }
-            // Drop old/unused entries by not adding them back to deviceKeys.
+
             userKeys.outdated = false;
             usersToPersist.add(userId);
           }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2618,7 +2618,7 @@ class Client extends MatrixApi {
         final userKeys = _userDeviceKeys[userId];
         if (userKeys != null) {
           userKeys.outdated = true;
-          await database.storeUserDeviceKeysInfo(userId, true);
+          await database.storeDeviceKeysList(userId, userKeys);
         } else {
           // Per spec `changed` also includes users who *now* share an
           // encrypted room with us. We might not know about them yet, for
@@ -3425,6 +3425,8 @@ class Client extends MatrixApi {
         final response = await queryKeys(outdatedLists, timeout: 10000);
         if (!isLogged()) return;
 
+        final usersToPersist = <String>{};
+
         final deviceKeys = response.deviceKeys;
         if (deviceKeys != null) {
           for (final rawDeviceKeyListEntry in deviceKeys.entries) {
@@ -3509,16 +3511,6 @@ class Client extends MatrixApi {
                     // Always trust the own device
                     entry.setDirectVerified(true);
                   }
-                  dbActions.add(
-                    () => database.storeUserDeviceKey(
-                      userId,
-                      deviceId,
-                      json.encode(entry.toJson()),
-                      entry.directVerified,
-                      entry.blocked,
-                      entry.lastActive.millisecondsSinceEpoch,
-                    ),
-                  );
                 } else if (oldKeys.containsKey(deviceId)) {
                   // This shouldn't ever happen. The same device ID has gotten
                   // a new public key. So we ignore the update. TODO: ask krille
@@ -3529,20 +3521,9 @@ class Client extends MatrixApi {
                 Logs().w('Invalid device ${entry.userId}:${entry.deviceId}');
               }
             }
-            // delete old/unused entries
-            for (final oldDeviceKeyEntry in oldKeys.entries) {
-              final deviceId = oldDeviceKeyEntry.key;
-              if (!userKeys.deviceKeys.containsKey(deviceId)) {
-                // we need to remove an old key
-                dbActions.add(
-                  () => database.removeUserDeviceKey(userId, deviceId),
-                );
-              }
-            }
+            // Drop old/unused entries by not adding them back to deviceKeys.
             userKeys.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
+            usersToPersist.add(userId);
           }
         }
         // next we parse and persist the cross signing keys
@@ -3571,14 +3552,9 @@ class Client extends MatrixApi {
             for (final oldEntry in oldKeys.entries) {
               if (!oldEntry.value.usage.contains(keyType)) {
                 userKeys.crossSigningKeys[oldEntry.key] = oldEntry.value;
-              } else {
-                // There is a previous cross-signing key with  this usage, that we no
-                // longer need/use. Clear it from the database.
-                dbActions.add(
-                  () =>
-                      database.removeUserCrossSigningKey(userId, oldEntry.key),
-                );
               }
+              // Previous cross-signing keys with this usage are dropped by not
+              // adding them back; storeDeviceKeysList persists that.
             }
             final entry = CrossSigningKey.fromMatrixCrossSigningKey(
               crossSigningKeyListEntry.value,
@@ -3607,22 +3583,16 @@ class Client extends MatrixApi {
                 // if we should instead use the new key with unknown verified / blocked status
                 userKeys.crossSigningKeys[publicKey] = oldKey;
               }
-              dbActions.add(
-                () => database.storeUserCrossSigningKey(
-                  userId,
-                  publicKey,
-                  json.encode(entry.toJson()),
-                  entry.directVerified,
-                  entry.blocked,
-                  trustOnFirstUseSince: entry.trustOnFirstUseSince,
-                ),
-              );
             }
             _userDeviceKeys[userId]?.outdated = false;
-            dbActions.add(
-              () => database.storeUserDeviceKeysInfo(userId, false),
-            );
+            usersToPersist.add(userId);
           }
+        }
+
+        for (final userId in usersToPersist) {
+          final list = _userDeviceKeys[userId];
+          if (list == null) continue;
+          dbActions.add(() => database.storeDeviceKeysList(userId, list));
         }
 
         // now process all the failures

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -4146,44 +4146,7 @@ class Client extends MatrixApi {
     Logs().d('Migrate Device Keys...');
     final userDeviceKeys = await legacyDatabase.getUserDeviceKeys(this);
     for (final userId in userDeviceKeys.keys) {
-      Logs().d('Migrate Device Keys of user $userId...');
-      final deviceKeysList = userDeviceKeys[userId];
-      for (final crossSigningKey
-          in deviceKeysList?.crossSigningKeys.values ?? <CrossSigningKey>[]) {
-        final pubKey = crossSigningKey.publicKey;
-        if (pubKey != null) {
-          Logs().d(
-            'Migrate cross signing key with usage ${crossSigningKey.usage} and verified ${crossSigningKey.directVerified}...',
-          );
-          await database.storeUserCrossSigningKey(
-            userId,
-            pubKey,
-            jsonEncode(crossSigningKey.toJson()),
-            crossSigningKey.directVerified,
-            crossSigningKey.blocked,
-            trustOnFirstUseSince: crossSigningKey.trustOnFirstUseSince,
-          );
-        }
-      }
-
-      if (deviceKeysList != null) {
-        for (final deviceKeys in deviceKeysList.deviceKeys.values) {
-          final deviceId = deviceKeys.deviceId;
-          if (deviceId != null) {
-            Logs().d('Migrate device keys for ${deviceKeys.deviceId}...');
-            await database.storeUserDeviceKey(
-              userId,
-              deviceId,
-              jsonEncode(deviceKeys.toJson()),
-              deviceKeys.directVerified,
-              deviceKeys.blocked,
-              deviceKeys.lastActive.millisecondsSinceEpoch,
-            );
-          }
-        }
-        Logs().d('Migrate user device keys info...');
-        await database.storeUserDeviceKeysInfo(userId, deviceKeysList.outdated);
-      }
+      await database.storeDeviceKeysList(userId, userDeviceKeys[userId]!);
     }
     Logs().d('Migrate inbound group sessions...');
     try {

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -212,56 +212,11 @@ abstract class DatabaseApi {
 
   Future deleteOldFiles(int savedAt);
 
-  Future storeUserDeviceKeysInfo(String userId, bool outdated);
-
-  Future storeUserDeviceKey(
-    String userId,
-    String deviceId,
-    String content,
-    bool verified,
-    bool blocked,
-    int lastActive,
-  );
-
-  Future removeUserDeviceKey(String userId, String deviceId);
-
-  Future removeUserCrossSigningKey(String userId, String publicKey);
-
-  Future storeUserCrossSigningKey(
-    String userId,
-    String publicKey,
-    String content,
-    bool verified,
-    bool blocked, {
-    DateTime? trustOnFirstUseSince,
-  });
-
   Future deleteFromToDeviceQueue(int id);
 
   Future removeEvent(String eventId, String roomId);
 
   Future setRoomPrevBatch(String? prevBatch, String roomId, Client client);
-
-  Future setVerifiedUserCrossSigningKey(
-    bool verified,
-    String userId,
-    String publicKey, {
-    DateTime? trustOnFirstUseSince,
-  });
-
-  Future setBlockedUserCrossSigningKey(
-    bool blocked,
-    String userId,
-    String publicKey,
-  );
-
-  Future setVerifiedUserDeviceKey(
-    bool verified,
-    String userId,
-    String deviceId,
-  );
-
-  Future setBlockedUserDeviceKey(bool blocked, String userId, String deviceId);
 
   Future<List<Event>> getUnimportantRoomEventStatesForRoom(
     List<String> events,

--- a/lib/src/database/database_api.dart
+++ b/lib/src/database/database_api.dart
@@ -327,4 +327,11 @@ abstract class DatabaseApi {
     String roomId,
     LatestReceiptState receiptState,
   );
+
+  Future<DeviceKeysList?> getDeviceKeysList(String userId, Client client);
+
+  Future<void> storeDeviceKeysList(
+    String userId,
+    DeviceKeysList deviceKeysList,
+  );
 }

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -83,6 +83,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   late Box<Map> _deviceKeysListBox;
 
+  /// Is a Tuple(userId, deviceId) to the last sent message as a json map:
+  late Box<String> _lastSentOlmMessagesBox;
+
   @override
   final int maxFileSize;
 
@@ -146,6 +149,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   static const String _readReceiptsBoxName = 'box_read_receipts';
 
   static const String _deviceKeysListBoxName = 'box_device_keys_list';
+
+  static const String _lastSentOlmMessagesBoxName =
+      'box_last_sent_olm_messages';
 
   Database? database;
 
@@ -224,6 +230,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _userProfilesBoxName,
         _readReceiptsBoxName,
         _deviceKeysListBoxName,
+        _lastSentOlmMessagesBoxName,
       },
       sqfliteDatabase: database,
       sqfliteFactory: sqfliteFactory,
@@ -257,6 +264,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _userProfilesBox = _collection.openBox(_userProfilesBoxName);
     _readReceiptsBox = _collection.openBox(_readReceiptsBoxName);
     _deviceKeysListBox = _collection.openBox(_deviceKeysListBoxName);
+    _lastSentOlmMessagesBox = _collection.openBox(_lastSentOlmMessagesBoxName);
 
     // Check version and check if we need a migration
     final currentVersion = int.tryParse(await _clientBox.get('version') ?? '');
@@ -334,6 +342,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _userProfilesBox.clearQuickAccessCache();
     _readReceiptsBox.clearQuickAccessCache();
     _deviceKeysListBox.clearQuickAccessCache();
+    _lastSentOlmMessagesBox.clearQuickAccessCache();
 
     await _collection.clear();
   }
@@ -514,11 +523,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final rawKeys = await getDeviceKeysList(
-      userId,
-      Client('db', database: this),
+    final messageStr = await _lastSentOlmMessagesBox.get(
+      TupleKey(userId, deviceId).toString(),
     );
-    return [?rawKeys?.deviceKeys[deviceId]?.lastSentMessage];
+    return [?messageStr];
   }
 
   @override
@@ -728,7 +736,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     return Event.fromJson(copyMap(state), room).asUser;
   }
 
-  /// Only for migration. Can be removed after a certain amount of time.
+  /// Only for migration. Can be removed after a certain amount of time. Also
+  /// clears everything from the old boxes!
   Future<Map<String, DeviceKeysList>> _legacyGetUserDeviceKeys(
     Client client,
   ) async {
@@ -751,6 +760,14 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     final userDeviceKeys = await legacyUserDeviceKeysBox.getAllValues();
     final userCrossSigningKeys = await legacyUserCrossSigningKeysBox
         .getAllValues();
+
+    // Migrate lastSentMessages
+    for (final entry in userDeviceKeys.entries) {
+      final lastSentMessage = entry.value['last_sent_message'];
+      if (lastSentMessage is! String || lastSentMessage.isEmpty) continue;
+      await _lastSentOlmMessagesBox.put(entry.key, lastSentMessage);
+    }
+
     for (final userId in deviceKeysOutdated.keys) {
       final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
         final tupleKey = TupleKey.fromString(tuple);
@@ -787,6 +804,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         client,
       );
     }
+    legacyUserDeviceKeysBox.clear();
+    legacyUserCrossSigningKeysBox.clear();
+    legacyUserDeviceKeysOutdatedBox.clear();
     return res;
   }
 
@@ -929,49 +949,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> removeUserCrossSigningKey(
-    String userId,
-    String publicKey,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys.remove(publicKey);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> removeUserDeviceKey(String userId, String deviceId) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys.remove(deviceId);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setBlockedUserCrossSigningKey(
-    bool blocked,
-    String userId,
-    String publicKey,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys[publicKey]?.blocked = blocked;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setBlockedUserDeviceKey(
-    bool blocked,
-    String userId,
-    String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.blocked = blocked;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
   Future<void> setLastActiveUserDeviceKey(
     int lastActive,
     String userId,
@@ -990,12 +967,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String lastSentMessage,
     String userId,
     String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.lastSentMessage = lastSentMessage;
-    await storeDeviceKeysList(userId, keys);
-  }
+  ) => _lastSentOlmMessagesBox.put(
+    TupleKey(userId, deviceId).toString(),
+    lastSentMessage,
+  );
 
   @override
   Future<void> setRoomPrevBatch(
@@ -1009,37 +984,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     room.prev_batch = prevBatch;
     await _roomsBox.put(roomId, room.toJson());
     return;
-  }
-
-  @override
-  Future<void> setVerifiedUserCrossSigningKey(
-    bool verified,
-    String userId,
-    String publicKey, {
-    DateTime? trustOnFirstUseSince,
-  }) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys[publicKey]?.setDirectVerified(verified);
-    if (trustOnFirstUseSince != null) {
-      keys.crossSigningKeys[publicKey]?.trustOnFirstUse(
-        since: trustOnFirstUseSince,
-        updateInDatabase: false,
-      );
-    }
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setVerifiedUserDeviceKey(
-    bool verified,
-    String userId,
-    String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.setDirectVerified(verified);
-    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1344,67 +1288,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> storeUserCrossSigningKey(
-    String userId,
-    String publicKey,
-    String content,
-    bool verified,
-    bool blocked, {
-    DateTime? trustOnFirstUseSince,
-  }) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-    keys.crossSigningKeys[publicKey] = CrossSigningKey.fromDbJson({
-      'user_id': userId,
-      'public_key': publicKey,
-      'content': content,
-      'verified': verified,
-      'blocked': blocked,
-      if (trustOnFirstUseSince != null)
-        'tofu': trustOnFirstUseSince.millisecondsSinceEpoch,
-    }, tmpClient);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> storeUserDeviceKey(
-    String userId,
-    String deviceId,
-    String content,
-    bool verified,
-    bool blocked,
-    int lastActive,
-  ) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-
-    keys.deviceKeys[deviceId] = DeviceKeys.fromDb({
-      'user_id': userId,
-      'device_id': deviceId,
-      'content': content,
-      'verified': verified,
-      'blocked': blocked,
-      'last_active': lastActive,
-      'last_sent_message': keys.deviceKeys[deviceId]?.lastSentMessage ?? '',
-    }, tmpClient);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> storeUserDeviceKeysInfo(String userId, bool outdated) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-    keys.outdated = outdated;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
   Future<void> transaction(Future<void> Function() action) =>
       _collection.transaction(action);
 
@@ -1565,6 +1448,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
           .getAllValues(),
       _olmSessionsBoxName: await _olmSessionsBox.getAllValues(),
       _deviceKeysListBoxName: await _deviceKeysListBox.getAllValues(),
+      _lastSentOlmMessagesBoxName: await _lastSentOlmMessagesBox.getAllValues(),
       _ssssCacheBoxName: await _ssssCacheBox.getAllValues(),
       _presencesBoxName: await _presencesBox.getAllValues(),
       _timelineFragmentsBoxName: await _timelineFragmentsBox.getAllValues(),
@@ -1636,6 +1520,12 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       }
       for (final key in json[_deviceKeysListBoxName]!.keys) {
         await _deviceKeysListBox.put(key, json[_deviceKeysListBoxName]![key]);
+      }
+      for (final key in json[_lastSentOlmMessagesBoxName]!.keys) {
+        await _lastSentOlmMessagesBox.put(
+          key,
+          json[_lastSentOlmMessagesBoxName]![key],
+        );
       }
       for (final key in json[_ssssCacheBoxName]!.keys) {
         await _ssssCacheBox.put(key, json[_ssssCacheBoxName]![key]);

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -34,7 +34,7 @@ import 'sqflite_box.dart' if (dart.library.js_interop) 'indexeddb_box.dart';
 /// Learn more at:
 /// https://github.com/famedly/matrix-dart-sdk/issues/1642#issuecomment-1865827227
 class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
-  static const int version = 11;
+  static const int version = 12;
   final String name;
 
   late BoxCollection _collection;
@@ -62,15 +62,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   late Box<String> _inboundGroupSessionsUploadQueueBox;
   late Box<Map> _outboundGroupSessionsBox;
   late Box<Map> _olmSessionsBox;
-
-  /// Key is a tuple as TupleKey(userId, deviceId)
-  late Box<Map> _userDeviceKeysBox;
-
-  /// Key is the user ID as a String
-  late Box<bool> _userDeviceKeysOutdatedBox;
-
-  /// Key is a tuple as TupleKey(userId, publicKey)
-  late Box<Map> _userCrossSigningKeysBox;
   late Box<Map> _ssssCacheBox;
   late Box<Map> _presencesBox;
 
@@ -89,6 +80,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   late Box<Map> _userProfilesBox;
 
   late Box<Map> _readReceiptsBox;
+
+  late Box<Map> _deviceKeysListBox;
 
   @override
   final int maxFileSize;
@@ -128,12 +121,13 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   static const String _olmSessionsBoxName = 'box_olm_session';
 
-  static const String _userDeviceKeysBoxName = 'box_user_device_keys';
+  static const String _legacyUserDeviceKeysBoxName = 'box_user_device_keys';
 
-  static const String _userDeviceKeysOutdatedBoxName =
+  static const String _legacyUserDeviceKeysOutdatedBoxName =
       'box_user_device_keys_outdated';
 
-  static const String _userCrossSigningKeysBoxName = 'box_cross_signing_keys';
+  static const String _legacyUserCrossSigningKeysBoxName =
+      'box_cross_signing_keys';
 
   static const String _ssssCacheBoxName = 'box_ssss_cache';
 
@@ -150,6 +144,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   static const String _userProfilesBoxName = 'box_user_profiles';
 
   static const String _readReceiptsBoxName = 'box_read_receipts';
+
+  static const String _deviceKeysListBoxName = 'box_device_keys_list';
 
   Database? database;
 
@@ -216,9 +212,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _inboundGroupSessionsUploadQueueBoxName,
         _outboundGroupSessionsBoxName,
         _olmSessionsBoxName,
-        _userDeviceKeysBoxName,
-        _userDeviceKeysOutdatedBoxName,
-        _userCrossSigningKeysBoxName,
+        _legacyUserDeviceKeysBoxName,
+        _legacyUserDeviceKeysOutdatedBoxName,
+        _legacyUserCrossSigningKeysBoxName,
         _ssssCacheBoxName,
         _presencesBoxName,
         _timelineFragmentsBoxName,
@@ -227,6 +223,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _seenDeviceKeysBoxName,
         _userProfilesBoxName,
         _readReceiptsBoxName,
+        _deviceKeysListBoxName,
       },
       sqfliteDatabase: database,
       sqfliteFactory: sqfliteFactory,
@@ -251,13 +248,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       _outboundGroupSessionsBoxName,
     );
     _olmSessionsBox = _collection.openBox(_olmSessionsBoxName);
-    _userDeviceKeysBox = _collection.openBox(_userDeviceKeysBoxName);
-    _userDeviceKeysOutdatedBox = _collection.openBox(
-      _userDeviceKeysOutdatedBoxName,
-    );
-    _userCrossSigningKeysBox = _collection.openBox(
-      _userCrossSigningKeysBoxName,
-    );
     _ssssCacheBox = _collection.openBox(_ssssCacheBoxName);
     _presencesBox = _collection.openBox(_presencesBoxName);
     _timelineFragmentsBox = _collection.openBox(_timelineFragmentsBoxName);
@@ -266,6 +256,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _seenDeviceKeysBox = _collection.openBox(_seenDeviceKeysBoxName);
     _userProfilesBox = _collection.openBox(_userProfilesBoxName);
     _readReceiptsBox = _collection.openBox(_readReceiptsBoxName);
+    _deviceKeysListBox = _collection.openBox(_deviceKeysListBoxName);
 
     // Check version and check if we need a migration
     final currentVersion = int.tryParse(await _clientBox.get('version') ?? '');
@@ -280,6 +271,16 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   Future<void> _migrateFromVersion(int currentVersion) async {
     Logs().i('Migrate store database from version $currentVersion to $version');
+
+    if (currentVersion <= 11) {
+      final deviceKeysLists = await _legacyGetUserDeviceKeys(
+        Client('migrationclient', database: this),
+      );
+      for (final entry in deviceKeysLists.entries) {
+        Logs().d('Migrate user keys', entry.key);
+        await storeDeviceKeysList(entry.key, entry.value);
+      }
+    }
 
     if (version == 8) {
       // Migrate to inbound group sessions upload queue:
@@ -324,9 +325,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _inboundGroupSessionsUploadQueueBox.clearQuickAccessCache();
     _outboundGroupSessionsBox.clearQuickAccessCache();
     _olmSessionsBox.clearQuickAccessCache();
-    _userDeviceKeysBox.clearQuickAccessCache();
-    _userDeviceKeysOutdatedBox.clearQuickAccessCache();
-    _userCrossSigningKeysBox.clearQuickAccessCache();
     _ssssCacheBox.clearQuickAccessCache();
     _presencesBox.clearQuickAccessCache();
     _timelineFragmentsBox.clearQuickAccessCache();
@@ -335,6 +333,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _seenDeviceKeysBox.clearQuickAccessCache();
     _userProfilesBox.clearQuickAccessCache();
     _readReceiptsBox.clearQuickAccessCache();
+    _deviceKeysListBox.clearQuickAccessCache();
 
     await _collection.clear();
   }
@@ -515,11 +514,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = await _userDeviceKeysBox.get(
-      TupleKey(userId, deviceId).toString(),
+    final rawKeys = await getDeviceKeysList(
+      userId,
+      Client('db', database: this),
     );
-    if (raw == null) return <String>[];
-    return <String>[raw['last_sent_message']];
+    return [?rawKeys?.deviceKeys[deviceId]?.lastSentMessage];
   }
 
   @override
@@ -729,61 +728,67 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     return Event.fromJson(copyMap(state), room).asUser;
   }
 
-  @override
-  Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client) =>
-      runBenchmarked<Map<String, DeviceKeysList>>(
-        'Get all user device keys from store',
-        () async {
-          final deviceKeysOutdated = await _userDeviceKeysOutdatedBox
-              .getAllValues();
-          if (deviceKeysOutdated.isEmpty) {
-            return {};
-          }
-          final res = <String, DeviceKeysList>{};
-          final userDeviceKeys = await _userDeviceKeysBox.getAllValues();
-          final userCrossSigningKeys = await _userCrossSigningKeysBox
-              .getAllValues();
-          for (final userId in deviceKeysOutdated.keys) {
-            final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
-              final tupleKey = TupleKey.fromString(tuple);
-              return tupleKey.parts.first == userId;
-            });
-            final crossSigningKeysBoxKeys = userCrossSigningKeys.keys.where((
-              tuple,
-            ) {
-              final tupleKey = TupleKey.fromString(tuple);
-              return tupleKey.parts.first == userId;
-            });
-            final childEntries = deviceKeysBoxKeys.map((key) {
-              final userDeviceKey = userDeviceKeys[key];
-              if (userDeviceKey == null) return null;
-              return copyMap(userDeviceKey);
-            });
-            final crossSigningEntries = crossSigningKeysBoxKeys.map((key) {
-              final crossSigningKey = userCrossSigningKeys[key];
-              if (crossSigningKey == null) return null;
-              return copyMap(crossSigningKey);
-            });
-            res[userId] = DeviceKeysList.fromDbJson(
-              {
-                'client_id': client.id,
-                'user_id': userId,
-                'outdated': deviceKeysOutdated[userId],
-              },
-              childEntries
-                  .where((c) => c != null)
-                  .toList()
-                  .cast<Map<String, dynamic>>(),
-              crossSigningEntries
-                  .where((c) => c != null)
-                  .toList()
-                  .cast<Map<String, dynamic>>(),
-              client,
-            );
-          }
-          return res;
+  /// Only for migration. Can be removed after a certain amount of time.
+  Future<Map<String, DeviceKeysList>> _legacyGetUserDeviceKeys(
+    Client client,
+  ) async {
+    final legacyUserDeviceKeysBox = _collection.openBox(
+      _legacyUserDeviceKeysBoxName,
+    );
+    final legacyUserDeviceKeysOutdatedBox = _collection.openBox(
+      _legacyUserDeviceKeysOutdatedBoxName,
+    );
+    final legacyUserCrossSigningKeysBox = _collection.openBox(
+      _legacyUserCrossSigningKeysBoxName,
+    );
+
+    final deviceKeysOutdated = await legacyUserDeviceKeysOutdatedBox
+        .getAllValues();
+    if (deviceKeysOutdated.isEmpty) {
+      return {};
+    }
+    final res = <String, DeviceKeysList>{};
+    final userDeviceKeys = await legacyUserDeviceKeysBox.getAllValues();
+    final userCrossSigningKeys = await legacyUserCrossSigningKeysBox
+        .getAllValues();
+    for (final userId in deviceKeysOutdated.keys) {
+      final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
+        final tupleKey = TupleKey.fromString(tuple);
+        return tupleKey.parts.first == userId;
+      });
+      final crossSigningKeysBoxKeys = userCrossSigningKeys.keys.where((tuple) {
+        final tupleKey = TupleKey.fromString(tuple);
+        return tupleKey.parts.first == userId;
+      });
+      final childEntries = deviceKeysBoxKeys.map((key) {
+        final userDeviceKey = userDeviceKeys[key];
+        if (userDeviceKey == null) return null;
+        return copyMap(userDeviceKey);
+      });
+      final crossSigningEntries = crossSigningKeysBoxKeys.map((key) {
+        final crossSigningKey = userCrossSigningKeys[key];
+        if (crossSigningKey == null) return null;
+        return copyMap(crossSigningKey);
+      });
+      res[userId] = DeviceKeysList.fromDbJson(
+        {
+          'client_id': client.id,
+          'user_id': userId,
+          'outdated': deviceKeysOutdated[userId],
         },
+        childEntries
+            .where((c) => c != null)
+            .toList()
+            .cast<Map<String, dynamic>>(),
+        crossSigningEntries
+            .where((c) => c != null)
+            .toList()
+            .cast<Map<String, dynamic>>(),
+        client,
       );
+    }
+    return res;
+  }
 
   @override
   Future<List<User>> getUsers(Room room) async {
@@ -928,16 +933,18 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String publicKey,
   ) async {
-    await _userCrossSigningKeysBox.delete(
-      TupleKey(userId, publicKey).toString(),
-    );
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys.remove(publicKey);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
   Future<void> removeUserDeviceKey(String userId, String deviceId) async {
-    await _userDeviceKeysBox.delete(TupleKey(userId, deviceId).toString());
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys.remove(deviceId);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -946,18 +953,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String publicKey,
   ) async {
-    final raw = copyMap(
-      await _userCrossSigningKeysBox.get(
-            TupleKey(userId, publicKey).toString(),
-          ) ??
-          {},
-    );
-    raw['blocked'] = blocked;
-    await _userCrossSigningKeysBox.put(
-      TupleKey(userId, publicKey).toString(),
-      raw,
-    );
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys[publicKey]?.blocked = blocked;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -966,12 +965,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['blocked'] = blocked;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.blocked = blocked;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -980,12 +977,12 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.lastActive = DateTime.fromMillisecondsSinceEpoch(
+      lastActive,
     );
-
-    raw['last_active'] = lastActive;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -994,11 +991,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['last_sent_message'] = lastSentMessage;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.lastSentMessage = lastSentMessage;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1022,21 +1018,16 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String publicKey, {
     DateTime? trustOnFirstUseSince,
   }) async {
-    final raw = copyMap(
-      (await _userCrossSigningKeysBox.get(
-            TupleKey(userId, publicKey).toString(),
-          )) ??
-          {},
-    );
-    raw['verified'] = verified;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys[publicKey]?.setDirectVerified(verified);
     if (trustOnFirstUseSince != null) {
-      raw['tofu'] = trustOnFirstUseSince.millisecondsSinceEpoch;
+      keys.crossSigningKeys[publicKey]?.trustOnFirstUse(
+        since: trustOnFirstUseSince,
+        updateInDatabase: false,
+      );
     }
-    await _userCrossSigningKeysBox.put(
-      TupleKey(userId, publicKey).toString(),
-      raw,
-    );
-    return;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1045,12 +1036,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['verified'] = verified;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.setDirectVerified(verified);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1359,7 +1348,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     bool blocked, {
     DateTime? trustOnFirstUseSince,
   }) async {
-    await _userCrossSigningKeysBox.put(TupleKey(userId, publicKey).toString(), {
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+    keys.crossSigningKeys[publicKey] = CrossSigningKey.fromDbJson({
       'user_id': userId,
       'public_key': publicKey,
       'content': content,
@@ -1367,7 +1360,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       'blocked': blocked,
       if (trustOnFirstUseSince != null)
         'tofu': trustOnFirstUseSince.millisecondsSinceEpoch,
-    });
+    }, tmpClient);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1379,22 +1373,31 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     bool blocked,
     int lastActive,
   ) async {
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), {
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+
+    keys.deviceKeys[deviceId] = DeviceKeys.fromDb({
       'user_id': userId,
       'device_id': deviceId,
       'content': content,
       'verified': verified,
       'blocked': blocked,
       'last_active': lastActive,
-      'last_sent_message': '',
-    });
-    return;
+      'last_sent_message': keys.deviceKeys[deviceId]?.lastSentMessage ?? '',
+    }, tmpClient);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
   Future<void> storeUserDeviceKeysInfo(String userId, bool outdated) async {
-    await _userDeviceKeysOutdatedBox.put(userId, outdated);
-    return;
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+    keys.outdated = outdated;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1557,11 +1560,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       _outboundGroupSessionsBoxName: await _outboundGroupSessionsBox
           .getAllValues(),
       _olmSessionsBoxName: await _olmSessionsBox.getAllValues(),
-      _userDeviceKeysBoxName: await _userDeviceKeysBox.getAllValues(),
-      _userDeviceKeysOutdatedBoxName: await _userDeviceKeysOutdatedBox
-          .getAllValues(),
-      _userCrossSigningKeysBoxName: await _userCrossSigningKeysBox
-          .getAllValues(),
+      _deviceKeysListBoxName: await _deviceKeysListBox.getAllValues(),
       _ssssCacheBoxName: await _ssssCacheBox.getAllValues(),
       _presencesBoxName: await _presencesBox.getAllValues(),
       _timelineFragmentsBoxName: await _timelineFragmentsBox.getAllValues(),
@@ -1631,20 +1630,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       for (final key in json[_olmSessionsBoxName]!.keys) {
         await _olmSessionsBox.put(key, json[_olmSessionsBoxName]![key]);
       }
-      for (final key in json[_userDeviceKeysBoxName]!.keys) {
-        await _userDeviceKeysBox.put(key, json[_userDeviceKeysBoxName]![key]);
-      }
-      for (final key in json[_userDeviceKeysOutdatedBoxName]!.keys) {
-        await _userDeviceKeysOutdatedBox.put(
-          key,
-          json[_userDeviceKeysOutdatedBoxName]![key],
-        );
-      }
-      for (final key in json[_userCrossSigningKeysBoxName]!.keys) {
-        await _userCrossSigningKeysBox.put(
-          key,
-          json[_userCrossSigningKeysBoxName]![key],
-        );
+      for (final key in json[_deviceKeysListBoxName]!.keys) {
+        await _deviceKeysListBox.put(key, json[_deviceKeysListBoxName]![key]);
       }
       for (final key in json[_ssssCacheBoxName]!.keys) {
         await _ssssCacheBox.put(key, json[_ssssCacheBoxName]![key]);
@@ -1794,6 +1781,36 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String roomId,
     LatestReceiptState receiptState,
   ) => _readReceiptsBox.put(roomId, receiptState.toJson());
+
+  @override
+  Future<DeviceKeysList?> getDeviceKeysList(
+    String userId,
+    Client client,
+  ) async {
+    final raw = await _deviceKeysListBox.get(userId);
+    if (raw == null) return null;
+    final json = copyMap(raw);
+    return DeviceKeysList.fromJson(json, client);
+  }
+
+  @override
+  Future<void> storeDeviceKeysList(
+    String userId,
+    DeviceKeysList deviceKeysList,
+  ) => _deviceKeysListBox.put(userId, deviceKeysList.toJson());
+
+  @override
+  Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client) async {
+    final raw = await _deviceKeysListBox.getAllValues();
+    return raw.map((k, v) {
+      try {
+        return MapEntry(k, DeviceKeysList.fromJson(copyMap(v), client));
+      } catch (e, s) {
+        Logs().w('Unable to parse device keys list for $k', e, s);
+        return MapEntry(k, DeviceKeysList(k, client, outdated: true));
+      }
+    });
+  }
 }
 
 class TupleKey {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -34,7 +34,7 @@ import 'sqflite_box.dart' if (dart.library.js_interop) 'indexeddb_box.dart';
 /// Learn more at:
 /// https://github.com/famedly/matrix-dart-sdk/issues/1642#issuecomment-1865827227
 class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
-  static const int version = 11;
+  static const int version = 12;
   final String name;
 
   late BoxCollection _collection;
@@ -62,15 +62,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   late Box<String> _inboundGroupSessionsUploadQueueBox;
   late Box<Map> _outboundGroupSessionsBox;
   late Box<Map> _olmSessionsBox;
-
-  /// Key is a tuple as TupleKey(userId, deviceId)
-  late Box<Map> _userDeviceKeysBox;
-
-  /// Key is the user ID as a String
-  late Box<bool> _userDeviceKeysOutdatedBox;
-
-  /// Key is a tuple as TupleKey(userId, publicKey)
-  late Box<Map> _userCrossSigningKeysBox;
   late Box<Map> _ssssCacheBox;
   late Box<Map> _presencesBox;
 
@@ -89,6 +80,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   late Box<Map> _userProfilesBox;
 
   late Box<Map> _readReceiptsBox;
+
+  late Box<Map> _deviceKeysListBox;
 
   @override
   final int maxFileSize;
@@ -128,12 +121,13 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   static const String _olmSessionsBoxName = 'box_olm_session';
 
-  static const String _userDeviceKeysBoxName = 'box_user_device_keys';
+  static const String _legacyUserDeviceKeysBoxName = 'box_user_device_keys';
 
-  static const String _userDeviceKeysOutdatedBoxName =
+  static const String _legacyUserDeviceKeysOutdatedBoxName =
       'box_user_device_keys_outdated';
 
-  static const String _userCrossSigningKeysBoxName = 'box_cross_signing_keys';
+  static const String _legacyUserCrossSigningKeysBoxName =
+      'box_cross_signing_keys';
 
   static const String _ssssCacheBoxName = 'box_ssss_cache';
 
@@ -150,6 +144,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   static const String _userProfilesBoxName = 'box_user_profiles';
 
   static const String _readReceiptsBoxName = 'box_read_receipts';
+
+  static const String _deviceKeysListBoxName = 'box_device_keys_list';
 
   Database? database;
 
@@ -216,9 +212,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _inboundGroupSessionsUploadQueueBoxName,
         _outboundGroupSessionsBoxName,
         _olmSessionsBoxName,
-        _userDeviceKeysBoxName,
-        _userDeviceKeysOutdatedBoxName,
-        _userCrossSigningKeysBoxName,
+        _legacyUserDeviceKeysBoxName,
+        _legacyUserDeviceKeysOutdatedBoxName,
+        _legacyUserCrossSigningKeysBoxName,
         _ssssCacheBoxName,
         _presencesBoxName,
         _timelineFragmentsBoxName,
@@ -227,6 +223,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _seenDeviceKeysBoxName,
         _userProfilesBoxName,
         _readReceiptsBoxName,
+        _deviceKeysListBoxName,
       },
       sqfliteDatabase: database,
       sqfliteFactory: sqfliteFactory,
@@ -251,13 +248,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       _outboundGroupSessionsBoxName,
     );
     _olmSessionsBox = _collection.openBox(_olmSessionsBoxName);
-    _userDeviceKeysBox = _collection.openBox(_userDeviceKeysBoxName);
-    _userDeviceKeysOutdatedBox = _collection.openBox(
-      _userDeviceKeysOutdatedBoxName,
-    );
-    _userCrossSigningKeysBox = _collection.openBox(
-      _userCrossSigningKeysBoxName,
-    );
     _ssssCacheBox = _collection.openBox(_ssssCacheBoxName);
     _presencesBox = _collection.openBox(_presencesBoxName);
     _timelineFragmentsBox = _collection.openBox(_timelineFragmentsBoxName);
@@ -266,6 +256,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _seenDeviceKeysBox = _collection.openBox(_seenDeviceKeysBoxName);
     _userProfilesBox = _collection.openBox(_userProfilesBoxName);
     _readReceiptsBox = _collection.openBox(_readReceiptsBoxName);
+    _deviceKeysListBox = _collection.openBox(_deviceKeysListBoxName);
 
     // Check version and check if we need a migration
     final currentVersion = int.tryParse(await _clientBox.get('version') ?? '');
@@ -280,6 +271,16 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   Future<void> _migrateFromVersion(int currentVersion) async {
     Logs().i('Migrate store database from version $currentVersion to $version');
+
+    if (currentVersion <= 11) {
+      final deviceKeysLists = await _legacyGetUserDeviceKeys(
+        Client('migrationclient', database: this),
+      );
+      for (final entry in deviceKeysLists.entries) {
+        Logs().d('Migrate user keys', entry.key);
+        await storeDeviceKeysList(entry.key, entry.value);
+      }
+    }
 
     if (version == 8) {
       // Migrate to inbound group sessions upload queue:
@@ -324,9 +325,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _inboundGroupSessionsUploadQueueBox.clearQuickAccessCache();
     _outboundGroupSessionsBox.clearQuickAccessCache();
     _olmSessionsBox.clearQuickAccessCache();
-    _userDeviceKeysBox.clearQuickAccessCache();
-    _userDeviceKeysOutdatedBox.clearQuickAccessCache();
-    _userCrossSigningKeysBox.clearQuickAccessCache();
     _ssssCacheBox.clearQuickAccessCache();
     _presencesBox.clearQuickAccessCache();
     _timelineFragmentsBox.clearQuickAccessCache();
@@ -335,6 +333,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _seenDeviceKeysBox.clearQuickAccessCache();
     _userProfilesBox.clearQuickAccessCache();
     _readReceiptsBox.clearQuickAccessCache();
+    _deviceKeysListBox.clearQuickAccessCache();
 
     await _collection.clear();
   }
@@ -515,11 +514,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = await _userDeviceKeysBox.get(
-      TupleKey(userId, deviceId).toString(),
+    final rawKeys = await getDeviceKeysList(
+      userId,
+      Client('db', database: this),
     );
-    if (raw == null) return <String>[];
-    return <String>[raw['last_sent_message']];
+    return [?rawKeys?.deviceKeys[deviceId]?.lastSentMessage];
   }
 
   @override
@@ -729,61 +728,67 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     return Event.fromJson(copyMap(state), room).asUser;
   }
 
-  @override
-  Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client) =>
-      runBenchmarked<Map<String, DeviceKeysList>>(
-        'Get all user device keys from store',
-        () async {
-          final deviceKeysOutdated = await _userDeviceKeysOutdatedBox
-              .getAllValues();
-          if (deviceKeysOutdated.isEmpty) {
-            return {};
-          }
-          final res = <String, DeviceKeysList>{};
-          final userDeviceKeys = await _userDeviceKeysBox.getAllValues();
-          final userCrossSigningKeys = await _userCrossSigningKeysBox
-              .getAllValues();
-          for (final userId in deviceKeysOutdated.keys) {
-            final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
-              final tupleKey = TupleKey.fromString(tuple);
-              return tupleKey.parts.first == userId;
-            });
-            final crossSigningKeysBoxKeys = userCrossSigningKeys.keys.where((
-              tuple,
-            ) {
-              final tupleKey = TupleKey.fromString(tuple);
-              return tupleKey.parts.first == userId;
-            });
-            final childEntries = deviceKeysBoxKeys.map((key) {
-              final userDeviceKey = userDeviceKeys[key];
-              if (userDeviceKey == null) return null;
-              return copyMap(userDeviceKey);
-            });
-            final crossSigningEntries = crossSigningKeysBoxKeys.map((key) {
-              final crossSigningKey = userCrossSigningKeys[key];
-              if (crossSigningKey == null) return null;
-              return copyMap(crossSigningKey);
-            });
-            res[userId] = DeviceKeysList.fromDbJson(
-              {
-                'client_id': client.id,
-                'user_id': userId,
-                'outdated': deviceKeysOutdated[userId],
-              },
-              childEntries
-                  .where((c) => c != null)
-                  .toList()
-                  .cast<Map<String, dynamic>>(),
-              crossSigningEntries
-                  .where((c) => c != null)
-                  .toList()
-                  .cast<Map<String, dynamic>>(),
-              client,
-            );
-          }
-          return res;
+  /// Only for migration. Can be removed after a certain amount of time.
+  Future<Map<String, DeviceKeysList>> _legacyGetUserDeviceKeys(
+    Client client,
+  ) async {
+    final legacyUserDeviceKeysBox = _collection.openBox(
+      _legacyUserDeviceKeysBoxName,
+    );
+    final legacyUserDeviceKeysOutdatedBox = _collection.openBox(
+      _legacyUserDeviceKeysOutdatedBoxName,
+    );
+    final legacyUserCrossSigningKeysBox = _collection.openBox(
+      _legacyUserCrossSigningKeysBoxName,
+    );
+
+    final deviceKeysOutdated = await legacyUserDeviceKeysOutdatedBox
+        .getAllValues();
+    if (deviceKeysOutdated.isEmpty) {
+      return {};
+    }
+    final res = <String, DeviceKeysList>{};
+    final userDeviceKeys = await legacyUserDeviceKeysBox.getAllValues();
+    final userCrossSigningKeys = await legacyUserCrossSigningKeysBox
+        .getAllValues();
+    for (final userId in deviceKeysOutdated.keys) {
+      final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
+        final tupleKey = TupleKey.fromString(tuple);
+        return tupleKey.parts.first == userId;
+      });
+      final crossSigningKeysBoxKeys = userCrossSigningKeys.keys.where((tuple) {
+        final tupleKey = TupleKey.fromString(tuple);
+        return tupleKey.parts.first == userId;
+      });
+      final childEntries = deviceKeysBoxKeys.map((key) {
+        final userDeviceKey = userDeviceKeys[key];
+        if (userDeviceKey == null) return null;
+        return copyMap(userDeviceKey);
+      });
+      final crossSigningEntries = crossSigningKeysBoxKeys.map((key) {
+        final crossSigningKey = userCrossSigningKeys[key];
+        if (crossSigningKey == null) return null;
+        return copyMap(crossSigningKey);
+      });
+      res[userId] = DeviceKeysList.fromDbJson(
+        {
+          'client_id': client.id,
+          'user_id': userId,
+          'outdated': deviceKeysOutdated[userId],
         },
+        childEntries
+            .where((c) => c != null)
+            .toList()
+            .cast<Map<String, dynamic>>(),
+        crossSigningEntries
+            .where((c) => c != null)
+            .toList()
+            .cast<Map<String, dynamic>>(),
+        client,
       );
+    }
+    return res;
+  }
 
   @override
   Future<List<User>> getUsers(Room room) async {
@@ -928,16 +933,18 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String publicKey,
   ) async {
-    await _userCrossSigningKeysBox.delete(
-      TupleKey(userId, publicKey).toString(),
-    );
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys.remove(publicKey);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
   Future<void> removeUserDeviceKey(String userId, String deviceId) async {
-    await _userDeviceKeysBox.delete(TupleKey(userId, deviceId).toString());
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys.remove(deviceId);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -946,18 +953,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String publicKey,
   ) async {
-    final raw = copyMap(
-      await _userCrossSigningKeysBox.get(
-            TupleKey(userId, publicKey).toString(),
-          ) ??
-          {},
-    );
-    raw['blocked'] = blocked;
-    await _userCrossSigningKeysBox.put(
-      TupleKey(userId, publicKey).toString(),
-      raw,
-    );
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys[publicKey]?.blocked = blocked;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -966,12 +965,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['blocked'] = blocked;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.blocked = blocked;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -980,12 +977,12 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.lastActive = DateTime.fromMillisecondsSinceEpoch(
+      lastActive,
     );
-
-    raw['last_active'] = lastActive;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -994,11 +991,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['last_sent_message'] = lastSentMessage;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.lastSentMessage = lastSentMessage;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1022,21 +1018,16 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String publicKey, {
     DateTime? trustOnFirstUseSince,
   }) async {
-    final raw = copyMap(
-      (await _userCrossSigningKeysBox.get(
-            TupleKey(userId, publicKey).toString(),
-          )) ??
-          {},
-    );
-    raw['verified'] = verified;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
+    keys.crossSigningKeys[publicKey]?.setDirectVerified(verified);
     if (trustOnFirstUseSince != null) {
-      raw['tofu'] = trustOnFirstUseSince.millisecondsSinceEpoch;
+      keys.crossSigningKeys[publicKey]?.trustOnFirstUse(
+        since: trustOnFirstUseSince,
+        updateInDatabase: false,
+      );
     }
-    await _userCrossSigningKeysBox.put(
-      TupleKey(userId, publicKey).toString(),
-      raw,
-    );
-    return;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1045,12 +1036,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final raw = copyMap(
-      await _userDeviceKeysBox.get(TupleKey(userId, deviceId).toString()) ?? {},
-    );
-    raw['verified'] = verified;
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), raw);
-    return;
+    final keys = await getDeviceKeysList(userId, Client('db', database: this));
+    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
+    keys.deviceKeys[deviceId]?.setDirectVerified(verified);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1363,7 +1352,11 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     bool blocked, {
     DateTime? trustOnFirstUseSince,
   }) async {
-    await _userCrossSigningKeysBox.put(TupleKey(userId, publicKey).toString(), {
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+    keys.crossSigningKeys[publicKey] = CrossSigningKey.fromDbJson({
       'user_id': userId,
       'public_key': publicKey,
       'content': content,
@@ -1371,7 +1364,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       'blocked': blocked,
       if (trustOnFirstUseSince != null)
         'tofu': trustOnFirstUseSince.millisecondsSinceEpoch,
-    });
+    }, tmpClient);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1383,22 +1377,31 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     bool blocked,
     int lastActive,
   ) async {
-    await _userDeviceKeysBox.put(TupleKey(userId, deviceId).toString(), {
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+
+    keys.deviceKeys[deviceId] = DeviceKeys.fromDb({
       'user_id': userId,
       'device_id': deviceId,
       'content': content,
       'verified': verified,
       'blocked': blocked,
       'last_active': lastActive,
-      'last_sent_message': '',
-    });
-    return;
+      'last_sent_message': keys.deviceKeys[deviceId]?.lastSentMessage ?? '',
+    }, tmpClient);
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
   Future<void> storeUserDeviceKeysInfo(String userId, bool outdated) async {
-    await _userDeviceKeysOutdatedBox.put(userId, outdated);
-    return;
+    final tmpClient = Client('db', database: this);
+    final keys =
+        await getDeviceKeysList(userId, tmpClient) ??
+        DeviceKeysList(userId, tmpClient);
+    keys.outdated = outdated;
+    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1561,11 +1564,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       _outboundGroupSessionsBoxName: await _outboundGroupSessionsBox
           .getAllValues(),
       _olmSessionsBoxName: await _olmSessionsBox.getAllValues(),
-      _userDeviceKeysBoxName: await _userDeviceKeysBox.getAllValues(),
-      _userDeviceKeysOutdatedBoxName: await _userDeviceKeysOutdatedBox
-          .getAllValues(),
-      _userCrossSigningKeysBoxName: await _userCrossSigningKeysBox
-          .getAllValues(),
+      _deviceKeysListBoxName: await _deviceKeysListBox.getAllValues(),
       _ssssCacheBoxName: await _ssssCacheBox.getAllValues(),
       _presencesBoxName: await _presencesBox.getAllValues(),
       _timelineFragmentsBoxName: await _timelineFragmentsBox.getAllValues(),
@@ -1635,20 +1634,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       for (final key in json[_olmSessionsBoxName]!.keys) {
         await _olmSessionsBox.put(key, json[_olmSessionsBoxName]![key]);
       }
-      for (final key in json[_userDeviceKeysBoxName]!.keys) {
-        await _userDeviceKeysBox.put(key, json[_userDeviceKeysBoxName]![key]);
-      }
-      for (final key in json[_userDeviceKeysOutdatedBoxName]!.keys) {
-        await _userDeviceKeysOutdatedBox.put(
-          key,
-          json[_userDeviceKeysOutdatedBoxName]![key],
-        );
-      }
-      for (final key in json[_userCrossSigningKeysBoxName]!.keys) {
-        await _userCrossSigningKeysBox.put(
-          key,
-          json[_userCrossSigningKeysBoxName]![key],
-        );
+      for (final key in json[_deviceKeysListBoxName]!.keys) {
+        await _deviceKeysListBox.put(key, json[_deviceKeysListBoxName]![key]);
       }
       for (final key in json[_ssssCacheBoxName]!.keys) {
         await _ssssCacheBox.put(key, json[_ssssCacheBoxName]![key]);
@@ -1798,6 +1785,36 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String roomId,
     LatestReceiptState receiptState,
   ) => _readReceiptsBox.put(roomId, receiptState.toJson());
+
+  @override
+  Future<DeviceKeysList?> getDeviceKeysList(
+    String userId,
+    Client client,
+  ) async {
+    final raw = await _deviceKeysListBox.get(userId);
+    if (raw == null) return null;
+    final json = copyMap(raw);
+    return DeviceKeysList.fromJson(json, client);
+  }
+
+  @override
+  Future<void> storeDeviceKeysList(
+    String userId,
+    DeviceKeysList deviceKeysList,
+  ) => _deviceKeysListBox.put(userId, deviceKeysList.toJson());
+
+  @override
+  Future<Map<String, DeviceKeysList>> getUserDeviceKeys(Client client) async {
+    final raw = await _deviceKeysListBox.getAllValues();
+    return raw.map((k, v) {
+      try {
+        return MapEntry(k, DeviceKeysList.fromJson(copyMap(v), client));
+      } catch (e, s) {
+        Logs().w('Unable to parse device keys list for $k', e, s);
+        return MapEntry(k, DeviceKeysList(k, client, outdated: true));
+      }
+    });
+  }
 }
 
 class TupleKey {

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -83,6 +83,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
 
   late Box<Map> _deviceKeysListBox;
 
+  /// Is a Tuple(userId, deviceId) to the last sent message as a json map:
+  late Box<String> _lastSentOlmMessagesBox;
+
   @override
   final int maxFileSize;
 
@@ -146,6 +149,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   static const String _readReceiptsBoxName = 'box_read_receipts';
 
   static const String _deviceKeysListBoxName = 'box_device_keys_list';
+
+  static const String _lastSentOlmMessagesBoxName =
+      'box_last_sent_olm_messages';
 
   Database? database;
 
@@ -224,6 +230,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         _userProfilesBoxName,
         _readReceiptsBoxName,
         _deviceKeysListBoxName,
+        _lastSentOlmMessagesBoxName,
       },
       sqfliteDatabase: database,
       sqfliteFactory: sqfliteFactory,
@@ -257,6 +264,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _userProfilesBox = _collection.openBox(_userProfilesBoxName);
     _readReceiptsBox = _collection.openBox(_readReceiptsBoxName);
     _deviceKeysListBox = _collection.openBox(_deviceKeysListBoxName);
+    _lastSentOlmMessagesBox = _collection.openBox(_lastSentOlmMessagesBoxName);
 
     // Check version and check if we need a migration
     final currentVersion = int.tryParse(await _clientBox.get('version') ?? '');
@@ -334,6 +342,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     _userProfilesBox.clearQuickAccessCache();
     _readReceiptsBox.clearQuickAccessCache();
     _deviceKeysListBox.clearQuickAccessCache();
+    _lastSentOlmMessagesBox.clearQuickAccessCache();
 
     await _collection.clear();
   }
@@ -514,11 +523,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String userId,
     String deviceId,
   ) async {
-    final rawKeys = await getDeviceKeysList(
-      userId,
-      Client('db', database: this),
+    final messageStr = await _lastSentOlmMessagesBox.get(
+      TupleKey(userId, deviceId).toString(),
     );
-    return [?rawKeys?.deviceKeys[deviceId]?.lastSentMessage];
+    return [?messageStr];
   }
 
   @override
@@ -728,7 +736,8 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     return Event.fromJson(copyMap(state), room).asUser;
   }
 
-  /// Only for migration. Can be removed after a certain amount of time.
+  /// Only for migration. Can be removed after a certain amount of time. Also
+  /// clears everything from the old boxes!
   Future<Map<String, DeviceKeysList>> _legacyGetUserDeviceKeys(
     Client client,
   ) async {
@@ -751,6 +760,14 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     final userDeviceKeys = await legacyUserDeviceKeysBox.getAllValues();
     final userCrossSigningKeys = await legacyUserCrossSigningKeysBox
         .getAllValues();
+
+    // Migrate lastSentMessages
+    for (final entry in userDeviceKeys.entries) {
+      final lastSentMessage = entry.value['last_sent_message'];
+      if (lastSentMessage is! String || lastSentMessage.isEmpty) continue;
+      await _lastSentOlmMessagesBox.put(entry.key, lastSentMessage);
+    }
+
     for (final userId in deviceKeysOutdated.keys) {
       final deviceKeysBoxKeys = userDeviceKeys.keys.where((tuple) {
         final tupleKey = TupleKey.fromString(tuple);
@@ -787,6 +804,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         client,
       );
     }
+    legacyUserDeviceKeysBox.clear();
+    legacyUserCrossSigningKeysBox.clear();
+    legacyUserDeviceKeysOutdatedBox.clear();
     return res;
   }
 
@@ -929,49 +949,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> removeUserCrossSigningKey(
-    String userId,
-    String publicKey,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys.remove(publicKey);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> removeUserDeviceKey(String userId, String deviceId) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys.remove(deviceId);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setBlockedUserCrossSigningKey(
-    bool blocked,
-    String userId,
-    String publicKey,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys[publicKey]?.blocked = blocked;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setBlockedUserDeviceKey(
-    bool blocked,
-    String userId,
-    String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.blocked = blocked;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
   Future<void> setLastActiveUserDeviceKey(
     int lastActive,
     String userId,
@@ -990,12 +967,10 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     String lastSentMessage,
     String userId,
     String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.lastSentMessage = lastSentMessage;
-    await storeDeviceKeysList(userId, keys);
-  }
+  ) => _lastSentOlmMessagesBox.put(
+    TupleKey(userId, deviceId).toString(),
+    lastSentMessage,
+  );
 
   @override
   Future<void> setRoomPrevBatch(
@@ -1009,37 +984,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
     room.prev_batch = prevBatch;
     await _roomsBox.put(roomId, room.toJson());
     return;
-  }
-
-  @override
-  Future<void> setVerifiedUserCrossSigningKey(
-    bool verified,
-    String userId,
-    String publicKey, {
-    DateTime? trustOnFirstUseSince,
-  }) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.crossSigningKeys.containsKey(publicKey)) return;
-    keys.crossSigningKeys[publicKey]?.setDirectVerified(verified);
-    if (trustOnFirstUseSince != null) {
-      keys.crossSigningKeys[publicKey]?.trustOnFirstUse(
-        since: trustOnFirstUseSince,
-        updateInDatabase: false,
-      );
-    }
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> setVerifiedUserDeviceKey(
-    bool verified,
-    String userId,
-    String deviceId,
-  ) async {
-    final keys = await getDeviceKeysList(userId, Client('db', database: this));
-    if (keys == null || !keys.deviceKeys.containsKey(deviceId)) return;
-    keys.deviceKeys[deviceId]?.setDirectVerified(verified);
-    await storeDeviceKeysList(userId, keys);
   }
 
   @override
@@ -1340,67 +1284,6 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
   }
 
   @override
-  Future<void> storeUserCrossSigningKey(
-    String userId,
-    String publicKey,
-    String content,
-    bool verified,
-    bool blocked, {
-    DateTime? trustOnFirstUseSince,
-  }) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-    keys.crossSigningKeys[publicKey] = CrossSigningKey.fromDbJson({
-      'user_id': userId,
-      'public_key': publicKey,
-      'content': content,
-      'verified': verified,
-      'blocked': blocked,
-      if (trustOnFirstUseSince != null)
-        'tofu': trustOnFirstUseSince.millisecondsSinceEpoch,
-    }, tmpClient);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> storeUserDeviceKey(
-    String userId,
-    String deviceId,
-    String content,
-    bool verified,
-    bool blocked,
-    int lastActive,
-  ) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-
-    keys.deviceKeys[deviceId] = DeviceKeys.fromDb({
-      'user_id': userId,
-      'device_id': deviceId,
-      'content': content,
-      'verified': verified,
-      'blocked': blocked,
-      'last_active': lastActive,
-      'last_sent_message': keys.deviceKeys[deviceId]?.lastSentMessage ?? '',
-    }, tmpClient);
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
-  Future<void> storeUserDeviceKeysInfo(String userId, bool outdated) async {
-    final tmpClient = Client('db', database: this);
-    final keys =
-        await getDeviceKeysList(userId, tmpClient) ??
-        DeviceKeysList(userId, tmpClient);
-    keys.outdated = outdated;
-    await storeDeviceKeysList(userId, keys);
-  }
-
-  @override
   Future<void> transaction(Future<void> Function() action) =>
       _collection.transaction(action);
 
@@ -1561,6 +1444,7 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
           .getAllValues(),
       _olmSessionsBoxName: await _olmSessionsBox.getAllValues(),
       _deviceKeysListBoxName: await _deviceKeysListBox.getAllValues(),
+      _lastSentOlmMessagesBoxName: await _lastSentOlmMessagesBox.getAllValues(),
       _ssssCacheBoxName: await _ssssCacheBox.getAllValues(),
       _presencesBoxName: await _presencesBox.getAllValues(),
       _timelineFragmentsBoxName: await _timelineFragmentsBox.getAllValues(),
@@ -1632,6 +1516,12 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
       }
       for (final key in json[_deviceKeysListBoxName]!.keys) {
         await _deviceKeysListBox.put(key, json[_deviceKeysListBoxName]![key]);
+      }
+      for (final key in json[_lastSentOlmMessagesBoxName]!.keys) {
+        await _lastSentOlmMessagesBox.put(
+          key,
+          json[_lastSentOlmMessagesBoxName]![key],
+        );
       }
       for (final key in json[_ssssCacheBoxName]!.keys) {
         await _ssssCacheBox.put(key, json[_ssssCacheBoxName]![key]);

--- a/lib/src/database/matrix_sdk_database.dart
+++ b/lib/src/database/matrix_sdk_database.dart
@@ -804,9 +804,9 @@ class MatrixSdkDatabase extends DatabaseApi with DatabaseFileStorage {
         client,
       );
     }
-    legacyUserDeviceKeysBox.clear();
-    legacyUserCrossSigningKeysBox.clear();
-    legacyUserDeviceKeysOutdatedBox.clear();
+    await legacyUserDeviceKeysBox.clear();
+    await legacyUserCrossSigningKeysBox.clear();
+    await legacyUserDeviceKeysOutdatedBox.clear();
     return res;
   }
 

--- a/lib/src/utils/device_keys_list.dart
+++ b/lib/src/utils/device_keys_list.dart
@@ -122,6 +122,37 @@ class DeviceKeysList {
     }
   }
 
+  Map<String, Object?> toJson() => {
+    'user_id': userId,
+    'outdated': outdated,
+    'device_keys': deviceKeys.map((k, v) => MapEntry(k, v.toDbJson())),
+    'cross_signing_keys': crossSigningKeys.map(
+      (k, v) => MapEntry(k, v.toDbJson()),
+    ),
+  };
+
+  factory DeviceKeysList.fromJson(Map<String, Object?> json, Client client) =>
+      DeviceKeysList(
+        json['user_id'] as String,
+        client,
+        outdated: json['outdated'] as bool,
+        deviceKeys: (json['device_keys'] as Map).map(
+          (k, v) => MapEntry(
+            k as String,
+            DeviceKeys.fromDb(Map<String, dynamic>.from(v as Map), client),
+          ),
+        ),
+        crossSigningKeys: (json['cross_signing_keys'] as Map).map(
+          (k, v) => MapEntry(
+            k as String,
+            CrossSigningKey.fromDbJson(
+              Map<String, dynamic>.from(v as Map),
+              client,
+            ),
+          ),
+        ),
+      );
+
   DeviceKeysList.fromDbJson(
     Map<String, dynamic> dbEntry,
     List<Map<String, dynamic>> childEntries,
@@ -152,7 +183,14 @@ class DeviceKeysList {
     }
   }
 
-  DeviceKeysList(this.userId, this.client);
+  DeviceKeysList(
+    this.userId,
+    this.client, {
+    this.outdated = true,
+    Map<String, CrossSigningKey>? crossSigningKeys,
+    Map<String, DeviceKeys>? deviceKeys,
+  }) : crossSigningKeys = crossSigningKeys ?? {},
+       deviceKeys = deviceKeys ?? {};
 }
 
 class SimpleSignableKey extends MatrixSignableKey {
@@ -486,6 +524,15 @@ class CrossSigningKey extends SignableKey {
       identifier = keys.values.first;
     }
   }
+
+  Map<String, Object?> toDbJson() => {
+    'user_id': userId,
+    'public_key': identifier,
+    'content': json.encode(toJson()),
+    'verified': _verified ?? false,
+    'blocked': _blocked ?? false,
+    'tofu': ?_trustOnFirstUseSince?.millisecondsSinceEpoch,
+  };
 }
 
 class DeviceKeys extends SignableKey {
@@ -495,6 +542,7 @@ class DeviceKeys extends SignableKey {
   String? get deviceId => identifier;
   late List<String> algorithms;
   late DateTime lastActive;
+  String lastSentMessage = '';
 
   String? get curve25519Key => keys['curve25519:$deviceId'];
   String? get deviceDisplayName =>
@@ -574,6 +622,7 @@ class DeviceKeys extends SignableKey {
     lastActive = DateTime.fromMillisecondsSinceEpoch(
       dbEntry['last_active'] ?? 0,
     );
+    lastSentMessage = dbEntry['last_sent_message'] as String? ?? '';
   }
 
   DeviceKeys.fromJson(Map<String, dynamic> json, Client client)
@@ -603,4 +652,14 @@ class DeviceKeys extends SignableKey {
     encryption.keyVerificationManager.addRequest(request);
     return request;
   }
+
+  Map<String, Object?> toDbJson() => {
+    'user_id': userId,
+    'device_id': identifier,
+    'content': json.encode(toJson()),
+    'verified': _verified ?? false,
+    'blocked': _blocked ?? false,
+    'last_active': lastActive.millisecondsSinceEpoch,
+    'last_sent_message': lastSentMessage,
+  };
 }

--- a/lib/src/utils/device_keys_list.dart
+++ b/lib/src/utils/device_keys_list.dart
@@ -207,6 +207,11 @@ abstract class SignableKey extends MatrixSignableKey {
   bool? _verified;
   bool? _blocked;
 
+  Future<void> _updateInDatabase() => client.database.storeDeviceKeysList(
+    userId,
+    client.userDeviceKeys[userId]!,
+  );
+
   String? get ed25519Key => keys['ed25519:$identifier'];
   bool get verified =>
       identifier != null && (directVerified || crossVerified) && !(blocked);
@@ -451,15 +456,10 @@ class CrossSigningKey extends SignableKey {
     bool updateInDatabase = true,
   }) async {
     since ??= DateTime.now();
-    if (updateInDatabase) {
-      await client.database.setVerifiedUserCrossSigningKey(
-        verified,
-        userId,
-        publicKey!,
-        trustOnFirstUseSince: since,
-      );
-    }
     _trustOnFirstUseSince = since;
+    if (updateInDatabase) {
+      await _updateInDatabase();
+    }
   }
 
   @override
@@ -468,12 +468,7 @@ class CrossSigningKey extends SignableKey {
       throw Exception('setVerified called on invalid key');
     }
     await super.setVerified(newVerified, sign);
-    await client.database.setVerifiedUserCrossSigningKey(
-      newVerified,
-      userId,
-      publicKey!,
-      trustOnFirstUseSince: trustOnFirstUseSince,
-    );
+    await _updateInDatabase();
   }
 
   @override
@@ -482,11 +477,7 @@ class CrossSigningKey extends SignableKey {
       throw Exception('setBlocked called on invalid key');
     }
     _blocked = newBlocked;
-    await client.database.setBlockedUserCrossSigningKey(
-      newBlocked,
-      userId,
-      publicKey!,
-    );
+    await _updateInDatabase();
   }
 
   CrossSigningKey.fromMatrixCrossSigningKey(
@@ -542,7 +533,6 @@ class DeviceKeys extends SignableKey {
   String? get deviceId => identifier;
   late List<String> algorithms;
   late DateTime lastActive;
-  String lastSentMessage = '';
 
   String? get curve25519Key => keys['curve25519:$deviceId'];
   String? get deviceDisplayName =>
@@ -581,11 +571,7 @@ class DeviceKeys extends SignableKey {
       throw Exception('setVerified called on invalid key');
     }
     await super.setVerified(newVerified, sign);
-    await client.database.setVerifiedUserDeviceKey(
-      newVerified,
-      userId,
-      deviceId!,
-    );
+    await _updateInDatabase();
   }
 
   @override
@@ -594,11 +580,7 @@ class DeviceKeys extends SignableKey {
       throw Exception('setBlocked called on invalid key');
     }
     _blocked = newBlocked;
-    await client.database.setBlockedUserDeviceKey(
-      newBlocked,
-      userId,
-      deviceId!,
-    );
+    await _updateInDatabase();
   }
 
   DeviceKeys.fromMatrixDeviceKeys(
@@ -622,7 +604,6 @@ class DeviceKeys extends SignableKey {
     lastActive = DateTime.fromMillisecondsSinceEpoch(
       dbEntry['last_active'] ?? 0,
     );
-    lastSentMessage = dbEntry['last_sent_message'] as String? ?? '';
   }
 
   DeviceKeys.fromJson(Map<String, dynamic> json, Client client)
@@ -660,6 +641,5 @@ class DeviceKeys extends SignableKey {
     'verified': _verified ?? false,
     'blocked': _blocked ?? false,
     'last_active': lastActive.millisecondsSinceEpoch,
-    'last_sent_message': lastSentMessage,
   };
 }

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -595,7 +595,12 @@ void main() {
         await database.storeUserCrossSigningKey(
           '@alice:example.com',
           'publicKey',
-          '{}',
+          jsonEncode({
+            'user_id': '@alice:example.com',
+            'usage': ['master'],
+            'keys': {'ed25519:publicKey': 'publicKey'},
+            'signatures': <String, Object?>{},
+          }),
           false,
           false,
         );
@@ -639,7 +644,25 @@ void main() {
         await database.storeUserDeviceKey(
           '@alice:example.com',
           'deviceId',
-          '{}',
+          jsonEncode({
+            'user_id': '@alice:example.com',
+            'device_id': 'deviceId',
+            'algorithms': [
+              AlgorithmTypes.olmV1Curve25519AesSha2,
+              AlgorithmTypes.megolmV1AesSha2,
+            ],
+            'keys': {
+              'curve25519:deviceId':
+                  '3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI',
+              'ed25519:deviceId': 'lEuiRJBit0IG6nUf5pUzWTUEsRVVe/HJkoKuEww9ULI',
+            },
+            'signatures': {
+              '@alice:example.com': {
+                'ed25519:deviceId':
+                    'dSO80A01XiigH3uBiDVx/EjzaoycHcjq9lfQX0uWsqxl2giMIiSPR8a4d291W1ihKJL/a+myXS367WT6NAIcBA',
+              },
+            },
+          }),
           false,
           false,
           0,

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -591,44 +591,6 @@ void main() {
           Client('testclient', database: await getMatrixSdkDatabase()),
         );
       });
-      test('storeUserCrossSigningKey', () async {
-        await database.storeUserCrossSigningKey(
-          '@alice:example.com',
-          'publicKey',
-          jsonEncode({
-            'user_id': '@alice:example.com',
-            'usage': ['master'],
-            'keys': {'ed25519:publicKey': 'publicKey'},
-            'signatures': <String, Object?>{},
-          }),
-          false,
-          false,
-        );
-      });
-      test('setVerifiedUserCrossSigningKey', () async {
-        await database.setVerifiedUserCrossSigningKey(
-          true,
-          '@alice:example.com',
-          'publicKey',
-          trustOnFirstUseSince: DateTime(2000),
-        );
-      });
-      test('setBlockedUserCrossSigningKey', () async {
-        await database.setBlockedUserCrossSigningKey(
-          true,
-          '@alice:example.com',
-          'publicKey',
-        );
-      });
-      test('removeUserCrossSigningKey', () async {
-        await database.removeUserCrossSigningKey(
-          '@alice:example.com',
-          'publicKey',
-        );
-      });
-      test('storeUserDeviceKeysInfo', () async {
-        await database.storeUserDeviceKeysInfo('@alice:example.com', true);
-      });
       test('storeUserDeviceKeysInfo', () async {
         var cache = await database.getCustomCacheObject('test');
         expect(cache, null);
@@ -639,48 +601,6 @@ void main() {
         await database.clearCache();
         cache = await database.getCustomCacheObject('test');
         expect(cache, null);
-      });
-      test('storeUserDeviceKey', () async {
-        await database.storeUserDeviceKey(
-          '@alice:example.com',
-          'deviceId',
-          jsonEncode({
-            'user_id': '@alice:example.com',
-            'device_id': 'deviceId',
-            'algorithms': [
-              AlgorithmTypes.olmV1Curve25519AesSha2,
-              AlgorithmTypes.megolmV1AesSha2,
-            ],
-            'keys': {
-              'curve25519:deviceId':
-                  '3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI',
-              'ed25519:deviceId': 'lEuiRJBit0IG6nUf5pUzWTUEsRVVe/HJkoKuEww9ULI',
-            },
-            'signatures': {
-              '@alice:example.com': {
-                'ed25519:deviceId':
-                    'dSO80A01XiigH3uBiDVx/EjzaoycHcjq9lfQX0uWsqxl2giMIiSPR8a4d291W1ihKJL/a+myXS367WT6NAIcBA',
-              },
-            },
-          }),
-          false,
-          false,
-          0,
-        );
-      });
-      test('setVerifiedUserDeviceKey', () async {
-        await database.setVerifiedUserDeviceKey(
-          true,
-          '@alice:example.com',
-          'deviceId',
-        );
-      });
-      test('setBlockedUserDeviceKey', () async {
-        await database.setBlockedUserDeviceKey(
-          true,
-          '@alice:example.com',
-          'deviceId',
-        );
       });
       test('getStorePresences', () async {
         const userId = '@alice:example.com';

--- a/test/database_api_test.dart
+++ b/test/database_api_test.dart
@@ -615,6 +615,21 @@ void main() {
         final storedPresence = await database.getPresence(userId);
         expect(presence.toJson(), storedPresence?.toJson());
       });
+      test('storeDeviceKeysLists', () async {
+        final tmpClient = Client('test', database: database);
+        await database.storeDeviceKeysList(
+          '@alice:example.com',
+          DeviceKeysList('@alice:example.com', tmpClient),
+        );
+        final keys = await database.getDeviceKeysList(
+          '@alice:example.com',
+          tmpClient,
+        );
+        expect(keys?.userId, '@alice:example.com');
+        expect(keys?.outdated, true);
+        expect(keys?.crossSigningKeys, {});
+        expect(keys?.deviceKeys, {});
+      });
       test('storeUserProfile', () async {
         final profile1 = await database.getUserProfile('@alice:example.com');
         expect(profile1, null);

--- a/test/device_keys_list_test.dart
+++ b/test/device_keys_list_test.dart
@@ -76,6 +76,17 @@ void main() async {
       final crossKey = CrossSigningKey.fromJson(rawJson, client);
       expect(json.encode(crossKey.toJson()), json.encode(rawJson));
       expect(crossKey.usage.first, 'master');
+      final deviceKeysList = DeviceKeysList(
+        '@alice:example.com',
+        client,
+        outdated: false,
+        crossSigningKeys: {'master': crossKey},
+        deviceKeys: {'JLAFKJWSCS': key},
+      );
+      expect(
+        deviceKeysList.toJson(),
+        DeviceKeysList.fromJson(deviceKeysList.toJson(), client).toJson(),
+      );
     });
 
     test('reject devices without self-signature', () async {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches E2EE device/cross-signing key persistence, verification/blocked flags, and a schema migration (DB v12). A bad migrate or serialize path can lose trust state or break encryption.
> 
> **Overview**
> Replaces per-device / per-cross-signing Hive boxes with a single `storeDeviceKeysList` / `getDeviceKeysList` API so a user's full `DeviceKeysList` is written as one JSON document.
> 
> `updateUserDeviceKeys` now batches one persist per user after applying `/keys/query` results (including dropping unused devices and old cross-signing keys of the same usage). Verify/block/TOFU updates rewrite the whole list via `_updateInDatabase`. Last-sent Olm messages move to their own box.
> 
> Schema version is **12**. Existing stores migrate from the three legacy boxes (and last-sent fields) into the new layout, then clear the old boxes. Dump/import and tests follow the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519ebfe76807e4f2fbe0fe5fc85348e2153c7db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->