### PR TITLE
chore: add 10.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 ## [11.0.0] 31st August 2026
 - build: update to vodozemac 0.8.0 (Christian Kußowski)
 - chore: add localization for incoming call (Christian Kußowski)
+
+## [10.2.2] 24th Auguest 2026
 - chore: log to-device recipients that get silently skipped (td)
 - fix: add reason why db was cleared (td)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or build impact.
> 
> **Overview**
> Adds a **10.2.2** (24 Aug 2026) section to `CHANGELOG.md` and moves two entries out of **11.0.0**: logging for silently skipped to-device recipients and recording why the DB was cleared.
> 
> **11.0.0** now only lists the vodozemac 0.8.0 bump and incoming-call localization. The new section heading uses **“Auguest”** instead of “August”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90504d60563edbd65921ca792a61fe70788a4045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->