### PR TITLE
fix(scripts): fail prepare_vodozemac.sh when the build fails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,22 +29,40 @@ root fails (the example needs the Flutter SDK). Use `dart pub get --no-example` 
 `flutter pub get`, which the shared `dart` CI template uses). All plain-dart CI jobs
 in `.github/workflows/integrate.yml` pass `--no-example`.
 
-Toolchain already provided by the VM snapshot (do not reinstall): Dart SDK 3.11.1 (on
-`PATH` as `dart`, pinned to `.github/workflows/versions.env`; the repo requires SDK
-`>=3.11.0`), the Rust toolchain (`cargo`), Docker, mikefarah `yq` (at
-`/usr/local/bin/yq` — required by `scripts/prepare_vodozemac.sh`; note the distro's
-`/usr/bin/yq` is the incompatible python `yq`), and `libsqlite3-dev`/`lcov`. The update
-script fetches dependencies with `dart pub get --no-example` (plain `dart pub get`
-fails on the Flutter example, see above).
+The Dart SDK version is pinned by `dart_version` in `.github/workflows/versions.env`
+(currently 3.12.2), which is what CI feeds to `dart-lang/setup-dart`. Environment setup
+installs exactly that version into `/usr/local/lib/dart-sdk` (symlinked as
+`/usr/local/bin/dart`), so the VM follows the pin whenever it moves. An SDK older than
+the pin cannot resolve dependencies: the `sqflite_common_ffi` dev dependency tracks new
+SDKs aggressively, so `dart pub get` then dies with `version solving failed`. To switch
+by hand, unpack
+`https://storage.googleapis.com/dart-archive/channels/stable/release/<dart_version>/sdk/dartsdk-linux-x64-release.zip`
+over `/usr/local/lib/dart-sdk`.
+
+Other toolchain provided by the VM snapshot (do not reinstall): the Rust toolchain via
+`rustup` (`CARGO_HOME=/usr/local/cargo`, `RUSTUP_HOME=/usr/local/rustup`, default
+toolchain `stable`), Docker, mikefarah `yq` (at `/usr/local/bin/yq` — required by
+`scripts/prepare_vodozemac.sh`; note the distro's `/usr/bin/yq` is the incompatible
+python `yq`), and `libsqlite3-dev`/`lcov`. Environment setup fetches dependencies with
+`dart pub get --no-example` (plain `dart pub get` fails on the Flutter example, see
+above) and refreshes the toolchain with `rustup update stable`, because the
+`dart-vodozemac` crates need a recent Rust (edition 2024, so >= 1.85).
+
+If `dart pub get` ever fails with `fatal: hardlink different from source`, the
+snapshot's `~/.pub-cache/git` mirror of the `famedly_dart_lints` git dependency is
+stale: pub clones the mirror with hardlinks, which the VM's overlay filesystem cannot
+satisfy for files from a lower layer. Run `rm -rf ~/.pub-cache/git` and retry; pub
+re-fetches the mirror (~1 MB).
 
 ### Lint / analyze
-- `dart analyze` (clean except pre-existing info-level deprecation hints). `dart format --output=none --set-exit-if-changed lib` enforces formatting in CI.
+- `dart analyze` (clean on the pinned SDK: "No issues found!"). `dart format --output=none --set-exit-if-changed lib` enforces formatting in CI.
+- License headers: `~/.local/bin/reuse lint`, the local equivalent of the `reuse-compliance-check` CI job. Every new file needs the SPDX header the other files carry, or an entry in `REUSE.toml`.
 
 ### Tests
 - Non-E2EE only: `NO_OLM=1 ./scripts/test.sh` (skips `olm`-tagged tests, no vodozemac needed).
 - Full suite incl. E2EE: `./scripts/test.sh` (runs all 52 files sequentially, ~10 min). Requires the native vodozemac library at `./rust/target/debug/libvodozemac_bindings_dart.so`.
 - Single file: `dart test test/<name>_test.dart` (add `-x olm` to skip encryption tests).
