### PR TITLE
fix: avoid using larger compressed images

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -910,13 +910,17 @@ class Room {
           customImageResizer: client.customImageResizer,
         );
         if (shrinkImageMaxDimension != null) {
-          file = await MatrixImageFile.shrink(
+          final shrunkFile = await MatrixImageFile.shrink(
             bytes: file.bytes,
             name: file.name,
             maxDimension: shrinkImageMaxDimension,
             customImageResizer: client.customImageResizer,
             nativeImplementations: client.nativeImplementations,
           );
+
+          if (shrunkFile.size < file.size) {
+            file = shrunkFile;
+          }
         }
 
         if (thumbnail != null && file.size < thumbnail.size) {


### PR DESCRIPTION
## What does this PR do?

Avoids using a compressed image when the compressed result is larger than the original image.

## Why?

Image compression should not increase the file size. This change ensures the original image is retained when compression produces a larger file.

## Testing

- `dart analyze lib/src/utils/matrix_file.dart` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to image send preprocessing with a conservative size check; no auth, encryption, or API contract changes.
> 
> **Overview**
> When sending images with **`shrinkImageMaxDimension`**, the upload path no longer blindly replaces the file with the shrunk result from **`MatrixImageFile.shrink`**.
> 
> It compares byte sizes and **only swaps to the shrunk file when it is smaller** than the original. If resizing/re-encoding grows the payload, the original image is uploaded instead—matching the existing rule that drops thumbnails when they are larger than the main image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ab946ef3a5d5620cf876b4dc77215af005af93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->