### PR TITLE
chore: remove unused CI SSH access

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,11 +21,9 @@ jobs:
   dart:
     permissions:
       contents: read
-    uses: famedly/frontend-ci-templates/.github/workflows/dart.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/dart.yml@v1.1.0
     with:
       env_file: ".github/workflows/versions.env"
-    secrets:
-      ssh_key: "${{ secrets.CI_SSH_PRIVATE_KEY }}"
 
   general:
     permissions:


### PR DESCRIPTION
### Description:

Remove unused SSH credentials from CI.

Closes https://famedly.atlassian.net/browse/FM-685

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that removes a secret passthrough and pins a reusable workflow tag; no application or auth logic is modified.
> 
> **Overview**
> Updates the **`dart`** job in `integrate.yml` to call `famedly/frontend-ci-templates`’s Dart workflow at **`v1.1.0`** instead of **`main`**, and **removes** the `secrets` mapping that passed **`CI_SSH_PRIVATE_KEY`** into that reusable workflow.
> 
> CI no longer supplies SSH credentials to the shared Dart template, matching the template version that no longer needs them for this pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997a5fac93b6fdecfe5dced94b42cabe7ed1f3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->