-- vodozemac native lib: built once via `./scripts/prepare_vodozemac.sh` (git-clones `dart-vodozemac` into `./rust/` and runs `cargo build`). The `./rust/` dir is gitignored and persists in the snapshot, so it normally does NOT need rebuilding. Only re-run the script if the `vodozemac` version in `pubspec.yaml` changes or `./rust/target/debug/*.so` is missing.
+- vodozemac native lib: built by `./scripts/prepare_vodozemac.sh` (git-clones `dart-vodozemac` into `./rust/` and runs `cargo build`, ~15 s). Environment setup runs it, so the `.so` is normally present. Each environment build re-clones `/workspace`, which wipes the gitignored `./rust/` dir, so re-run the script whenever `./rust/target/debug/libvodozemac_bindings_dart.so` is missing or the `vodozemac` version in `pubspec.yaml` changes.
 
 ### Integration / E2EE tests against a real homeserver
 - Needs a running homeserver. `dockerd` is installed but is NOT auto-started — start it first (e.g. `sudo dockerd &`) and confirm with `sudo docker info`. The daemon is configured for `fuse-overlayfs` with the containerd-snapshotter disabled (required for Docker on this VM).

--- a/scripts/prepare_vodozemac.sh
+++ b/scripts/prepare_vodozemac.sh
@@ -4,10 +4,20 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-rm -rf rust
+# Fail loudly: without this the script used to exit 0 on a broken `cargo build`,
+# so the missing native library only surfaced much later as cryptic failures in
+# the olm-tagged tests.
+set -euo pipefail
+
 version=$(yq ".dependencies.vodozemac" < pubspec.yaml)
-version=$(expr "$version" : '\^*\(.*\)')
-git clone https://github.com/famedly/dart-vodozemac.git -b ${version}
+version=${version#^}
+if [ -z "$version" ] || [ "$version" = "null" ]; then
+  echo "prepare_vodozemac: no dependencies.vodozemac version in pubspec.yaml" >&2
+  exit 1
+fi
+
+rm -rf rust dart-vodozemac
+git clone https://github.com/famedly/dart-vodozemac.git -b "$version"
 mv ./dart-vodozemac/rust ./
 rm -rf dart-vodozemac
 cd ./rust


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While diagnosing a failed Cursor Cloud environment build (install step died on
`dart pub get --no-example`, because the VM still had Dart 3.11.1 while
`versions.env` pins 3.12.2 and `sqflite_common_ffi ^2.4.2` needs `>=3.12.0`), two
repo-side problems showed up:

- `scripts/prepare_vodozemac.sh` exited 0 even when `cargo build` failed. That hid a
  broken Rust toolchain (1.83 cannot build the current bindings, which need edition
  2024, so >= 1.85) and left CI and local setups without a native library, failing much
  later inside the olm-tagged tests. The script now uses `set -euo pipefail` and checks
  that it read a version from `pubspec.yaml`.
- `AGENTS.md` described the environment inaccurately: the Dart version, the claim that
  the gitignored `./rust/` dir survives (each environment build re-clones `/workspace`),
  and the Rust toolchain requirement. It now also notes the stale `~/.pub-cache/git`
  mirror gotcha and how to lint license headers locally.

The Dart SDK pin is followed by the environment's install command, not by a script in
this repo.

## Verification

- `./scripts/test.sh` — full suite on Dart 3.12.2 with the native vodozemac library
- `dart analyze` (no issues), `dart format --output=none --set-exit-if-changed lib`, `reuse lint`
- `scripts/prepare_vodozemac.sh` builds the library in ~13 s, and now exits 101 instead
  of 0 when forced onto Rust 1.83

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b64a00-efca-4d6d-ac03-d2d449b11880?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b64a00-efca-4d6d-ac03-d2d449b11880&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

