### PR TITLE
fix: read fresh keys in IndexedDB Box.getAllValues

### DIFF
--- a/lib/src/database/indexeddb_box.dart
+++ b/lib/src/database/indexeddb_box.dart
@@ -188,6 +188,18 @@ class Box<V> {
   Future<List<String>> getAllKeys([IDBTransaction? txn]) async {
     if (_quickAccessCachedKeys != null) return _quickAccessCachedKeys!.toList();
     txn ??= boxCollection._db.transaction(name.toJS, 'readonly');
+    final keys = await _getAllKeysFromStore(txn);
+    _quickAccessCachedKeys = keys.toSet();
+    return keys;
+  }
+
+  /// Reads the keys from the object store, bypassing [_quickAccessCachedKeys].
+  ///
+  /// [put] and [delete] keep the cached key set complete, but in their own
+  /// mutation order rather than in the store's key order, while
+  /// [IDBObjectStore.getAll] always returns the values in key order. So only
+  /// freshly read keys may be zipped against those values.
+  Future<List<String>> _getAllKeysFromStore(IDBTransaction txn) async {
     final store = txn.objectStore(name);
     final getAllKeysCompleter = Completer();
     final request = store.getAllKeys();
@@ -201,9 +213,7 @@ class Box<V> {
       getAllKeysCompleter.complete();
     }.toJS;
     await getAllKeysCompleter.future;
-    final keys = (request.result?.dartify() as List?)?.cast<String>() ?? [];
-    _quickAccessCachedKeys = keys.toSet();
-    return keys;
+    return (request.result?.dartify() as List?)?.cast<String>() ?? [];
   }
 
   Future<Map<String, V>> getAllValues([IDBTransaction? txn]) async {
@@ -214,7 +224,8 @@ class Box<V> {
     /// NOTE: This is a workaround to get the keys as [IDBObjectStore.getAll()]
     /// only returns the values as a list.
     /// And using the [IDBObjectStore.openCursor()] method is not working as expected.
-    final keys = await getAllKeys(txn);
+    final keys = await _getAllKeysFromStore(txn);
+    _quickAccessCachedKeys = keys.toSet();
 
     final getAllValuesCompleter = Completer();
     final getAllValuesRequest = store.getAll();

--- a/test/box_test.dart
+++ b/test/box_test.dart
@@ -58,6 +58,24 @@ void main() {
       await box.clear();
     });
 
+    test(
+      'Box.getAllValues with a key added after the keys were cached',
+      () async {
+        final box = collection.openBox<Map>('cats');
+        await box.put('fluffy', data);
+
+        // Populate the key cache, like any earlier read from the box does.
+        expect(await box.getAllKeys(), ['fluffy']);
+
+        // 'alpha' sorts before 'fluffy', so the order the keys were written in
+        // differs from the order the box stores them in.
+        await box.put('alpha', data2);
+
+        expect(await box.getAllValues(), {'fluffy': data, 'alpha': data2});
+        await box.clear();
+      },
+    );
+
     test('Box.delete', () async {
       final box = collection.openBox<Map>('cats');
       await box.put('fluffy', data);


### PR DESCRIPTION
## Summary

- `Box.getAllValues()` zipped keys from `getAllKeys()` against values from `IDBObjectStore.getAll()`. Once `_quickAccessCachedKeys` is populated, `getAllKeys()` returns it in the order `put`/`delete` mutated it, while `getAll()` always returns values in key order — so every value landed under the wrong key as soon as a new key was written during the session.
- `getAllValues()` now reads the keys straight from the object store, so keys and values come from the same enumeration. Web only; `sqflite_box` already selects both columns in one query.

Real-world impact: on web, `Client.refreshAccessToken()` read `refresh_token` out of the client box and got the `homeserver_url` value instead, so the routine pre-expiry refresh posted the homeserver URL as the refresh token. Synapse answered `M_UNKNOWN_TOKEN: invalid refresh token` and the SDK cleared the session, logging the user out mid-session roughly every access-token lifetime. `Client.init()` restores `homeserver`, `accessToken`, `user_id` and `device_id` from that same map, so the blast radius was wider than refresh alone.

The first read after a page load was always correct (the key cache starts empty), which is why sessions worked until enough keys — `custom_cache_*`, `sync_filter_id`, `prev_batch` — had been written to shift the offset.

## Test plan

- [x] `dart test test/box_test.dart --platform chrome` — 11/11 pass
- [x] New test fails without the fix: `Expected: {'fluffy': Fluffy, 'alpha': Loki}` / `Actual: {'fluffy': Loki, 'alpha': Fluffy}`. The existing `Box.getAllValues` test could not catch this because its keys are inserted in sorted order.
- [x] Verified end to end in the Famedly web app against this branch: refresh at the soft-logout boundary now logs `Access token has been refreshed` and returns to `LoginState.loggedIn` with a renewed expiry, instead of `M_UNKNOWN_TOKEN` followed by a cleared session.
- [ ] CI green