### PR TITLE
fix: add reason why db was cleared

### DIFF
--- a/lib/encryption/olm_manager.dart
+++ b/lib/encryption/olm_manager.dart
@@ -65,7 +65,9 @@ class OlmManager {
             ? pickleKey
             : null,
       )) {
-        throw ('Upload key failed');
+        // Reached from `Client.init` for a session that has no stored olm
+        // account, where failing to publish the keys costs the session.
+        throw ('Upload of the device keys for the new olm account failed');
       }
     } else {
       try {
@@ -127,6 +129,7 @@ class OlmManager {
     }
 
     if (_uploadKeysLock) {
+      Logs().w('Not uploading keys: another upload is already in flight');
       return false;
     }
     _uploadKeysLock = true;
@@ -248,6 +251,7 @@ class OlmManager {
       );
       final response = await currentUpload.valueOrCancellation();
       if (response == null) {
+        Logs().w('Not uploading keys: the upload was cancelled');
         _uploadKeysLock = false;
         return false;
       }
@@ -257,9 +261,15 @@ class OlmManager {
       if (updateDatabase) {
         await encryption.olmDatabase?.updateClientKeys(pickledOlmAccount!);
       }
-      return (uploadedOneTimeKeysCount != null &&
-              response['signed_curve25519'] == uploadedOneTimeKeysCount) ||
-          uploadedOneTimeKeysCount == null;
+      final uploaded = response['signed_curve25519'];
+      if (uploadedOneTimeKeysCount != null &&
+          uploaded != uploadedOneTimeKeysCount) {
+        Logs().w(
+          'Key upload accepted $uploaded of $uploadedOneTimeKeysCount one time keys',
+        );
+        return false;
+      }
+      return true;
     } on MatrixException catch (exception) {
       _uploadKeysLock = false;
 
@@ -285,6 +295,8 @@ class OlmManager {
           unusedFallbackKey: unusedFallbackKey,
           retry: retry - 1,
         );
+      } else {
+        Logs().w('Key upload was rejected by the homeserver', exception);
       }
     } finally {
       _uploadKeysLock = false;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -33,6 +33,30 @@ typedef RoomSorter = int Function(Room a, Room b);
 
 enum LoginState { loggedIn, loggedOut, softLoggedOut }
 
+/// Why [Client.clear] dropped the local session.
+///
+/// `loggedOut` on its own cannot tell a deliberate sign out from one the SDK
+/// decided on, which makes unexpected sign outs hard to trace in the wild.
+enum SessionClearReason {
+  /// The user signed out through [Client.logout].
+  logout,
+
+  /// The session was moved to another device by [Client.exportDump].
+  exportDump,
+
+  /// [Client.init] failed and could not keep the session.
+  initFailed,
+
+  /// The homeserver refused to refresh an expired access token.
+  softLogoutRefreshFailed,
+
+  /// The homeserver rejected the access token and offered no way back.
+  unknownToken,
+
+  /// [Client.clear] was called directly, so only the caller knows why.
+  unspecified,
+}
+
 extension TrailingSlash on Uri {
   Uri stripTrailingSlash() => path.endsWith('/')
       ? replace(path: path.substring(0, path.length - 1))
@@ -810,7 +834,7 @@ class Client extends MatrixApi {
       Logs().e('Logout failed', e, s);
       rethrow;
     } finally {
-      await clear();
+      await clear(reason: SessionClearReason.logout);
     }
   }
 
@@ -825,7 +849,7 @@ class Client extends MatrixApi {
 
     final futures = <Future>[];
     futures.add(super.logoutAll());
-    futures.add(clear());
+    futures.add(clear(reason: SessionClearReason.logout));
     await Future.wait(futures).catchError((e, s) {
       Logs().e('Logout all failed', e, s);
       throw e;
@@ -1660,7 +1684,7 @@ class Client extends MatrixApi {
 
     final export = await database.exportDump();
 
-    await clear();
+    await clear(reason: SessionClearReason.exportDump);
     return export;
   }
 
@@ -1789,6 +1813,11 @@ class Client extends MatrixApi {
 
   /// Called when the login state e.g. user gets logged out.
   final CachedStreamController<LoginState> onLoginStateChanged =
+      CachedStreamController();
+
+  /// Called just before [onLoginStateChanged] reports [LoginState.loggedOut]
+  /// because the local session was dropped, so listeners can tell why.
+  final CachedStreamController<SessionClearReason> onSessionCleared =
       CachedStreamController();
 
   /// Called when the local cache is reset
@@ -2276,7 +2305,7 @@ class Client extends MatrixApi {
         deviceName: deviceName,
         olmAccount: olmAccount,
       );
-      await clear();
+      await clear(reason: SessionClearReason.initFailed);
       throw clientInitException;
     } finally {
       _initLock = false;
@@ -2289,7 +2318,10 @@ class Client extends MatrixApi {
   }
 
   /// Resets all settings and stops the synchronisation.
-  Future<void> clear() async {
+  Future<void> clear({
+    SessionClearReason reason = SessionClearReason.unspecified,
+  }) async {
+    Logs().i('Clearing the session because of $reason');
     Logs().outputEvents.clear();
     DatabaseApi? legacyDatabase;
     if (legacyDatabaseBuilder != null) {
@@ -2316,6 +2348,7 @@ class Client extends MatrixApi {
     _eventsPendingDecryption.clear();
     await encryption?.dispose();
     _encryption = null;
+    onSessionCleared.add(reason);
     onLoginStateChanged.add(LoginState.loggedOut);
   }
 
@@ -2386,7 +2419,7 @@ class Client extends MatrixApi {
           'Unable to refresh session after soft logout. Clearing session...',
           e,
         );
-        await clear();
+        await clear(reason: SessionClearReason.softLogoutRefreshFailed);
         rethrow;
       } catch (e, s) {
         Logs().e(
@@ -2526,8 +2559,12 @@ class Client extends MatrixApi {
           Logs().w('The user has been logged out! Try to refresh token...', e);
           await _handleSoftLogout();
         } else {
-          Logs().w('The user has been logged out!', e);
-          await clear();
+          Logs().w(
+            'The user has been logged out! No refresh token and the server did '
+            'not offer a soft logout, so the session cannot be recovered.',
+            e,
+          );
+          await clear(reason: SessionClearReason.unknownToken);
         }
       }
     } on SyncConnectionException catch (e, s) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches session teardown and login-state signaling, so apps that only listen to `loggedOut` still behave the same, but init/token-failure paths remain security-sensitive. No auth algorithm changes.
> 
> **Overview**
> Unexpected logouts are now distinguishable from a user-initiated sign out. `Client.clear` takes a `SessionClearReason` and emits it on a new `onSessionCleared` stream immediately before `onLoginStateChanged` reports `loggedOut`.
> 
> Call sites pass a specific reason: `logout`, `exportDump`, `initFailed`, `softLogoutRefreshFailed`, or `unknownToken`. Direct `clear()` stays `unspecified`.
> 
> Olm key upload also logs lock/cancel/partial-accept/homeserver-reject cases, and the new-account upload failure message now notes that this path can wipe the session during `Client.init`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7627ea53a2d79907db1351d17cb382941c39aa0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->