### PR TITLE
chore: make autoRequestProfileForMissingUsers and getDisplayNameAndAvatarFromPrevContent configurable

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -128,6 +128,9 @@ class Client extends MatrixApi {
 
   final Duration sendTimelineEventTimeout;
 
+  final bool autoRequestProfileForMissingUsers;
+  final bool getDisplayNameAndAvatarFromPrevContent;
+
   /// The timeout until a typing indicator gets removed automatically.
   final Duration typingIndicatorTimeout;
 
@@ -243,6 +246,15 @@ class Client extends MatrixApi {
     this.dehydratedDeviceDisplayName = 'Dehydrated Device',
     RoomSorter? customRoomSorter,
     this.contentScannerConfig,
+
+    /// Whether the app automatically requests the profile for users which have
+    /// no filled out member state in a room. This is e.g. the case for left
+    /// or banned users.
+    this.autoRequestProfileForMissingUsers = true,
+
+    /// Whether the app should get DisplayName and Avatar also from the
+    /// previous content of a member state event.
+    this.getDisplayNameAndAvatarFromPrevContent = true,
   }) : _database = database,
        syncFilter =
            syncFilter ??

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -2145,7 +2145,7 @@ class Room {
     String mxID, {
     bool ignoreErrors = false,
     bool requestState = true,
-    bool requestProfile = true,
+    bool? requestProfile,
   }) async {
     assert(mxID.isValidMatrixIdStrict());
 
@@ -2153,7 +2153,8 @@ class Room {
       mxID: mxID,
       ignoreErrors: ignoreErrors,
       requestState: requestState,
-      requestProfile: requestProfile,
+      requestProfile:
+          requestProfile ?? client.autoRequestProfileForMissingUsers,
     );
 
     final cache = _inflightUserRequests[parameters] ??= AsyncCache.ephemeral();
@@ -2164,7 +2165,8 @@ class Room {
           mxID,
           ignoreErrors: ignoreErrors,
           requestState: requestState,
-          requestProfile: requestProfile,
+          requestProfile:
+              requestProfile ?? client.autoRequestProfileForMissingUsers,
         ),
       );
       _inflightUserRequests.remove(parameters);

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -57,7 +57,8 @@ class User extends StrippedStateEvent {
   /// The displayname of the user if the user has set one.
   String? get displayName =>
       content.tryGet<String>('displayname') ??
-      (membership == Membership.join
+      (membership == Membership.join ||
+              !room.client.getDisplayNameAndAvatarFromPrevContent
           ? null
           : prevContent?.tryGet<String>('displayname'));
 
@@ -80,7 +81,8 @@ class User extends StrippedStateEvent {
   Uri? get avatarUrl {
     final uri =
         content.tryGet<String>('avatar_url') ??
-        (membership == Membership.join
+        (membership == Membership.join ||
+                !room.client.getDisplayNameAndAvatarFromPrevContent
             ? null
             : prevContent?.tryGet<String>('avatar_url'));
     return uri == null ? null : Uri.tryParse(uri);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavioral toggles default to existing behavior; risk is mainly misconfiguration (fewer profile fetches or missing display names for left users).
> 
> **Overview**
> Adds two **Client** constructor flags so apps can tune how missing room members are resolved without changing call sites everywhere.
> 
> **`autoRequestProfileForMissingUsers`** (default `true`) drives whether `Room.requestUser` falls back to the global profile when member state is empty. **`requestProfile`** is now optional; when omitted it uses that client setting.
> 
> **`getDisplayNameAndAvatarFromPrevContent`** (default `true`) gates whether `User.displayName` and `User.avatarUrl` still read from `prevContent` for non-joined members (e.g. left or banned). Turning it off stops using stale names/avatars from prior member events while keeping current defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03a1f6ad7d4a6fa4dc933880731edeb2e5a08ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->