### PR TITLE
Correctly fall back to timestamps when own receipt positions are unknown

### DIFF
--- a/lib/src/models/receipts.dart
+++ b/lib/src/models/receipts.dart
@@ -300,12 +300,22 @@ class LatestReceiptState {
         final privatePos = eventOrder.indexOf(private.eventId);
         final publicPos = eventOrder.indexOf(public.eventId);
 
-        if (publicPos < 0 ||
-            privatePos <= publicPos ||
-            (privatePos < 0 && private.ts > public.ts)) {
-          timeline.latestOwnReceipt = private;
+        if (privatePos < 0 || publicPos < 0) {
+          // At least one receipt points at an event which is not in the
+          // locally stored timeline (for example because a limited sync
+          // wiped the timeline fragments), so their positions can not be
+          // compared. Fall back to the receipt timestamps and prefer the
+          // private receipt on ties, as clients of this SDK always send
+          // one alongside their public receipts.
+          timeline.latestOwnReceipt = private.ts >= public.ts
+              ? private
+              : public;
         } else {
-          timeline.latestOwnReceipt = public;
+          // Both positions are known: the receipt furthest down the
+          // timeline wins.
+          timeline.latestOwnReceipt = privatePos <= publicPos
+              ? private
+              : public;
         }
       }
     }

--- a/test/timeline_test.dart
+++ b/test/timeline_test.dart
@@ -552,6 +552,184 @@ void main() {
       },
     );
 
+    test(
+      'Own receipts fall back to timestamps for unknown positions',
+      () async {
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  timeline: TimelineUpdate(
+                    events: [
+                      MatrixEvent.fromJson({
+                        'type': 'm.room.message',
+                        'content': {'msgtype': 'm.text', 'body': 'Testcase'},
+                        'sender': '@alice:example.com',
+                        'status': EventStatus.synced.intValue,
+                        'event_id': '\$1',
+                        'origin_server_ts': 1000,
+                      }),
+                    ],
+                  ),
+                ),
+              },
+            ),
+          ),
+        );
+
+        // Own private receipt on the locally known event, as SDK clients
+        // always send one alongside their public receipts.
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something2',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  ephemeral: [
+                    BasicEvent.fromJson({
+                      'type': 'm.receipt',
+                      'content': {
+                        '\$1': {
+                          'm.read.private': {
+                            client.userID: {'ts': 2000},
+                          },
+                        },
+                      },
+                    }),
+                  ],
+                ),
+              },
+            ),
+          ),
+        );
+
+        expect(room.receiptState.global.latestOwnReceipt?.eventId, '\$1');
+
+        // A client which only sends public receipts (e.g. Cinny) reads an
+        // event this device has not stored, so its timeline position is
+        // unknown. Its newer timestamp must win over the stale private
+        // receipt instead of being ignored.
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something3',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  ephemeral: [
+                    BasicEvent.fromJson({
+                      'type': 'm.receipt',
+                      'content': {
+                        '\$unknown': {
+                          'm.read': {
+                            client.userID: {'ts': 3000},
+                          },
+                        },
+                      },
+                    }),
+                  ],
+                ),
+              },
+            ),
+          ),
+        );
+
+        expect(room.receiptState.global.ownPublic?.eventId, '\$unknown');
+        expect(room.receiptState.global.latestOwnReceipt?.eventId, '\$unknown');
+
+        // With both positions unknown the timestamps decide: the newer
+        // private receipt wins.
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something4',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  ephemeral: [
+                    BasicEvent.fromJson({
+                      'type': 'm.receipt',
+                      'content': {
+                        '\$unknown2': {
+                          'm.read.private': {
+                            client.userID: {'ts': 4000},
+                          },
+                        },
+                      },
+                    }),
+                  ],
+                ),
+              },
+            ),
+          ),
+        );
+
+        expect(
+          room.receiptState.global.latestOwnReceipt?.eventId,
+          '\$unknown2',
+        );
+
+        // ... and a public receipt with the same timestamp loses the tie
+        // against the private one.
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something5',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  ephemeral: [
+                    BasicEvent.fromJson({
+                      'type': 'm.receipt',
+                      'content': {
+                        '\$unknown3': {
+                          'm.read': {
+                            client.userID: {'ts': 4000},
+                          },
+                        },
+                      },
+                    }),
+                  ],
+                ),
+              },
+            ),
+          ),
+        );
+
+        expect(
+          room.receiptState.global.latestOwnReceipt?.eventId,
+          '\$unknown2',
+        );
+
+        // A public receipt on a locally known event with a newer timestamp
+        // wins against a private receipt on an unknown event.
+        await client.handleSync(
+          SyncUpdate(
+            nextBatch: 'something6',
+            rooms: RoomsUpdate(
+              join: {
+                room.id: JoinedRoomUpdate(
+                  ephemeral: [
+                    BasicEvent.fromJson({
+                      'type': 'm.receipt',
+                      'content': {
+                        '\$1': {
+                          'm.read': {
+                            client.userID: {'ts': 5000},
+                          },
+                        },
+                      },
+                    }),
+                  ],
+                ),
+              },
+            ),
+          ),
+        );
+
+        expect(room.receiptState.global.latestOwnReceipt?.eventId, '\$1');
+      },
+    );
+
     test('Send message', () async {
       await room.sendTextEvent('test', txid: '1234');
 


### PR DESCRIPTION
When selecting the latest own receipt, a public receipt previously only won if its event was provably further down the local timeline. Receipts pointing at events missing from the local timeline fragments (limited syncs, gaps, fresh logins) silently lost to a potentially stale private receipt, so reads from clients that only send public receipts (e.g. Cinny) were ignored by `Room.hasNewMessages`, e.g. leaving a permanent unread (dark blue) dot in FluffyChat. The `else` clause could never fire because the condition is always true:

```
publicPos < 0 ||
            privatePos <= publicPos ||
            (privatePos < 0 && private.ts > public.ts)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes receipt merge logic that drives read markers and unread state across rooms; behavior is well-tested but edge cases around timestamp ordering for the same user remain a documented tradeoff.
> 
> **Overview**
> Fixes **latest own receipt** selection when public and private read receipts point at events that are not in the locally stored timeline (limited sync, gaps, or reads from another client such as Cinny that only sends public receipts).
> 
> Previously, a public receipt only won if its event was provably further down the timeline; if either event ID was missing from local `eventOrder`, the logic effectively kept the private receipt, so newer public reads could be ignored and apps like FluffyChat could show a stuck unread indicator via `hasNewMessages`.
> 
> The updated logic in `LatestReceiptState.update` **splits two cases**: when either position is unknown, compare **timestamps** and prefer the private receipt on ties; when both positions are known, keep comparing timeline order (receipt furthest down wins). A timeline test covers unknown events, timestamp ordering, ties, and a known public receipt beating an unknown private one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e8019399552dd74495a98274dd51c975df82a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->