### PR TITLE
refactor: drop redundant database index

### DIFF
--- a/lib/src/database/sqflite_box.dart
+++ b/lib/src/database/sqflite_box.dart
@@ -34,7 +34,9 @@ class BoxCollection with ZoneTransactionMixin {
       batch.execute(
         'CREATE TABLE IF NOT EXISTS $name (k TEXT PRIMARY KEY NOT NULL, v TEXT)',
       );
-      batch.execute('CREATE INDEX IF NOT EXISTS k_index ON $name (k)');
+      batch.execute(
+        'DROP INDEX IF EXISTS k_index',
+      ); // Previously we have created a redundant index. We can safely remove it.
     }
     await batch.commit(noResult: true);
     return BoxCollection(sqfliteDatabase, boxNames, name);


### PR DESCRIPTION
The k_index we created here was actually never used and just duplicated the key which blows up the database without any benefit. We can safely drop it to decrease database size.#

Have tested it on macOS native and FluffyChat on Android and everything still seems to work fine. But it also doesn't decrease the database size actually. However we still don't need this index so we should remove it