### PR TITLE
chore: log to-device recipients that get silently skipped

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -3759,13 +3759,28 @@ class Client extends MatrixApi {
     // Don't send this message to blocked devices, and if specified onlyVerified
     // then only send it to verified devices
     if (deviceKeys.isNotEmpty) {
+      final skipped = deviceKeys
+          .where(
+            (deviceKey) =>
+                deviceKey.blocked || (onlyVerified && !deviceKey.verified),
+          )
+          .map((deviceKey) => '${deviceKey.userId}:${deviceKey.deviceId}')
+          .toList();
+      if (skipped.isNotEmpty) {
+        Logs().w(
+          'Not sending $eventType to $skipped, they are blocked or unverified',
+        );
+      }
       deviceKeys.removeWhere(
         (DeviceKeys deviceKeys) =>
             deviceKeys.blocked ||
             (deviceKeys.userId == userID && deviceKeys.deviceId == deviceID) ||
             (onlyVerified && !deviceKeys.verified),
       );
-      if (deviceKeys.isEmpty) return;
+      if (deviceKeys.isEmpty) {
+        Logs().w('Not sending $eventType, no devices are left to send it to');
+        return;
+      }
     }
 
     // So that we can guarantee order of encrypted to_device messages to be preserved we

--- a/lib/src/voip/backend/livekit_backend.dart
+++ b/lib/src/voip/backend/livekit_backend.dart
@@ -323,16 +323,25 @@ class LiveKitBackend extends CallBackend {
     final unencryptedDataToSend = <String, Map<String, Map<String, Object>>>{};
 
     for (final participant in remoteParticipants) {
-      if (participant.deviceId == null) continue;
+      if (participant.deviceId == null) {
+        Logs().w(
+          '[VOIP E2EE] _sendToDeviceEvent: not sending $eventType to ${participant.id}, it has no device id',
+        );
+        continue;
+      }
       if (mustEncrypt) {
         await groupCall.client.userDeviceKeysLoading;
         final deviceKey = groupCall
             .client
             .userDeviceKeys[participant.userId]
             ?.deviceKeys[participant.deviceId];
-        if (deviceKey != null) {
-          mustEncryptkeysToSendTo.add(deviceKey);
+        if (deviceKey == null) {
+          Logs().w(
+            '[VOIP E2EE] _sendToDeviceEvent: not sending $eventType to ${participant.id}, we have no device keys for it',
+          );
+          continue;
         }
+        mustEncryptkeysToSendTo.add(deviceKey);
       } else {
         unencryptedDataToSend.addAll({
           participant.userId: {participant.deviceId!: data},


### PR DESCRIPTION
A participant with no cached device keys, and a device that is blocked or unverified, were both dropped without a trace, so a key that never arrived looked exactly like one that was never asked for.