### PR TITLE
fix: handle unavailable notifications fallback

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1972,17 +1972,28 @@ class Client extends MatrixApi {
         roomId,
         eventId,
       ).timeout(timeoutForServerRequests);
-    } on MatrixException catch (_) {
-      // No access to the MatrixEvent. Search in /notifications
-      await ensureNotSoftLoggedOut();
-      final notificationsResponse = await getNotifications();
-      matrixEvent ??= notificationsResponse.notifications
-          .firstWhereOrNull(
-            (notification) =>
-                notification.roomId == roomId &&
-                notification.event.eventId == eventId,
-          )
-          ?.event;
+    } on MatrixException catch (e, s) {
+      Logs().w(
+        'Unable to fetch event directly, trying notifications endpoint.',
+        e,
+        s,
+      );
+
+      try {
+        await ensureNotSoftLoggedOut();
+
+        final notificationsResponse = await getNotifications();
+
+        matrixEvent ??= notificationsResponse.notifications
+            .firstWhereOrNull(
+              (notification) =>
+                  notification.roomId == roomId &&
+                  notification.event.eventId == eventId,
+            )
+            ?.event;
+      } on MatrixException catch (e, s) {
+        Logs().w('Unable to fetch event from notifications endpoint.', e, s);
+      }
     }
 
     if (matrixEvent == null) {


### PR DESCRIPTION
## What does this PR do?

Handles failures when the notifications endpoint is unavailable while resolving an event from a push notification.

If fetching the event directly fails, the SDK falls back to the notifications endpoint. Some homeservers may not support this endpoint and return `M_UNRECOGNIZED`.

This change prevents the `/notifications` fallback error from escaping as an unhandled MatrixException.

## Related Issue

Fixes #3370

## Testing

- `dart analyze lib/src/client.dart` — passed
- `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to push-notification event resolution error handling; no auth or data-model changes, only prevents an extra exception type from escaping the fallback path.
> 
> **Overview**
> When resolving a push notification event, a failed direct fetch already fell back to **`getNotifications()`**, but if that endpoint failed (e.g. **`M_UNRECOGNIZED`** on homeservers without `/notifications`), the **`MatrixException`** bubbled up instead of being treated as “event not found.”
> 
> The fallback path is now wrapped in its own **`try/on MatrixException`**: failures are **logged** and ignored so resolution can still end with the existing “unable to find event” error only when no event was obtained from any source. The outer catch also **logs** before attempting the notifications fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c29b891060f0f34b413b303f71b021fa587f987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->