### PR TITLE
fix: ignore missing files during local file cache cleanup

### DIFF
--- a/lib/src/database/database_file_storage_io.dart
+++ b/lib/src/database/database_file_storage_io.dart
@@ -56,7 +56,11 @@ mixin DatabaseFileStorage {
 
     if (await file.exists() == false) return false;
 
-    await file.delete();
+    try {
+      await file.delete();
+    } on PathNotFoundException {
+      return false;
+    }
     return true;
   }
 
@@ -73,9 +77,14 @@ mixin DatabaseFileStorage {
     for (final file in entities) {
       if (file is! File) continue;
       final stat = await file.stat();
+      if (stat.type != FileSystemEntityType.file) continue;
       if (DateTime.now().difference(stat.modified) > deleteFilesAfterDuration) {
         Logs().v('Delete old file', file.path);
-        await file.delete();
+        try {
+          await file.delete();
+        } on PathNotFoundException {
+          // File may have been removed after listing, e.g. by sendFileEvent cleanup.
+        }
       }
     }
   }


### PR DESCRIPTION
`deleteOldFiles` listed the cache dir then deleted each file. `sendFileEvent` can remove the same pending cache/thumbnail in between, which threw `PathNotFoundException`.

Look here: https://github.com/famedly/app/actions/runs/32008653312/job/95324150045?pr=7395
https://github.com/famedly/app/actions/runs/32087445150/job/95578783567#step:16:1